### PR TITLE
[BE] 예외 응답시 JSON 형태로 응답하도록 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/SwaggerConfig.java
@@ -21,6 +21,7 @@ public class SwaggerConfig {
 
     private static final String ORGANIZATION_SCHEME_NAME = "조직(Organization) ID 값";
     private static final List<String[]> API_GROUPS = List.of(
+            new String[]{"전체", "/**"},
             new String[]{"일정 API", "/schedules/**"},
             new String[]{"플레이스 API", "/places/**"},
             new String[]{"공지 API", "/announcements/**"},

--- a/backend/src/main/java/com/daedan/festabook/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/BusinessException.java
@@ -14,6 +14,6 @@ public class BusinessException extends RuntimeException {
     }
 
     public ExceptionResponse toResponse() {
-        return ExceptionResponse.from(getMessage());
+        return new ExceptionResponse(getMessage());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/BusinessException.java
@@ -13,7 +13,7 @@ public class BusinessException extends RuntimeException {
         this.status = status;
     }
 
-    public ExceptionResponse getResponse() {
+    public ExceptionResponse toResponse() {
         return ExceptionResponse.from(getMessage());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/BusinessException.java
@@ -12,4 +12,8 @@ public class BusinessException extends RuntimeException {
         super(message);
         this.status = status;
     }
+
+    public ExceptionResponse getResponse() {
+        return ExceptionResponse.from(getMessage());
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/ExceptionResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/ExceptionResponse.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.global.exception;
+
+public record ExceptionResponse(
+        String message
+) {
+
+    public static ExceptionResponse from(String message) {
+        return new ExceptionResponse(message);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/exception/ExceptionResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/ExceptionResponse.java
@@ -3,8 +3,4 @@ package com.daedan.festabook.global.exception;
 public record ExceptionResponse(
         String message
 ) {
-
-    public static ExceptionResponse from(String message) {
-        return new ExceptionResponse(message);
-    }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -12,15 +12,16 @@ public class GlobalExceptionHandler {
     private static final String INTERNAL_ERROR_MESSAGE = "서버에 오류가 발생하였습니다. 관리자에게 문의해주세요.";
 
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<String> handleBusinessException(BusinessException businessException) {
+    public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException businessException) {
+
         return ResponseEntity.status(businessException.getStatus())
-                .body(businessException.getMessage());
+                .body(businessException.getResponse());
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleException(Exception exception) {
+    public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
         log.warn(exception.getMessage());
         return ResponseEntity.internalServerError()
-                .body(INTERNAL_ERROR_MESSAGE);
+                .body(ExceptionResponse.from(INTERNAL_ERROR_MESSAGE));
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException businessException) {
 
         return ResponseEntity.status(businessException.getStatus())
-                .body(businessException.getResponse());
+                .body(businessException.toResponse());
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -14,14 +14,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException businessException) {
         log.info(businessException.getMessage());
-        return ResponseEntity.status(businessException.getStatus())
+        return ResponseEntity
+                .status(businessException.getStatus())
                 .body(businessException.toResponse());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
         log.warn(exception.getMessage());
-        return ResponseEntity.internalServerError()
+        return ResponseEntity
+                .internalServerError()
                 .body(new ExceptionResponse(INTERNAL_ERROR_MESSAGE));
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -22,6 +22,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
         log.warn(exception.getMessage());
         return ResponseEntity.internalServerError()
-                .body(ExceptionResponse.from(INTERNAL_ERROR_MESSAGE));
+                .body(new ExceptionResponse(INTERNAL_ERROR_MESSAGE));
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException businessException) {
-
+        log.info(businessException.getMessage());
         return ResponseEntity.status(businessException.getStatus())
                 .body(businessException.toResponse());
     }

--- a/backend/src/test/java/com/daedan/festabook/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/global/exception/GlobalExceptionHandlerTest.java
@@ -40,6 +40,7 @@ class GlobalExceptionHandlerTest {
             // given
             String expectedMessage = "예외가 발생했습니다.";
             int expectedStatusCode = HttpStatus.I_AM_A_TEAPOT.value();
+            int expectedFieldSize = 1;
 
             // when & then
             RestAssured
@@ -52,7 +53,8 @@ class GlobalExceptionHandlerTest {
                     .log()
                     .all()
                     .statusCode(expectedStatusCode)
-                    .body(equalTo(expectedMessage));
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("message", equalTo(expectedMessage));
         }
 
         @Test
@@ -60,6 +62,7 @@ class GlobalExceptionHandlerTest {
             // given
             String expectedMessage = "관리자에게";
             int expectedStatusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+            int expectedFieldSize = 1;
 
             // when & then
             RestAssured
@@ -70,7 +73,8 @@ class GlobalExceptionHandlerTest {
                     .log()
                     .all()
                     .statusCode(expectedStatusCode)
-                    .body(containsString(expectedMessage));
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("message", containsString(expectedMessage));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -333,6 +333,7 @@ class PlaceControllerTest {
             organizationJpaRepository.save(organization);
 
             Long placeId = 0L;
+            int expectedFieldSize = 1;
 
             // when & then
             RestAssured
@@ -344,7 +345,8 @@ class PlaceControllerTest {
                     .log()
                     .all()
                     .statusCode(HttpStatus.NOT_FOUND.value())
-                    .body(equalTo("존재하지 않는 플레이스 세부 정보입니다."));
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("message", equalTo("존재하지 않는 플레이스 세부 정보입니다."));
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#149 

<br>

## 🛠️ 작업 내용

- 예외 응답 메시지를 문자열 텍스트에서 JSON으로 변경
    - 추가될 예외 정보를 대비하여 객체 형태로 변경 
    - 모든 응답이 application/json 형태로 통일


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모든 API 경로를 아우르는 "전체" API 그룹이 추가되어 API 문서에서 전체 엔드포인트를 한 번에 확인할 수 있습니다.
  * 예외 처리 시 반환되는 응답이 구조화된 JSON 형태(`message` 필드 포함)로 개선되어, 에러 메시지 확인이 더 명확해졌습니다.

* **버그 수정**
  * 예외 처리 로직이 개선되어 예외 메시지 로깅이 추가되고, 일관된 JSON 응답으로 반환됩니다.

* **테스트**
  * 예외 처리 및 에러 메시지 반환 관련 테스트가 구조화된 JSON 응답 형태를 검증하도록 개선되었습니다.
  * 플레이스 상세 정보 조회 실패 시 반환되는 에러 메시지 테스트가 JSON 구조를 검증하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->