### PR TITLE
[AN] 소식 화면 - 클릭 시 공지 확장 기능 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,6 +43,7 @@ android {
     buildFeatures {
         buildConfig = true
         dataBinding = true
+        viewBinding = true
     }
 }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -11,8 +11,8 @@ class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
     private val noticeAdapter: NoticeAdapter by lazy {
         NoticeAdapter { notice ->
             val newList =
-                noticeAdapter.currentList.map {
-                    if (it.id == notice.id) it.copy(isExpanded = !it.isExpanded) else it
+                noticeAdapter.currentList.map { updateNotice ->
+                    if (updateNotice.id == notice.id) updateNotice.copy(isExpanded = !updateNotice.isExpanded) else updateNotice
                 }
             noticeAdapter.submitList(newList)
         }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -9,10 +9,10 @@ import com.daedan.festabook.presentation.news.notice.adapter.NoticeAdapter
 
 class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
     private val noticeAdapter: NoticeAdapter by lazy {
-        NoticeAdapter { notice ->
+        NoticeAdapter { noticeId ->
             val newList =
                 noticeAdapter.currentList.map { updateNotice ->
-                    if (updateNotice.id == notice.id) updateNotice.copy(isExpanded = !updateNotice.isExpanded) else updateNotice
+                    if (updateNotice.id == noticeId) updateNotice.copy(isExpanded = !updateNotice.isExpanded) else updateNotice
                 }
             noticeAdapter.submitList(newList)
         }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -1,4 +1,4 @@
-package com.daedan.festabook.presentation.news
+package com.daedan.festabook.presentation.news.notice
 
 import android.os.Bundle
 import android.view.View
@@ -6,10 +6,17 @@ import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentNewsBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.news.notice.adapter.NoticeAdapter
-import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
 class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
-    private val noticeAdapter: NoticeAdapter by lazy { NoticeAdapter() }
+    private val noticeAdapter: NoticeAdapter by lazy {
+        NoticeAdapter { notice ->
+            val newList =
+                noticeAdapter.currentList.map {
+                    if (it.id == notice.id) it.copy(isExpanded = !it.isExpanded) else it
+                }
+            noticeAdapter.submitList(newList)
+        }
+    }
 
     override fun onViewCreated(
         view: View,
@@ -20,17 +27,47 @@ class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
         binding.rvNoticeList.adapter = noticeAdapter
         val notices =
             listOf(
+                NoticeUiModel(1L, "제목1", "설명1", "2025-07-14T05:22:39.963Z"),
+                NoticeUiModel(2L, "제목2", "설명2", "2025-07-13T11:11:39.963Z"),
                 NoticeUiModel(
-                    id = 1,
-                    title = "제목1",
-                    description = "설명1",
-                    createdAt = "2025-07-14T05:22:39.963Z",
+                    3L,
+                    "제목3",
+                    "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다.",
+                    "2025-07-13T11:11:39.963Z",
                 ),
                 NoticeUiModel(
-                    id = 2,
-                    title = "제목2",
-                    description = "설명2",
-                    createdAt = "2025-07-13T11:11:39.963Z",
+                    4L,
+                    "제목4",
+                    "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다." +
+                        "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다." +
+                        "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다." +
+                        "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다." +
+                        "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다.",
+                    "2025-07-13T11:11:39.963Z",
+                ),
+                NoticeUiModel(
+                    5L,
+                    "제목5",
+                    "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다.",
+                    "2025-07-13T11:11:39.963Z",
+                ),
+                NoticeUiModel(
+                    6L,
+                    "제목6",
+                    "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다.",
+                    "2025-07-13T11:11:39.963Z",
+                ),
+                NoticeUiModel(
+                    7L,
+                    "제목7",
+                    "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다.",
+                    "2025-07-13T11:11:39.963Z",
+                ),
+                NoticeUiModel(
+                    8L,
+                    "제목8",
+                    "엄청 긴 설명입니다. 엄청 긴 ~~~~~~~ 설명입니다. 엄청 긴 설명입니ㅏㄷ. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다. 엄청 긴 설명입니다.",
+                    "2025-07-13T11:11:39.963Z",
                 ),
             )
         noticeAdapter.submitList(notices)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeAdapter.kt
@@ -5,11 +5,13 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
-class NoticeAdapter : ListAdapter<NoticeUiModel, NoticeViewHolder>(noticeDiffCallback) {
+class NoticeAdapter(
+    private val noticeListener: OnNoticeClickListener,
+) : ListAdapter<NoticeUiModel, NoticeViewHolder>(noticeDiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): NoticeViewHolder = NoticeViewHolder.from(parent)
+    ): NoticeViewHolder = NoticeViewHolder.from(parent, noticeListener)
 
     override fun onBindViewHolder(
         holder: NoticeViewHolder,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
@@ -9,22 +9,24 @@ import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
 class NoticeViewHolder(
     private val binding: ItemNoticeBinding,
-    private val listener: OnNoticeClickListener,
+    noticeItemClickListener: OnNoticeClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
+    init {
+        binding.listener = noticeItemClickListener
+    }
+
     fun bind(notice: NoticeUiModel) {
         binding.notice = notice
 
         binding.tvNoticeDescription.maxLines =
-            if (notice.isExpanded) Integer.MAX_VALUE else 2
+            if (notice.isExpanded) Integer.MAX_VALUE else DEFAULT_LINE_COUNT
         binding.tvNoticeDescription.ellipsize =
             if (notice.isExpanded) null else TextUtils.TruncateAt.END
-
-        binding.root.setOnClickListener {
-            listener.onNoticeClick(notice)
-        }
     }
 
     companion object {
+        private const val DEFAULT_LINE_COUNT = 2
+
         fun from(
             parent: ViewGroup,
             listener: OnNoticeClickListener,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
@@ -1,5 +1,6 @@
 package com.daedan.festabook.presentation.news.notice.adapter
 
+import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -8,16 +9,29 @@ import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
 class NoticeViewHolder(
     private val binding: ItemNoticeBinding,
+    private val listener: OnNoticeClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(notice: NoticeUiModel) {
         binding.notice = notice
+
+        binding.tvNoticeDescription.maxLines =
+            if (notice.isExpanded) Integer.MAX_VALUE else 2
+        binding.tvNoticeDescription.ellipsize =
+            if (notice.isExpanded) null else TextUtils.TruncateAt.END
+
+        binding.root.setOnClickListener {
+            listener.onNoticeClick(notice)
+        }
     }
 
     companion object {
-        fun from(parent: ViewGroup): NoticeViewHolder {
+        fun from(
+            parent: ViewGroup,
+            listener: OnNoticeClickListener,
+        ): NoticeViewHolder {
             val binding =
                 ItemNoticeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-            return NoticeViewHolder(binding)
+            return NoticeViewHolder(binding, listener)
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNoticeClickListener.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNoticeClickListener.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.presentation.news.notice.adapter
+
+import com.daedan.festabook.presentation.news.notice.NoticeUiModel
+
+fun interface OnNoticeClickListener {
+    fun onNoticeClick(notice: NoticeUiModel)
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNoticeClickListener.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNoticeClickListener.kt
@@ -1,7 +1,5 @@
 package com.daedan.festabook.presentation.news.notice.adapter
 
-import com.daedan.festabook.presentation.news.notice.NoticeUiModel
-
 fun interface OnNoticeClickListener {
-    fun onNoticeClick(notice: NoticeUiModel)
+    fun onNoticeClick(noticeId: Long)
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/model/NoticeUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/model/NoticeUiModel.kt
@@ -6,5 +6,5 @@ data class NoticeUiModel(
     val description: String,
     val createdAt: String,
     val isPinned: Boolean = false,
-    val isExpanded: Boolean = false,
+    var isExpanded: Boolean = false,
 )

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/model/NoticeUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/model/NoticeUiModel.kt
@@ -6,5 +6,5 @@ data class NoticeUiModel(
     val description: String,
     val createdAt: String,
     val isPinned: Boolean = false,
-    var isExpanded: Boolean = false,
+    val isExpanded: Boolean = false,
 )

--- a/android/app/src/main/res/layout/fragment_news.xml
+++ b/android/app/src/main/res/layout/fragment_news.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginHorizontal="16dp"
-        tools:context=".presentation.news.NewsFragment">
+        tools:context=".presentation.news.notice.NewsFragment">
 
         <TextView
             android:id="@+id/tv_news_title"
@@ -28,6 +28,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="20dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_news_title"
             tools:listitem="@layout/item_notice" />
 

--- a/android/app/src/main/res/layout/item_notice.xml
+++ b/android/app/src/main/res/layout/item_notice.xml
@@ -39,21 +39,24 @@
             app:layout_constraintBottom_toBottomOf="@id/iv_speaker"
             app:layout_constraintStart_toEndOf="@id/iv_speaker"
             app:layout_constraintTop_toTopOf="@id/iv_speaker"
+            android:text="@{notice.title}"
             tools:text="제목입니다." />
 
         <TextView
             android:id="@+id/tv_notice_description"
             style="@style/PretendardRegular12"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             android:text="@{notice.description}"
             android:textColor="@color/gray500"
+            app:layout_constraintEnd_toEndOf="@+id/textView"
             app:layout_constraintStart_toStartOf="@id/tv_notice_title"
             app:layout_constraintTop_toBottomOf="@id/tv_notice_title"
             tools:text="설명입니다.설명입니다.설명입니다." />
 
         <TextView
+            android:id="@+id/textView"
             style="@style/PretendardRegular10"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/item_notice.xml
+++ b/android/app/src/main/res/layout/item_notice.xml
@@ -19,7 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:onClick="@{() -> listener.onNoticeClick(notice)}"
+        android:onClick="@{() -> listener.onNoticeClick(notice.id)}"
         android:background="@drawable/bg_stroke_gray400_radius_10dp"
         android:paddingVertical="16dp">
 

--- a/android/app/src/main/res/layout/item_notice.xml
+++ b/android/app/src/main/res/layout/item_notice.xml
@@ -16,14 +16,13 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:background="@drawable/bg_stroke_gray400_radius_10dp"
-        android:paddingBottom="20dp">
+        android:paddingVertical="16dp">
 
         <ImageView
             android:id="@+id/iv_speaker"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
             android:contentDescription="@string/iv_speaker"
             android:src="@drawable/ic_speaker"
             app:layout_constraintStart_toStartOf="parent"
@@ -48,10 +47,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
+            android:layout_marginHorizontal="16dp"
             android:text="@{notice.description}"
             android:textColor="@color/gray500"
-            app:layout_constraintEnd_toEndOf="@+id/textView"
-            app:layout_constraintStart_toStartOf="@id/tv_notice_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_notice_title"
             tools:text="설명입니다.설명입니다.설명입니다." />
 
@@ -60,7 +60,6 @@
             style="@style/PretendardRegular10"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
             android:textColor="@color/gray500"
             app:formattedNoticeDateTime='@{notice.createdAt}'

--- a/android/app/src/main/res/layout/item_notice.xml
+++ b/android/app/src/main/res/layout/item_notice.xml
@@ -6,6 +6,10 @@
     <data>
 
         <variable
+            name="listener"
+            type="com.daedan.festabook.presentation.news.notice.adapter.OnNoticeClickListener" />
+
+        <variable
             name="notice"
             type="com.daedan.festabook.presentation.news.notice.model.NoticeUiModel" />
 
@@ -15,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:onClick="@{() -> listener.onNoticeClick(notice)}"
         android:background="@drawable/bg_stroke_gray400_radius_10dp"
         android:paddingVertical="16dp">
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #81 

<br>

## 🛠️ 작업 내용

- 공지 설명이 긴 경우, 누르면 확장 되능 기능 추가

<br>

## 🙇🏻 중점 리뷰 요청

- 리스너 인터페이스를 별도의 파일로 분리했습니다. 
- 해당 리스너를 현재 뷰(프래그먼트)에서 구현하고 있습니다. 후추에 뷰모델을 도입하여 구현 위치를 옮기고자 하는데, 이 외에 다른 좋은 방법이 있을 지 궁금합니다. 

<br>



## 📸 이미지 첨부 (Optional)
https://github.com/user-attachments/assets/fe23d51a-67c5-42ab-b202-b5d1a6073a00