### PR TITLE
[BE] PR의 base branch가 main, backend이라면, 테스트를 실행하는 workflow 작성

### DIFF
--- a/.github/workflows/backend-pr-test.yml
+++ b/.github/workflows/backend-pr-test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - backend
+    paths:
+      - 'backend/**' # backend 디렉토리 및 모든 하위 파일/폴더 변경 감지
 
 jobs:
   Run-PR-Test:

--- a/.github/workflows/backend-pr-test.yml
+++ b/.github/workflows/backend-pr-test.yml
@@ -1,0 +1,55 @@
+name: Run Test
+
+# base가 main, backend로 PR
+on:
+  pull_request:
+    branches:
+      - main
+      - backend
+
+jobs:
+  Run-PR-Test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # 저장소 읽기 권한
+      pull-requests: write # PR 코멘트 권한
+
+    steps:
+      # 저장소 checkout
+      - name: Repository Checkout
+        uses: actions/checkout@v4
+
+      # 자바 21
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # 캐시
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('backend/**/*.gradle*', 'backend/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # 테스트 실행
+      - name: Run Gradle Test
+        run: ./gradlew clean test
+        working-directory: backend
+
+      # 테스트 성공 유무 알림
+      - name: Comment on PR (Success)
+        if: success()
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "✅ 테스트가 성공적으로 완료되었습니다."
+        env:
+          GITHUB_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
+
+      - name: Comment on PR (Failure)
+        if: failure()
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "❌ 테스트가 실패했습니다. 로그를 확인해주세요."
+        env:
+          GITHUB_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
+

--- a/.github/workflows/backend-pr-test.yml
+++ b/.github/workflows/backend-pr-test.yml
@@ -1,34 +1,28 @@
 name: Run Test
 
-# base가 main, backend로 PR
 on:
   pull_request:
     branches:
       - main
       - backend
-    paths:
-      - 'backend/**' # backend 디렉토리 및 모든 하위 파일/폴더 변경 감지
 
 jobs:
   Run-PR-Test:
     runs-on: ubuntu-latest
     permissions:
-      contents: read # 저장소 읽기 권한
-      pull-requests: write # PR 코멘트 권한
+      contents: read
+      pull-requests: write
 
     steps:
-      # 저장소 checkout
       - name: Repository Checkout
         uses: actions/checkout@v4
 
-      # 자바 21
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      # 캐시
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -37,21 +31,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 테스트 실행
       - name: Run Gradle Test
+        id: run_gradle_test
         run: ./gradlew clean test
         working-directory: backend
 
-      # 테스트 성공 유무 알림
-      - name: Comment on PR (Success)
-        if: success()
-        run: gh pr comment ${{ github.event.pull_request.number }} --body "✅ 테스트가 성공적으로 완료되었습니다."
+      - name: Comment on PR based on test result
+        if: always()
+        run: |
+          TEST_RESULT="${{ steps.run_gradle_test.outcome }}"
+          if [[ "$TEST_RESULT" == "success" ]]; then
+            MESSAGE="✅ 테스트가 성공적으로 완료되었습니다. 고생하셨습니다."
+          elif [[ "$TEST_RESULT" == "failure" ]]; then
+            MESSAGE="❌ 테스트가 실패했습니다. 로그를 확인해주세요."
+          else
+            MESSAGE="⚠️ 테스트가 완료되지 않았습니다. (상태: ${TEST_RESULT})"
+          fi
+          
+          gh pr comment ${{ github.event.pull_request.number }} --body "$MESSAGE"
         env:
           GITHUB_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
-
-      - name: Comment on PR (Failure)
-        if: failure()
-        run: gh pr comment ${{ github.event.pull_request.number }} --body "❌ 테스트가 실패했습니다. 로그를 확인해주세요."
-        env:
-          GITHUB_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
-


### PR DESCRIPTION
## #️⃣ 이슈 번호

#118 

<br>

## 🛠️ 작업 내용

PR을 올렸을 때, 테스트를 실행하고 성공 실패 유무를 PR 코멘트로 작성해준다.
- 캐싱 처리를 통해 gradle의 증분 빌드, 빌드 캐시 작업을 수행할 수 있도록 하였다.


<br>

## 📸 이미지 첨부 (Optional)

<img width="866" height="525" alt="image" src="https://github.com/user-attachments/assets/112246a6-3dba-49d1-a6a7-43aac7f740d3" />

