### PR TITLE
[FE] 지도 좌표 설정 페이지 구현 

### DIFF
--- a/frontend/src/components/map/MapSelector.tsx
+++ b/frontend/src/components/map/MapSelector.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useRef, useState } from 'react';
+import api from '../../utils/api';
+
+type MapSelectorProps = {
+  placeId: number;
+  onSaved?: (result: any) => void;
+};
+
+const DEFAULT_CENTER = { lat: 37.5665, lng: 126.9780 };
+const DEFAULT_ZOOM = 15;
+const NAVER_MAP_CLIENT_ID = '09h8qpimmp';
+
+declare global {
+  interface ImportMetaEnv {
+    VITE_NAVER_MAP_CLIENT_ID: string;
+  }
+  interface ImportMeta {
+    env: ImportMetaEnv;
+  }
+  interface Window {
+    naver: any;
+    navermap_authFailure: () => void;
+  }
+}
+
+const MapSelector: React.FC<MapSelectorProps> = ({ placeId, onSaved }) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const markerRef = useRef<any>(null); // 마커를 useRef로 관리
+  const [loading, setLoading] = useState(true); // 네이버 지도 API 준비 여부
+  const [mapReady, setMapReady] = useState(false); // 실제 지도 준비 여부
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [center, setCenter] = useState(DEFAULT_CENTER);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+
+  useEffect(() => {
+    async function fetchGeography() {
+      try {
+        const res = await api.get('/organizations/geography');
+        if (res.data && res.data.centerCoordinate) {
+          setCenter({
+            lat: res.data.centerCoordinate.latitude,
+            lng: res.data.centerCoordinate.longitude,
+          });
+        }
+        if (res.data && res.data.zoom) {
+          setZoom(res.data.zoom);
+        }
+      } catch (e) {
+        // 실패 시 기본값 유지
+      }
+    }
+    fetchGeography();
+  }, []);
+
+    // 네이버 지도 API
+  useEffect(() => {
+    if (window.naver && window.naver.maps) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    window.navermap_authFailure = function () {
+      console.log('네이버 지도 인증 실패');
+    };
+    const script = document.createElement('script');
+    script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${NAVER_MAP_CLIENT_ID}&submodules=gl`;
+    script.async = true;
+    script.onload = () => setLoading(false);
+    script.onerror = () => setLoading(false);
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  // 지도 및 클릭 이벤트 초기화
+  useEffect(() => {
+    if (loading) return;
+    if (!window.naver || !mapRef.current) return;
+    const naver = window.naver;
+    const mapInstance = new naver.maps.Map(mapRef.current, {
+      center: new naver.maps.LatLng(center.lat, center.lng),
+      zoom: zoom + 1,
+      gl: true,
+      customStyleId: '4b934c2a-71f5-4506-ab90-4e6aa14c0820',
+      zoomControl: true,
+      zoomControlOptions: {
+          position: naver.maps.Position.TOP_RIGHT,
+          style: naver.maps.ZoomControlStyle.SMALL
+      }
+    });
+    setMapReady(true);
+    const handleClick = (e: any) => {
+      const lat = e.coord.lat();
+      const lng = e.coord.lng();
+      setCoords({ lat, lng });
+      if (markerRef.current) {
+        markerRef.current.setMap(null);
+      }
+      const newMarker = new naver.maps.Marker({
+        position: new naver.maps.LatLng(lat, lng),
+        map: mapInstance,
+      });
+      markerRef.current = newMarker;
+    };
+    naver.maps.Event.addListener(mapInstance, 'click', handleClick);
+    return () => {
+      naver.maps.Event.clearInstanceListeners(mapInstance);
+      if (markerRef.current) {
+        markerRef.current.setMap(null);
+        markerRef.current = null;
+      }
+    };
+  }, [loading, center, zoom]);
+
+  const handleSave = async () => {
+    if (!coords) return;
+    setSaving(true);
+    try {
+      const res = await api.post('/places/geographies', {
+        placeId,
+        latitude: coords.lat,
+        longitude: coords.lng,
+      });
+      onSaved && onSaved(res.data);
+      alert('좌표가 저장되었습니다!');
+    } catch (e: any) {
+      alert(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      {loading || !mapReady ? <div>지도를 불러오는 중입니다...</div> : null}
+      <div
+        id="map"
+        ref={mapRef}
+        style={{ width: '100%', height: 400, display: loading || !mapReady ? 'none' : 'block' }}
+      />
+      <div className="mt-4 flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={!coords || saving}
+          className="bg-blue-600 text-white px-4 py-2 rounded disabled:bg-gray-300"
+        >
+          {saving ? '저장 중...' : '좌표 설정'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MapSelector; 

--- a/frontend/src/pages/MapSettingsPage.jsx
+++ b/frontend/src/pages/MapSettingsPage.jsx
@@ -1,33 +1,246 @@
-import React from 'react';
-import { useData } from '../hooks/useData';
+import React, { useState, useEffect, useRef } from 'react';
 import { placeCategories } from '../constants/categories';
+import Modal from '../components/common/Modal';
+import MapSelector from '../components/map/MapSelector';
+import api from '../utils/api';
+
+const DEFAULT_CENTER = { lat: 37.5665, lng: 126.9780 };
+const DEFAULT_ZOOM = 15;
+const NAVER_MAP_CLIENT_ID = '09h8qpimmp';
+const KOREA_BOUNDARY = [
+  [39.2163345, 123.5125660],
+  [39.2163345, 130.5440844],
+  [32.8709533, 130.5440844],
+  [32.8709533, 123.5125660],
+];
 
 const MapSettingsPage = () => {
-    const { booths } = useData();
+  const [booths, setBooths] = useState([]);
+  const [selectedPlace, setSelectedPlace] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [center, setCenter] = useState(DEFAULT_CENTER);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+  const [loading, setLoading] = useState(true);
+  const [mapReady, setMapReady] = useState(false);
+  const [holeBoundary, setHoleBoundary] = useState([]);
+  const [markers, setMarkers] = useState([]);
+  const mapRef = useRef(null);
+  const polygonRef = useRef(null);
+  const markerRefs = useRef([]);
+  const [mapHeight, setMapHeight] = useState(() => {
+    return window.innerWidth < 1024 ? Math.min(Math.max(window.innerWidth * 0.8, 400), 600) : '100%';
+  });
+
+  useEffect(() => {
+    async function fetchBooths() {
+      try {
+        const res = await api.get('/places/previews');
+        setBooths(res.data || []);
+      } catch (e) {
+        setBooths([]);
+      }
+    }
+    fetchBooths();
+  }, []);
+
+  useEffect(() => {
+    async function fetchGeography() {
+      try {
+        const res = await api.get('/organizations/geography');
+        if (res.data && res.data.centerCoordinate) {
+          setCenter({
+            lat: res.data.centerCoordinate.latitude,
+            lng: res.data.centerCoordinate.longitude,
+          });
+        }
+        if (res.data && res.data.zoom) {
+          setZoom(res.data.zoom);
+        }
+        if (res.data && res.data.polygonHoleBoundary) {
+          setHoleBoundary(res.data.polygonHoleBoundary);
+        }
+      } catch (e) {
+        // 실패 시 기본값 유지
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchGeography();
+  }, []);
+
+    // 네이버 지도 API
+    useEffect(() => {
+        if (window.naver && window.naver.maps) {
+            setMapReady(true);
+            return;
+        }
+        setMapReady(false);
+        window.navermap_authFailure = function () {
+            console.log('네이버 지도 인증 실패');
+        };
+        const script = document.createElement('script');
+        script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${NAVER_MAP_CLIENT_ID}&submodules=gl`;
+        script.async = true;
+        script.onload = () => setMapReady(true);
+        script.onerror = () => setMapReady(false);
+        document.body.appendChild(script);
+        return () => {
+            document.body.removeChild(script);
+        };
+    }, []);
+
+    // 마커 좌표 목록 API
+    useEffect(() => {
+      async function fetchMarkers() {
+        try {
+          const res = await api.get('/places/geographies');
+          setMarkers(res.data || []);
+        } catch (e) {
+          setMarkers([]);
+        }
+      }
+      fetchMarkers();
+    }, []);
+
+    useEffect(() => {
+        const updateHeight = () => {
+          const newHeight = window.innerWidth < 1024
+            ? Math.min(Math.max(window.innerWidth * 0.8, 400), 600)
+            : '100%';
+          setMapHeight(newHeight);
+        };
+        window.addEventListener('resize', updateHeight);
+        return () => window.removeEventListener('resize', updateHeight);
+      }, []);
+
+    useEffect(() => {
+        if (loading || !mapReady) return;
+        if (!window.naver || !mapRef.current) return;
+        const naver = window.naver;
+        const mapInstance = new naver.maps.Map(mapRef.current, {
+            center: new naver.maps.LatLng(center.lat, center.lng),
+            zoom: zoom + 2,
+            gl: true,
+            customStyleId: '4b934c2a-71f5-4506-ab90-4e6aa14c0820',
+            zoomControl: true,
+            zoomControlOptions: {
+                position: naver.maps.Position.TOP_RIGHT,
+                style: naver.maps.ZoomControlStyle.SMALL
+            }
+        });
+        // 폴리곤 그리기
+        if (holeBoundary && holeBoundary.length > 2) {
+            // 대한민국 전체 외곽선
+            const outer = KOREA_BOUNDARY.map(([lat, lng]) => new naver.maps.LatLng(lat, lng));
+            // 서버에서 받은 홀(구멍) 외곽선
+            const hole = holeBoundary.map((p) => new naver.maps.LatLng(p.latitude, p.longitude));
+            if (polygonRef.current) {
+                polygonRef.current.setMap(null);
+            }
+            polygonRef.current = new naver.maps.Polygon({
+                map: mapInstance,
+                paths: [outer, hole],
+                fillColor: '#1b1b1b',
+                fillOpacity: 0.3,
+                strokeColor: '#1b1b1b',
+                strokeOpacity: 0.6,
+                strokeWeight: 3
+            });
+        }
+        // 마커 그리기
+        markerRefs.current.forEach(m => m.setMap(null));
+        markerRefs.current = [];
+        markers.forEach(marker => {
+          if (marker.markerCoordinate) {
+            const m = new naver.maps.Marker({
+              position: new naver.maps.LatLng(marker.markerCoordinate.latitude, marker.markerCoordinate.longitude),
+              map: mapInstance,
+              title: marker.category
+            });
+            markerRefs.current.push(m);
+          }
+        });
+        return () => {
+            naver.maps.Event.clearInstanceListeners(mapInstance);
+            if (polygonRef.current) {
+                polygonRef.current.setMap(null);
+                polygonRef.current = null;
+            }
+            markerRefs.current.forEach(m => m.setMap(null));
+            markerRefs.current = [];
+        };
+    }, [loading, mapReady, center, zoom, holeBoundary, markers]);
+
+    useEffect(() => {
+      if (!modalOpen) return;
+      // ESC 키 이벤트 핸들러
+      const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+          setModalOpen(false);
+        }
+      };
+      window.addEventListener('keydown', handleKeyDown);
+      return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [modalOpen]);
+
     return (
-        <div>
+        <div style={{ height: '100%', boxSizing: 'border-box' }}>
             <h2 className="text-3xl font-bold mb-6">지도 설정</h2>
-            <div style={{ width: '100%', height: '400px' }} className="bg-gray-200 rounded-lg shadow-sm border border-gray-300 mb-6 flex items-center justify-center">
-                <p className="text-gray-500 font-semibold">지도 표시 영역</p>
+            <div className="mb-2 flex gap-4 items-center">
             </div>
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 overflow-x-auto">
-                <h3 className="text-xl font-bold mb-4">플레이스 목록</h3>
-                <div className="space-y-2">
-                    {booths.map(booth => (
-                        <div key={booth.id} className="p-3 rounded-md flex justify-between items-center bg-gray-50">
-                            <div>
-                                <p className="font-semibold">{booth.title}</p>
-                                <p className="text-sm text-gray-500">{placeCategories[booth.category]}</p>
-                            </div>
-                            <button
-                                className="font-bold py-2 px-4 rounded-lg text-sm bg-gray-200 hover:bg-gray-300 text-gray-800"
-                            >
-                                좌표 설정
-                            </button>
+            <div className="flex flex-col lg:flex-row gap-8" style={{ height: 'calc(100% - 64px)' }}>
+                {/* 지도 영역 */}
+                <div className="flex-grow flex justify-center items-start" style={{ height: '100%' }}>
+                    <div
+                        className="bg-gray-200 rounded-lg shadow-sm border border-gray-300 flex items-center justify-center"
+                        style={{ width: '100%', height: '100%', minWidth: 320, minHeight: 320, maxWidth: '100vw', maxHeight: '100%' }}
+                        >
+                        {loading || !mapReady ? (
+                        <div>지도를 불러오는 중입니다...</div>
+                        ) : (
+                            <div
+                                id="main-map"
+                                ref={mapRef}
+                                className="w-full"
+                                style={{
+                                    height: mapHeight,
+                                }}
+                            />
+                        )}
+                    </div>
+                </div>
+                {/* 플레이스 목록 */}
+                <div className="w-full lg:max-w-[420px]" style={{ height: '100%' }}>
+                    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 overflow-x-auto" style={{ height: '100%', overflowY: 'auto' }}>
+                        <h3 className="text-xl font-bold mb-4">플레이스 목록</h3>
+                        <div className="space-y-2">
+                            {booths.map(booth => (
+                                <div key={booth.id} className="p-3 rounded-md flex justify-between items-center bg-gray-50">
+                                    <div>
+                                        <p className="font-semibold">{booth.title}</p>
+                                        <p className="text-sm text-gray-500">{placeCategories[booth.category]}</p>
+                                    </div>
+                                    <button
+                                        className="font-bold py-2 px-4 rounded-lg text-sm bg-gray-200 hover:bg-gray-300 text-gray-800"
+                                        onClick={() => { setSelectedPlace(booth); setModalOpen(true); }}
+                                    >
+                                        좌표 설정
+                                    </button>
+                                </div>
+                            ))}
                         </div>
-                    ))}
+                    </div>
                 </div>
             </div>
+            {modalOpen && selectedPlace && (
+                <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)} maxWidth="max-w-2xl">
+                    <h3 className="text-xl font-bold mb-4">{selectedPlace.title} 좌표 설정</h3>
+                    <MapSelector
+                        placeId={selectedPlace.id}
+                        onSaved={() => { setModalOpen(false); }}
+                    />
+                </Modal>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## #️⃣ 이슈 번호

#187

<br>

## 🛠️ 작업 내용

- 초기 중심 좌표를 organizationId를 통한 GET /organizations/geography 엔드포인트를 통해 받아오기
- GET /places/geographies 를 통해 지도의 모든 마커 조회 후 표시하기
- 지도와 플레이스 화면 양옆으로 배열
- 반응형 적용
- 좌표 설정 창 ESC 누를 시 닫히기 구현

<br>

## 🙇🏻 중점 리뷰 요청

- 혹시 가능하시다면 직접 제 브랜치로 체크아웃해서 여러 개 눌러봐주시면 좋을 것 같아요.
- 추가적으로 구현하고 싶은 화면에 대한 기능이 있으시면 말씀해 주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img width="3558" height="1952" alt="image" src="https://github.com/user-attachments/assets/cf7b5058-b7f5-4919-b765-114d8144e5cb" />

<img width="3562" height="1948" alt="image" src="https://github.com/user-attachments/assets/423cbae7-ccdd-4c93-b405-b18cdd6f2cbc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Naver 지도를 활용한 좌표 선택 기능이 추가되었습니다.
  * 장소별로 "좌표 설정" 버튼을 통해 좌표를 직접 선택하고 저장할 수 있습니다.
  * 지도에 폴리곤 및 마커가 표시되어 시각적으로 위치를 확인할 수 있습니다.

* **UI 개선**
  * 지도와 장소 리스트가 2단 레이아웃으로 구성되어 사용성이 향상되었습니다.
  * 좌표 설정 시 모달 창이 열려 편리하게 편집할 수 있습니다.

* **버그 수정**
  * 지도 및 데이터 로딩, 저장 과정에서 사용자에게 알림 및 상태 표시가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->