### PR TITLE
[AN] 일정화면 디자인 변경

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NewsFragment.kt
@@ -19,8 +19,18 @@ class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
         binding.rvNoticeList.adapter = noticeAdapter
         val notices =
             listOf(
-                NoticeUiModel("제목1", "설명1", "2025-07-14T05:22:39.963Z"),
-                NoticeUiModel("제목2", "설명2", "2025-07-13T11:11:39.963Z"),
+                NoticeUiModel(
+                    id = 1,
+                    title = "제목1",
+                    description = "설명1",
+                    createdAt = "2025-07-14T05:22:39.963Z",
+                ),
+                NoticeUiModel(
+                    id = 2,
+                    title = "제목2",
+                    description = "설명2",
+                    createdAt = "2025-07-13T11:11:39.963Z",
+                ),
             )
         noticeAdapter.submitList(notices)
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
@@ -29,16 +29,26 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>(R.layout.fragment
         savedInstanceState: Bundle?,
     ) {
         binding.vpSchedule.adapter = adapter
+        setupScheduleTabLayout(view)
+    }
 
+    private fun setupScheduleTabLayout(view: View) {
         TabLayoutMediator(binding.tlSchedule, binding.vpSchedule) { tab, position ->
-            val itemTabBinding =
+            val itemScheduleTabBinding =
                 ItemScheduleTabBinding.inflate(
                     LayoutInflater.from(view.context),
                     binding.tlSchedule,
                     false,
                 )
-            itemTabBinding.tvScheduleTabItem.text = tabTitles[position]
-            tab.customView = itemTabBinding.root
+            tab.customView = itemScheduleTabBinding.root
+            itemScheduleTabBinding.tvScheduleTabItem.text = tabTitles[position]
+            addScheduleTabSelectedListener(itemScheduleTabBinding)
         }.attach()
+    }
+
+    private fun addScheduleTabSelectedListener(itemScheduleTabBinding: ItemScheduleTabBinding) {
+        binding.tlSchedule.addOnTabSelectedListener(
+            ScheduleTabSelectedListener(itemScheduleTabBinding),
+        )
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabSelectedListener.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabSelectedListener.kt
@@ -1,0 +1,23 @@
+package com.daedan.festabook.presentation.schedule
+
+import android.graphics.Typeface
+import com.daedan.festabook.databinding.ItemScheduleTabBinding
+import com.google.android.material.tabs.TabLayout
+
+class ScheduleTabSelectedListener(
+    private val itemTabBinding: ItemScheduleTabBinding,
+) : TabLayout.OnTabSelectedListener {
+    override fun onTabSelected(tab: TabLayout.Tab?) {
+        tab?.customView?.isSelected = true
+        itemTabBinding.tvScheduleTabItem.setTypeface(null, Typeface.BOLD)
+    }
+
+    override fun onTabUnselected(tab: TabLayout.Tab?) {
+        tab?.customView?.isSelected = false
+        itemTabBinding.tvScheduleTabItem.setTypeface(null, Typeface.NORMAL)
+    }
+
+    override fun onTabReselected(tab: TabLayout.Tab?) {
+        return
+    }
+}

--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -18,7 +18,7 @@
             style="@style/PretendardBold24"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="40dp"
             android:text="@string/schedule_title"
             android:textColor="@color/gray900"
             app:layout_constraintBottom_toTopOf="@id/tl_schedule"

--- a/android/app/src/main/res/layout/item_schedule_tab.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_schedule_tab_item"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/selector_schedule_tab_background"


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/88


## 🛠️ 작업 내용

- "일정 타임라인" 타이틀에 marginTop 추가
- 날짜 탭 선택시 textStyle, background 변경

<br>

## 🙇🏻 중점 리뷰 요청



<br>

## 📸 이미지 첨부 (Optional)
<img src="https://github.com/user-attachments/assets/1cf95f5c-393a-4aba-86ed-eb739156902a" width="50%" height="50%"/>
