### PR TITLE
[BE] CORS 설정 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/WebMvcConfig.java
@@ -20,7 +20,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:5173", "http://127.0.0.1:5173")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
                 .allowedHeaders("*")
-                .allowCredentials(true)
                 .maxAge(3600);
     }
 

--- a/backend/src/test/java/com/daedan/festabook/global/config/WebMvcConfigTest.java
+++ b/backend/src/test/java/com/daedan/festabook/global/config/WebMvcConfigTest.java
@@ -73,30 +73,27 @@ class WebMvcConfigTest {
             String origin1 = "http://localhost:5173";
             String origin2 = "http://127.0.0.1:5173";
             String expectedResponse = "addCorsMappings-POST";
-            String expectedAllowCredentials = "true";
 
             // when & then
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin1)
                     .when()
                     .post("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin1))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin1));
 
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin2)
                     .when()
                     .post("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin2))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin2));
         }
 
         @Test
@@ -105,30 +102,27 @@ class WebMvcConfigTest {
             String origin1 = "http://localhost:5173";
             String origin2 = "http://127.0.0.1:5173";
             String expectedResponse = "addCorsMappings-GET";
-            String expectedAllowCredentials = "true";
 
             // when & then
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin1)
                     .when()
                     .get("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin1))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin1));
 
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin2)
                     .when()
                     .get("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin2))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin2));
         }
 
         @Test
@@ -137,30 +131,27 @@ class WebMvcConfigTest {
             String origin1 = "http://localhost:5173";
             String origin2 = "http://127.0.0.1:5173";
             String expectedResponse = "addCorsMappings-PUT";
-            String expectedAllowCredentials = "true";
 
             // when & then
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin1)
                     .when()
                     .put("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin1))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin1));
 
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin2)
                     .when()
                     .put("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin2))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin2));
         }
 
         @Test
@@ -169,30 +160,27 @@ class WebMvcConfigTest {
             String origin1 = "http://localhost:5173";
             String origin2 = "http://127.0.0.1:5173";
             String expectedResponse = "addCorsMappings-PATCH";
-            String expectedAllowCredentials = "true";
 
             // when & then
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin1)
                     .when()
                     .patch("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin1))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin1));
 
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin2)
                     .when()
                     .patch("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin2))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin2));
         }
 
         @Test
@@ -201,42 +189,40 @@ class WebMvcConfigTest {
             String origin1 = "http://localhost:5173";
             String origin2 = "http://127.0.0.1:5173";
             String expectedResponse = "addCorsMappings-DELETE";
-            String expectedAllowCredentials = "true";
 
             // when & then
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin1)
                     .when()
                     .delete("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin1))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin1));
 
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Origin", origin2)
                     .when()
                     .delete("/test/addCorsMappings")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body(equalTo(expectedResponse))
-                    .header("Access-Control-Allow-Origin", equalTo(origin2))
-                    .header("Access-Control-Allow-Credentials", equalTo(expectedAllowCredentials));
+                    .header("Access-Control-Allow-Origin", equalTo(origin2));
         }
 
         @Test
         void 성공_Preflight_요청() {
             // given & when & then
-            RestAssured.
-                    given()
+            RestAssured
+                    .given()
                     .header("Access-Control-Request-Method", "POST")
                     .header("Access-Control-Request-Headers", "Content-Type,organization")
                     .when()
                     .options("/test/addCorsMappings")
                     .then()
+                    .log().all()
                     .statusCode(HttpStatus.OK.value())
                     .header("Allow", containsString("POST"))
                     .header("Allow", containsString("GET"))


### PR DESCRIPTION
## #️⃣ 이슈 번호

#168 

<br>

## 🛠️ 작업 내용

localhost, 127.0.0.1 origin에 대한 CORS 허용 헤더를 응답에 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 특정 출처에서의 요청을 허용하는 CORS 설정이 추가되었습니다. 이제 `http://localhost:5173` 및 `http://127.0.0.1:5173`에서 GET, POST, PUT, PATCH, DELETE 메서드로 접근할 수 있습니다.

* **테스트**
  * 다양한 HTTP 메서드와 프리플라이트 요청에 대한 CORS 동작을 검증하는 테스트가 추가되었습니다.
  * 허용되지 않은 출처에서의 요청이 차단되는지 확인하는 테스트가 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->