### PR TITLE
[AN] 소식 > 공지 아이템 표시 기능 추가

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Run ktlint
         run: ./gradlew ktlintCheck
+        
+      - name: Run Unit Test
+        run: ./gradlew test
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -79,27 +79,24 @@ class AppContainer(
     }
 
     init {
-        ensureUuidExists()
-        updateFcmToken()
+        ensureDeviceIdentifiers()
     }
 
-    private fun ensureUuidExists() {
+    private fun ensureDeviceIdentifiers() {
         if (preferencesManager.getUuid().isNullOrEmpty()) {
-            val newUuid = UUID.randomUUID().toString()
-            preferencesManager.saveUuid(newUuid)
-            Timber.d("새로 생성한 uuid : $newUuid")
+            val uuid = UUID.randomUUID().toString()
+            preferencesManager.saveUuid(uuid)
+            Timber.d("🆕 UUID 생성 및 저장: $uuid")
         }
-    }
 
-    private fun updateFcmToken() {
         FirebaseMessaging
             .getInstance()
             .token
             .addOnSuccessListener { token ->
                 preferencesManager.saveFcmToken(token)
-                Timber.d(" 저장된 FCM token: $token")
+                Timber.d("📡 FCM 토큰 저장: $token")
             }.addOnFailureListener {
-                Timber.w(it, "Failed to get FCM token")
+                Timber.w(it, "❌ FCM 토큰 수신 실패")
             }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/NoticeDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/NoticeDataSource.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.datasource.remote
 
-import com.daedan.festabook.data.model.response.NoticeResponse
+import com.daedan.festabook.data.model.response.NoticeListResponse
 
 interface NoticeDataSource {
-    suspend fun fetchNotices(): ApiResult<List<NoticeResponse>>
+    suspend fun fetchNotices(): ApiResult<NoticeListResponse>
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/NoticeDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/NoticeDataSourceImpl.kt
@@ -1,10 +1,10 @@
 package com.daedan.festabook.data.datasource.remote
 
-import com.daedan.festabook.data.model.response.NoticeResponse
+import com.daedan.festabook.data.model.response.NoticeListResponse
 import com.daedan.festabook.data.service.NoticeService
 
 class NoticeDataSourceImpl(
     private val noticeService: NoticeService,
 ) : NoticeDataSource {
-    override suspend fun fetchNotices(): ApiResult<List<NoticeResponse>> = ApiResult.toApiResult { noticeService.getNotices() }
+    override suspend fun fetchNotices(): ApiResult<NoticeListResponse> = ApiResult.toApiResult { noticeService.getNotices() }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/NoticeListResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/NoticeListResponse.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NoticeListResponse(
+    @SerialName("pinned")
+    val pinned: List<NoticeResponse> = emptyList(),
+    @SerialName("unpinned")
+    val unpinned: List<NoticeResponse> = emptyList(),
+)

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/NoticeRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/NoticeRepositoryImpl.kt
@@ -11,6 +11,10 @@ class NoticeRepositoryImpl(
 ) : NoticeRepository {
     override suspend fun fetchNotices(): Result<List<Notice>> {
         val response = noticeDataSource.fetchNotices().toResult()
-        return response.map { notices -> notices.map { it.toDomain() } }
+        return response.map { noticeListResponse ->
+            val pinned = noticeListResponse.pinned.map { it.toDomain() }
+            val unpinned = noticeListResponse.unpinned.map { it.toDomain() }
+            pinned + unpinned
+        }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/service/NoticeService.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/NoticeService.kt
@@ -1,10 +1,10 @@
 package com.daedan.festabook.data.service
 
-import com.daedan.festabook.data.model.response.NoticeResponse
+import com.daedan.festabook.data.model.response.NoticeListResponse
 import retrofit2.Response
 import retrofit2.http.GET
 
 interface NoticeService {
     @GET("announcements")
-    suspend fun getNotices(): Response<List<NoticeResponse>>
+    suspend fun getNotices(): Response<NoticeListResponse>
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/PermissionUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/PermissionUtil.kt
@@ -2,17 +2,7 @@ package com.daedan.festabook.presentation.common
 
 import android.Manifest
 import android.content.Context
-import android.widget.Toast
 import com.daedan.festabook.R
-
-fun Context.showToast(text: String) {
-    Toast
-        .makeText(
-            this,
-            text,
-            Toast.LENGTH_SHORT,
-        ).show()
-}
 
 fun Int.isGranted(): Boolean = this == 0
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/Toast.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/Toast.kt
@@ -1,0 +1,8 @@
+package com.daedan.festabook.presentation.common
+
+import android.content.Context
+import android.widget.Toast
+
+fun Context.showToast(msg: String) {
+    Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentHomeBinding
 import com.daedan.festabook.domain.repository.BookmarkRepository
 import com.daedan.festabook.presentation.common.BaseFragment
+import com.daedan.festabook.presentation.common.showToast
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -47,8 +48,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                         bookmarkedID = bookmarkId
                         prefsManager.saveBookmarkId(bookmarkId)
                         Timber.d("✅ 북마크 등록 성공: $bookmarkId")
+                        requireContext().showToast("북마크 등록 성공")
                     }.onFailure {
                         Timber.e("❌ 북마크 등록 실패: ${it.message}")
+                        requireContext().showToast("북마크 등록 실패")
                     }
             }
         }
@@ -65,8 +68,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                         bookmarkedID = null
                         prefsManager.clearBookmarkId()
                         Timber.d("✅ 북마크 삭제 성공")
+                        requireContext().showToast("북마크 삭제 성공")
                     }.onFailure {
                         Timber.e("❌ 북마크 삭제 실패: ${it.message}")
+                        requireContext().showToast("북마크 삭제 실패")
                     }
             }
         }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -8,14 +8,13 @@ import com.daedan.festabook.databinding.FragmentNewsBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.news.notice.NoticeViewModel
 import com.daedan.festabook.presentation.news.notice.adapter.NoticeAdapter
-import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
 class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
     private val viewModel: NoticeViewModel by viewModels { NoticeViewModel.Factory }
 
     private val noticeAdapter: NoticeAdapter by lazy {
-        NoticeAdapter { noticeId ->
-            viewModel.toggleNoticeExpanded(noticeId)
+        NoticeAdapter { notice ->
+            viewModel.toggleNoticeExpanded(notice)
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeViewModel.kt
@@ -17,6 +17,9 @@ import kotlinx.coroutines.launch
 class NoticeViewModel(
     private val noticeRepository: NoticeRepository,
 ) : ViewModel() {
+    private val _notices = MutableLiveData<List<NoticeUiModel>>()
+    val notices: LiveData<List<NoticeUiModel>> = _notices
+
     private val _noticeUiState: MutableLiveData<NoticeUiState> = MutableLiveData<NoticeUiState>()
     val noticeUiState: LiveData<NoticeUiState> = _noticeUiState
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeViewModel.kt
@@ -13,13 +13,11 @@ import com.daedan.festabook.domain.repository.NoticeRepository
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 import com.daedan.festabook.presentation.news.notice.model.toUiModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class NoticeViewModel(
     private val noticeRepository: NoticeRepository,
 ) : ViewModel() {
-    private val _notices = MutableLiveData<List<NoticeUiModel>>()
-    val notices: LiveData<List<NoticeUiModel>> = _notices
-
     private val _noticeUiState: MutableLiveData<NoticeUiState> = MutableLiveData<NoticeUiState>()
     val noticeUiState: LiveData<NoticeUiState> = _noticeUiState
 
@@ -32,6 +30,7 @@ class NoticeViewModel(
             _noticeUiState.value = NoticeUiState.Loading
 
             val result = noticeRepository.fetchNotices()
+            Timber.d("result: $result")
             result
                 .onSuccess { notices ->
                     _noticeUiState.value = NoticeUiState.Success(notices.map { it.toUiModel() })
@@ -42,16 +41,15 @@ class NoticeViewModel(
     }
 
     fun toggleNoticeExpanded(notice: NoticeUiModel) {
-        val currentList = _notices.value ?: return
-        val updatedList =
-            currentList.map { updatedNotice ->
+        updateNoticeUiState { notices ->
+            notices.map { updatedNotice ->
                 if (notice.id == updatedNotice.id) {
                     updatedNotice.copy(isExpanded = !updatedNotice.isExpanded)
                 } else {
                     updatedNotice
                 }
             }
-        _notices.value = updatedList
+        }
     }
 
     private fun updateNoticeUiState(onUpdate: (List<NoticeUiModel>) -> List<NoticeUiModel>) {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeViewModel.kt
@@ -32,14 +32,14 @@ class NoticeViewModel(
         }
     }
 
-    fun toggleNoticeExpanded(noticeId: Long) {
+    fun toggleNoticeExpanded(notice: NoticeUiModel) {
         val currentList = _notices.value ?: return
         val updatedList =
-            currentList.map { notice ->
-                if (notice.id == noticeId) {
-                    notice.copy(isExpanded = !notice.isExpanded)
+            currentList.map { updatedNotice ->
+                if (notice.id == updatedNotice.id) {
+                    updatedNotice.copy(isExpanded = !updatedNotice.isExpanded)
                 } else {
-                    notice
+                    updatedNotice
                 }
             }
         _notices.value = updatedList

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ItemNoticeBinding
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
@@ -17,6 +18,14 @@ class NoticeViewHolder(
 
     fun bind(notice: NoticeUiModel) {
         binding.notice = notice
+
+        if (notice.isPinned) {
+            binding.ivNoticeIcon.setImageResource(R.drawable.ic_pin)
+            binding.layoutNoticeItem.setBackgroundResource(R.drawable.bg_gray100_stroke_gray400_radius_10dp)
+        } else {
+            binding.ivNoticeIcon.setImageResource(R.drawable.ic_speaker)
+            binding.layoutNoticeItem.setBackgroundResource(R.drawable.bg_stroke_gray400_radius_10dp)
+        }
 
         binding.tvNoticeDescription.maxLines =
             if (notice.isExpanded) Integer.MAX_VALUE else DEFAULT_LINE_COUNT

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNoticeClickListener.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNoticeClickListener.kt
@@ -1,5 +1,7 @@
 package com.daedan.festabook.presentation.news.notice.adapter
 
+import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
+
 fun interface OnNoticeClickListener {
-    fun onNoticeClick(noticeId: Long)
+    fun onNoticeClick(notice: NoticeUiModel)
 }

--- a/android/app/src/main/res/drawable/bg_gray100_stroke_gray400_radius_10dp.xml
+++ b/android/app/src/main/res/drawable/bg_gray100_stroke_gray400_radius_10dp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <solid android:color="@color/gray100" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray400" />
+</shape>

--- a/android/app/src/main/res/layout/item_notice.xml
+++ b/android/app/src/main/res/layout/item_notice.xml
@@ -30,21 +30,23 @@
             android:layout_marginStart="16dp"
             android:contentDescription="@string/iv_speaker"
             android:src="@drawable/ic_speaker"
+            app:layout_constraintBottom_toBottomOf="@id/tv_notice_title"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="@id/tv_notice_title" />
 
         <TextView
             android:id="@+id/tv_notice_title"
             style="@style/PretendardMedium14"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
+            android:layout_marginEnd="4dp"
             android:text="@{notice.title}"
             android:textColor="@color/gray900"
-            app:layout_constraintBottom_toBottomOf="@id/iv_speaker"
+            app:layout_constraintEnd_toStartOf="@id/tv_notice_createdAt"
             app:layout_constraintStart_toEndOf="@id/iv_speaker"
-            app:layout_constraintTop_toTopOf="@id/iv_speaker"
-            tools:text="제목입니다." />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="제목은몇자까지될가요?제목은몇자까지될까요?제목은몇자까지될까오하하이제줄바꿈이되어도안겹치지롱" />
 
         <TextView
             android:id="@+id/tv_notice_description"
@@ -58,10 +60,11 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_notice_title"
-            tools:text="설명입니다.설명입니다.설명입니다." />
+            tools:text="설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면???
+설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면??? 설명입니다.설명입니다.설명입니다.설명이 길어진다면? 설명이 길어진다면???  " />
 
         <TextView
-            android:id="@+id/textView"
+            android:id="@+id/tv_notice_createdAt"
             style="@style/PretendardRegular10"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/item_notice.xml
+++ b/android/app/src/main/res/layout/item_notice.xml
@@ -16,15 +16,16 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_notice_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:background="@drawable/bg_stroke_gray400_radius_10dp"
-        android:onClick="@{() -> listener.onNoticeClick(notice.id)}"
+        android:onClick="@{() -> listener.onNoticeClick(notice)}"
         android:paddingVertical="16dp">
 
         <ImageView
-            android:id="@+id/iv_speaker"
+            android:id="@+id/iv_notice_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
@@ -44,7 +45,7 @@
             android:text="@{notice.title}"
             android:textColor="@color/gray900"
             app:layout_constraintEnd_toStartOf="@id/tv_notice_createdAt"
-            app:layout_constraintStart_toEndOf="@id/iv_speaker"
+            app:layout_constraintStart_toEndOf="@id/iv_notice_icon"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="제목은몇자까지될가요?제목은몇자까지될까요?제목은몇자까지될까오하하이제줄바꿈이되어도안겹치지롱" />
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #79 

<br>

## 🛠️ 작업 내용

- 공지의 고정 여부에 따라 뷰가 달라지도록 했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 우선 뷰 바인딩으로 처리했는데, 괜찮은 지 확인해주세요

<br>

## 📸 이미지 첨부 (Optional)
<img width="403" height="906" alt="스크린샷 2025-07-24 오후 3 35 17" src="https://github.com/user-attachments/assets/f9e917e6-7eda-41d7-a45b-0ed88660e56b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 고정(핀)된 공지와 일반 공지를 시각적으로 구분할 수 있도록 스타일이 추가되었습니다.
  * 북마크 등록 및 삭제 성공/실패 시 토스트 메시지로 사용자 피드백이 제공됩니다.

* **버그 수정**
  * 공지 클릭 시 전체 공지 객체가 전달되어 더 정확한 동작이 이루어집니다.
  * FCM 토큰이 없을 경우 자동으로 새 토큰을 요청하여 디바이스 등록이 개선되었습니다.

* **스타일**
  * 고정된 공지에 회색 배경과 테두리, 핀 아이콘이 적용됩니다.
  * 레이아웃 정렬 및 아이콘, 텍스트뷰 ID 등이 개선되어 가독성이 향상되었습니다.

* **기타**
  * 새로운 배경 드로어블 리소스가 추가되었습니다.
  * 토스트 메시지 표시를 위한 공통 함수가 추가 및 기존 함수가 정리되었습니다.
  * 앱 초기화 로직이 간소화되어 디바이스 식별자 관리가 통합되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->