### PR TITLE
[AN] 일정 화면 SwipeRefreshLayout, Skeleton UI 적용

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.swiperefreshlayout)
+    implementation(libs.shimmer)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.retrofit2.kotlinx.serialization.converter)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.viewpager2)
+    implementation(libs.androidx.swiperefreshlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
@@ -48,18 +48,30 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>(R.layout.fragment
 
             when (scheduleDateUiModels) {
                 is ScheduleDatesUiState.Loading -> {
-                    Log.d("TAG", "setupDate: 로딩중")
+                    showSkeleton(isLoading = true)
                 }
 
                 is ScheduleDatesUiState.Success -> {
+                    showSkeleton(isLoading = false)
                     setupScheduleTabLayout()
                     adapter.submitList(scheduleDateUiModels.dates.map { it.id })
                 }
 
                 is ScheduleDatesUiState.Error -> {
+                    showSkeleton(isLoading = false)
                     Log.d("TAG", "setupDate: ${scheduleDateUiModels.message}")
                 }
             }
+        }
+    }
+
+    private fun showSkeleton(isLoading: Boolean) {
+        if (isLoading) {
+            binding.sflScheduleTabSkeleton.visibility = View.VISIBLE
+            binding.sflScheduleSkeleton.visibility = View.VISIBLE
+        } else {
+            binding.sflScheduleTabSkeleton.visibility = View.GONE
+            binding.sflScheduleSkeleton.visibility = View.GONE
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
@@ -17,7 +17,7 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>(R.layout.fragment
         SchedulePagerAdapter(this)
     }
 
-    private val viewModel: ScheduleViewModel by viewModels { ScheduleViewModel.Factory }
+    private val viewModel: ScheduleViewModel by viewModels { ScheduleViewModel.Factory() }
 
     override fun onViewCreated(
         view: View,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
@@ -72,6 +72,9 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>(R.layout.fragment
         } else {
             binding.sflScheduleTabSkeleton.visibility = View.GONE
             binding.sflScheduleSkeleton.visibility = View.GONE
+
+            binding.sflScheduleTabSkeleton.stopShimmer()
+            binding.sflScheduleSkeleton.stopShimmer()
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -50,20 +50,31 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
         viewModel.scheduleEventsUiState.observe(viewLifecycleOwner) { schedule ->
             when (schedule) {
                 is ScheduleEventsUiState.Loading -> {
-                    Log.d("TAG", "setupObservers: 로딩중")
+                    showSkeleton(isLoading = true)
                 }
 
                 is ScheduleEventsUiState.Success -> {
                     adapter.submitList(schedule.events)
-                    binding.srlScheduleEvent.isRefreshing = false
+                    showSkeleton(isLoading = false)
                 }
 
                 is ScheduleEventsUiState.Error -> {
                     Log.d("TAG", "setupObservers: ${schedule.message}")
-                    binding.srlScheduleEvent.isRefreshing = false
+                    showSkeleton(isLoading = false)
                 }
             }
         }
+    }
+
+    private fun showSkeleton(isLoading: Boolean) {
+        if (isLoading) {
+            binding.rvScheduleEvent.visibility = View.INVISIBLE
+            binding.sflScheduleSkeleton.visibility = View.VISIBLE
+        } else {
+            binding.rvScheduleEvent.visibility = View.VISIBLE
+            binding.sflScheduleSkeleton.visibility = View.GONE
+        }
+        binding.srlScheduleEvent.isRefreshing = isLoading
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -9,10 +9,14 @@ import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentScheduleTabPageBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.schedule.adapter.ScheduleAdapter
+import java.lang.IllegalArgumentException
 
 class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.layout.fragment_schedule_tab_page) {
     private lateinit var adapter: ScheduleAdapter
-    private val viewModel: ScheduleViewModel by viewModels { ScheduleViewModel.Factory }
+    private val viewModel: ScheduleViewModel by viewModels {
+        val dateId: Long = arguments?.getLong(KEY_DATE_ID) ?: throw IllegalArgumentException()
+        ScheduleViewModel.Factory(dateId)
+    }
 
     override fun onViewCreated(
         view: View,
@@ -24,10 +28,7 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
         binding.lifecycleOwner = viewLifecycleOwner
         setupObservers()
 
-        val dateId: Long = arguments?.getLong(KEY_DATE_ID) ?: return
-        viewModel.loadScheduleByDate(dateId)
-
-        onSwipeRefreshScheduleByDateListener(dateId)
+        onSwipeRefreshScheduleByDateListener()
     }
 
     private fun setupScheduleEventRecyclerView() {
@@ -40,9 +41,9 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
             false
     }
 
-    private fun onSwipeRefreshScheduleByDateListener(dateId: Long) {
+    private fun onSwipeRefreshScheduleByDateListener() {
         binding.srlScheduleEvent.setOnRefreshListener {
-            viewModel.loadScheduleByDate(dateId)
+            viewModel.loadScheduleByDate()
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -12,7 +12,6 @@ import com.daedan.festabook.FestaBookApp
 import com.daedan.festabook.domain.repository.ScheduleRepository
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
 import com.daedan.festabook.presentation.schedule.model.toUiModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class ScheduleViewModel(
@@ -44,7 +43,6 @@ class ScheduleViewModel(
 
     fun loadScheduleByDate(dateId: Long) {
         viewModelScope.launch {
-            delay(5000)
             _scheduleEventsUiState.value = ScheduleEventsUiState.Loading
 
             val result = scheduleRepository.fetchScheduleEventsById(dateId)
@@ -62,8 +60,6 @@ class ScheduleViewModel(
 
     private fun loadAllScheduleDates() {
         viewModelScope.launch {
-            delay(5000)
-
             _scheduleDatesUiState.value = ScheduleDatesUiState.Loading
 
             val result = scheduleRepository.fetchAllScheduleDates()

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 
 class ScheduleViewModel(
     private val scheduleRepository: ScheduleRepository,
+    private val dateId: Long,
 ) : ViewModel() {
     private val _scheduleEventsUiState: MutableLiveData<ScheduleEventsUiState> =
         MutableLiveData<ScheduleEventsUiState>()
@@ -27,6 +28,7 @@ class ScheduleViewModel(
 
     init {
         loadAllScheduleDates()
+        loadScheduleByDate()
     }
 
     fun updateBookmark(scheduleEventId: Long) {
@@ -41,7 +43,7 @@ class ScheduleViewModel(
         }
     }
 
-    fun loadScheduleByDate(dateId: Long) {
+    fun loadScheduleByDate() {
         viewModelScope.launch {
             _scheduleEventsUiState.value = ScheduleEventsUiState.Loading
 
@@ -85,12 +87,13 @@ class ScheduleViewModel(
     }
 
     companion object {
-        val Factory: ViewModelProvider.Factory =
+        fun Factory(dateId: Long = 0L): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     val scheduleRepository =
                         (this[APPLICATION_KEY] as FestaBookApp).appContainer.scheduleRepository
-                    ScheduleViewModel(scheduleRepository)
+
+                    ScheduleViewModel(scheduleRepository, dateId)
                 }
             }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -28,7 +28,7 @@ class ScheduleViewModel(
 
     init {
         loadAllScheduleDates()
-        loadScheduleByDate()
+        if (dateId != INVALID_DATE_ID) loadScheduleByDate()
     }
 
     fun updateBookmark(scheduleEventId: Long) {
@@ -87,7 +87,9 @@ class ScheduleViewModel(
     }
 
     companion object {
-        fun Factory(dateId: Long = 0L): ViewModelProvider.Factory =
+        private const val INVALID_DATE_ID: Long = -1L
+
+        fun Factory(dateId: Long = INVALID_DATE_ID): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     val scheduleRepository =

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -12,6 +12,7 @@ import com.daedan.festabook.FestaBookApp
 import com.daedan.festabook.domain.repository.ScheduleRepository
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
 import com.daedan.festabook.presentation.schedule.model.toUiModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class ScheduleViewModel(
@@ -43,6 +44,7 @@ class ScheduleViewModel(
 
     fun loadScheduleByDate(dateId: Long) {
         viewModelScope.launch {
+            delay(5000)
             _scheduleEventsUiState.value = ScheduleEventsUiState.Loading
 
             val result = scheduleRepository.fetchScheduleEventsById(dateId)
@@ -60,6 +62,8 @@ class ScheduleViewModel(
 
     private fun loadAllScheduleDates() {
         viewModelScope.launch {
+            delay(5000)
+
             _scheduleDatesUiState.value = ScheduleDatesUiState.Loading
 
             val result = scheduleRepository.fetchAllScheduleDates()

--- a/android/app/src/main/res/drawable/bg_gray300_radius_10dp.xml
+++ b/android/app/src/main/res/drawable/bg_gray300_radius_10dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <solid android:color="?attr/SkeletonBackground" />
+</shape>

--- a/android/app/src/main/res/drawable/bg_gray300_radius_20dp.xml
+++ b/android/app/src/main/res/drawable/bg_gray300_radius_20dp.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/gray300" />
+
+    <corners android:radius="20dp" />
+</shape>

--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -54,6 +54,7 @@
             android:id="@+id/sfl_schedule_tab_skeleton"
             android:layout_width="match_parent"
             android:layout_height="32dp"
+            android:importantForAccessibility="no"
             app:layout_constraintBottom_toTopOf="@id/view_schedule_tab_line"
             app:layout_constraintTop_toBottomOf="@+id/tv_schedule_title"
             app:shimmer_auto_start="true">
@@ -68,21 +69,21 @@
                     layout="@layout/item_schedule_tab_skeleton"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:layout_marginEnd="12dp"
+                    android:layout_marginEnd="@dimen/schedule_tab_item_end_margin"
                     android:layout_weight="1" />
 
                 <include
                     layout="@layout/item_schedule_tab_skeleton"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:layout_marginEnd="12dp"
+                    android:layout_marginEnd="@dimen/schedule_tab_item_end_margin"
                     android:layout_weight="1" />
 
                 <include
                     layout="@layout/item_schedule_tab_skeleton"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:layout_marginEnd="12dp"
+                    android:layout_marginEnd="@dimen/schedule_tab_item_end_margin"
                     android:layout_weight="1" />
 
                 <include
@@ -98,6 +99,7 @@
             android:id="@+id/sfl_schedule_skeleton"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:importantForAccessibility="no"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_schedule_tab_line"
             app:shimmer_auto_start="true">

--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -3,9 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <data>
-
-    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -53,5 +50,74 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_schedule_tab_line" />
 
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/sfl_schedule_tab_skeleton"
+            android:layout_width="match_parent"
+            android:layout_height="32dp"
+            app:layout_constraintBottom_toTopOf="@id/view_schedule_tab_line"
+            app:layout_constraintTop_toBottomOf="@+id/tv_schedule_title"
+            app:shimmer_auto_start="true">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:baselineAligned="false"
+                android:orientation="horizontal">
+
+                <include
+                    layout="@layout/item_schedule_tab_skeleton"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="12dp"
+                    android:layout_weight="1" />
+
+                <include
+                    layout="@layout/item_schedule_tab_skeleton"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="12dp"
+                    android:layout_weight="1" />
+
+                <include
+                    layout="@layout/item_schedule_tab_skeleton"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="12dp"
+                    android:layout_weight="1" />
+
+                <include
+                    layout="@layout/item_schedule_tab_skeleton"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/sfl_schedule_skeleton"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_schedule_tab_line"
+            app:shimmer_auto_start="true">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+            </LinearLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
@@ -2,11 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <data>
-
-    </data>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -28,6 +24,28 @@
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/sfl_schedule_skeleton"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:shimmer_auto_start="true">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+                <include layout="@layout/item_schedule_tab_page_skeleton" />
+
+            </LinearLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
+    </FrameLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
@@ -9,7 +9,8 @@
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/srl_schedule_event"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:importantForAccessibility="no">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_schedule_event"
@@ -28,6 +29,7 @@
             android:id="@+id/sfl_schedule_skeleton"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:importantForAccessibility="no"
             app:shimmer_auto_start="true">
 
             <LinearLayout

--- a/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
@@ -10,16 +10,24 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_schedule_event"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srl_schedule_event"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_schedule_event"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_schedule_event_card_skeleton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="20dp"
+        android:background="@color/gray300"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_schedule_event_time_line_circle_skeleton"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_schedule_event_title_skeleton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="20dp"
+            app:layout_constraintStart_toStartOf="@id/cl_schedule_event_card_skeleton"
+            app:layout_constraintTop_toTopOf="@id/cl_schedule_event_card_skeleton" />
+
+
+        <TextView
+            android:id="@+id/tv_schedule_event_status_skeleton"
+            android:layout_width="48dp"
+            android:layout_height="24dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="@id/cl_schedule_event_card_skeleton"
+            app:layout_constraintTop_toTopOf="@id/cl_schedule_event_card_skeleton" />
+
+        <View
+            android:id="@+id/view_schedule_event_location_skeleton"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="20dp"
+            android:contentDescription="@string/schedule_location"
+            app:layout_constraintBottom_toBottomOf="@id/cl_schedule_event_card_skeleton"
+            app:layout_constraintEnd_toStartOf="@id/tv_schedule_event_location_skeleton"
+            app:layout_constraintStart_toStartOf="@id/cl_schedule_event_card_skeleton"
+            app:layout_constraintTop_toBottomOf="@id/view_schedule_event_clock_skeleton" />
+
+        <TextView
+            android:id="@+id/tv_schedule_event_location_skeleton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            app:layout_constraintBottom_toBottomOf="@id/view_schedule_event_location_skeleton"
+            app:layout_constraintStart_toEndOf="@id/view_schedule_event_location_skeleton"
+            app:layout_constraintTop_toTopOf="@+id/view_schedule_event_location_skeleton" />
+
+        <View
+            android:id="@+id/view_schedule_event_clock_skeleton"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:contentDescription="@string/schedule_time"
+            app:layout_constraintBottom_toTopOf="@id/view_schedule_event_location_skeleton"
+            app:layout_constraintStart_toStartOf="@id/cl_schedule_event_card_skeleton"
+            app:layout_constraintTop_toBottomOf="@id/tv_schedule_event_title_skeleton" />
+
+        <TextView
+            android:id="@+id/tv_schedule_event_time_skeleton"
+            style="@style/PretendardRegular12"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            app:layout_constraintBottom_toBottomOf="@id/view_schedule_event_clock_skeleton"
+            app:layout_constraintStart_toEndOf="@id/view_schedule_event_clock_skeleton"
+            app:layout_constraintTop_toTopOf="@id/view_schedule_event_clock_skeleton" />
+
+        <View
+            android:id="@+id/view_schedule_event_book_mark_skeleton"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="20dp"
+            android:contentDescription="@string/all_book_mark"
+            app:layout_constraintBottom_toBottomOf="@id/cl_schedule_event_card_skeleton"
+            app:layout_constraintEnd_toEndOf="@id/cl_schedule_event_card_skeleton" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/view_schedule_event_time_line_skeleton"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:layout_marginEnd="12dp"
+        android:background="@color/gray300"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/cl_schedule_event_card_skeleton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/iv_schedule_event_time_line_circle_skeleton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="12dp"
+        android:contentDescription="@string/schedule_circle"
+        android:elevation="11dp"
+        android:src="@drawable/ic_circle_gray300"
+        app:layout_constraintBottom_toBottomOf="@id/cl_schedule_event_card_skeleton"
+        app:layout_constraintEnd_toStartOf="@id/cl_schedule_event_card_skeleton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/cl_schedule_event_card_skeleton" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_schedule_event_card_skeleton"
@@ -10,7 +10,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginTop="20dp"
-        android:background="@color/gray300"
+        android:background="@drawable/bg_gray300_radius_10dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/iv_schedule_event_time_line_circle_skeleton"
@@ -96,7 +96,7 @@
         android:layout_width="1dp"
         android:layout_height="0dp"
         android:layout_marginEnd="12dp"
-        android:background="@color/gray300"
+        android:background="?attr/SkeletonBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/cl_schedule_event_card_skeleton"
         app:layout_constraintStart_toStartOf="parent"

--- a/android/app/src/main/res/layout/item_schedule_tab_skeleton.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_skeleton.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="0dp"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <View
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:background="@color/gray300" />
+        android:background="@drawable/bg_gray300_radius_20dp" />
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/item_schedule_tab_skeleton.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_skeleton.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="0dp"
+    android:layout_height="match_parent">
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:background="@color/gray300" />
+
+</LinearLayout>

--- a/android/app/src/main/res/values/attrs.xml
+++ b/android/app/src/main/res/values/attrs.xml
@@ -4,4 +4,8 @@
         <attr name="initialY" format="dimension" />
         <attr name="minimumY" format="dimension" />
     </declare-styleable>
+
+    <declare-styleable name="SkeletonView">
+        <attr name="SkeletonBackground" format="color" />
+    </declare-styleable>
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="schedule_tab_item_end_margin">12dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -2,6 +2,7 @@
     <!-- Base application theme. -->
     <style name="Base.Theme.Festabook" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowBackground">@color/gray050</item>
+        <item name="SkeletonBackground">@color/gray300</item>
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
     </style>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,10 +14,12 @@ constraintlayout = "2.2.1"
 retrofit = "3.0.0"
 kotlinx-serialization-json = "1.9.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
+swiperefreshlayout = "1.1.0"
 viewpager2 = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
 coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ constraintlayout = "2.2.1"
 retrofit = "3.0.0"
 kotlinx-serialization-json = "1.9.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
+shimmer = "0.5.0"
 swiperefreshlayout = "1.1.0"
 viewpager2 = "1.1.0"
 
@@ -34,6 +35,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
+shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/137

<br>

## 🛠️ 작업 내용

- 일정 화면에서 현재 탭의 일정을 위에서 아래로 스크롤 하면 일정이 업데이트 되는 기능을 추가했습니다.
- 로딩 상태일 때 skeleton ui를 추가했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 해당 화면에 대한 예외처리는 하지 않았습니다. 새로운 이슈를 생성해서 구현할 예정입니다.
- xml에서 ShimmerFrameLayout 를 구현할 때 일정카드 한개의 내부 아이템들이 필요 없어서 제거를 하다 보니 제약조건이 풀려서 카드의 사이즈를 동적으로 구현 못하게 되어 사이즈를 하드코딩 했습니다. 이를 해결할 방법이 있으면 리뷰에서 알려주세요.

<br>

## 📸 이미지 첨부 (Optional)
### 전체화면 로딩


https://github.com/user-attachments/assets/06433873-9a94-4f1c-b65c-08137d8103bb





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 일정 화면에 스켈레톤(Shimmer) 로딩 UI가 추가되어 데이터 로딩 시 시각적 피드백을 제공합니다.
  * 일정 탭 페이지에서 당겨서 새로고침(Swipe-to-Refresh) 기능이 추가되었습니다.
  * 일정 조회 시 특정 날짜 ID를 기반으로 데이터를 불러오는 기능이 도입되었습니다.

* **스타일**
  * 일정 및 일정 탭 페이지에 스켈레톤 뷰와 관련된 레이아웃이 추가되었습니다.

* **리팩터**
  * 일정 탭 페이지의 UI 설정 로직이 함수로 분리되어 코드 구조가 개선되었습니다.
  * ViewModel 초기화 방식이 변경되어 날짜 ID를 필수 인자로 받도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->