### PR TITLE
[AN]Timber 로깅 라이브러리 추가

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.swiperefreshlayout)
     implementation(libs.shimmer)
+    implementation(libs.timber)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
+++ b/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
@@ -1,9 +1,8 @@
 package com.daedan.festabook
 
 import android.app.Application
-import com.daedan.festabook.data.repository.ScheduleRepositoryImpl
-import com.daedan.festabook.domain.repository.ScheduleRepository
 import com.naver.maps.map.NaverMapSdk
+import timber.log.Timber
 
 class FestaBookApp : Application() {
     lateinit var appContainer: AppContainer
@@ -11,9 +10,22 @@ class FestaBookApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        setupTimber()
         appContainer = AppContainer()
         setUpNaverSdk()
+    }
 
+    private fun setupTimber() {
+        if (BuildConfig.DEBUG) plantDebugTimberTree()
+    }
+
+    private fun plantDebugTimberTree() {
+        Timber.plant(
+            object : Timber.DebugTree() {
+                override fun createStackElementTag(element: StackTraceElement): String =
+                    "${super.createStackElementTag(element)}:${element.lineNumber}"
+            },
+        )
     }
 
     private fun setUpNaverSdk() {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ kotlinx-serialization-json = "1.9.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
 shimmer = "0.5.0"
 swiperefreshlayout = "1.1.0"
+timber = "5.0.1"
 viewpager2 = "1.1.0"
 ktlint = "13.0.0"
 
@@ -41,6 +42,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
 shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Timber 라이브러리 의존성 추가
- Application 클래스에 Timber 초기화 로직 추가
- 디버그 빌드 시 라인 번호가 포함된 Timber DebugTree 활성화

## #️⃣ 이슈 번호
https://github.com/woowacourse-teams/2025-festabook/issues/151


<br>

## 🛠️ 작업 내용

- Timber 로깅 라이브러리 추가
- 로그 메시지 포맷팅

<br>

## 🙇🏻 중점 리뷰 요청


<br>

## 📸 이미지 첨부 (Optional)

<img width="409" height="30" alt="image" src="https://github.com/user-attachments/assets/7a2e8f70-bf4e-4b2d-b3e2-e774a478f183" />

<img width="981" height="29" alt="image" src="https://github.com/user-attachments/assets/91be55a7-fce2-4b0c-9c12-837f4d596942" />

- {파일}:{라인} {메시지} 로 출력됩니당. 로그 찍을 때 참고해주세용

