### PR TITLE
[AN] 소식 화면 SwipeRefreshLayout 구현

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -41,8 +41,14 @@ class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
     private fun setupObserver() {
         viewModel.noticeUiState.observe(viewLifecycleOwner) { noticeState ->
             when (noticeState) {
-                is NoticeUiState.Error -> {}
-                NoticeUiState.Loading -> {}
+                is NoticeUiState.Error -> {
+                    binding.srlNoticeList.isRefreshing = false
+                }
+
+                is NoticeUiState.Loading -> {
+                    binding.srlNoticeList.isRefreshing = true
+                }
+
                 is NoticeUiState.Success -> {
                     noticeAdapter.submitList(noticeState.notices)
                     binding.srlNoticeList.isRefreshing = false

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -6,9 +6,9 @@ import androidx.fragment.app.viewModels
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentNewsBinding
 import com.daedan.festabook.presentation.common.BaseFragment
+import com.daedan.festabook.presentation.news.notice.NoticeUiState
 import com.daedan.festabook.presentation.news.notice.NoticeViewModel
 import com.daedan.festabook.presentation.news.notice.adapter.NoticeAdapter
-import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
 class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
     private val viewModel: NoticeViewModel by viewModels { NoticeViewModel.Factory }
@@ -17,11 +17,6 @@ class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
         NoticeAdapter { noticeId ->
             viewModel.toggleNoticeExpanded(noticeId)
         }
-    }
-
-    override fun onStart() {
-        super.onStart()
-        fetchNotices()
     }
 
     override fun onViewCreated(
@@ -34,15 +29,25 @@ class NewsFragment : BaseFragment<FragmentNewsBinding>(R.layout.fragment_news) {
         binding.rvNoticeList.adapter = noticeAdapter
 
         setupObserver()
+        onSwipeRefreshNoticesListener()
     }
 
-    private fun fetchNotices() {
-        viewModel.fetchNotices()
+    private fun onSwipeRefreshNoticesListener() {
+        binding.srlNoticeList.setOnRefreshListener {
+            viewModel.fetchNotices()
+        }
     }
 
     private fun setupObserver() {
-        viewModel.notices.observe(viewLifecycleOwner) { notices ->
-            noticeAdapter.submitList(notices)
+        viewModel.noticeUiState.observe(viewLifecycleOwner) { noticeState ->
+            when (noticeState) {
+                is NoticeUiState.Error -> {}
+                NoticeUiState.Loading -> {}
+                is NoticeUiState.Success -> {
+                    noticeAdapter.submitList(noticeState.notices)
+                    binding.srlNoticeList.isRefreshing = false
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeUiState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeUiState.kt
@@ -1,0 +1,15 @@
+package com.daedan.festabook.presentation.news.notice
+
+import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
+
+sealed interface NoticeUiState {
+    data object Loading : NoticeUiState
+
+    data class Success(
+        val notices: List<NoticeUiModel>,
+    ) : NoticeUiState
+
+    data class Error(
+        val message: String,
+    ) : NoticeUiState
+}

--- a/android/app/src/main/res/layout/fragment_news.xml
+++ b/android/app/src/main/res/layout/fragment_news.xml
@@ -22,15 +22,25 @@
             android:text="@string/news_title"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_notice_list"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srl_notice_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginTop="20dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_news_title"
-            tools:listitem="@layout/item_notice" />
+            app:layout_constraintTop_toBottomOf="@id/tv_news_title">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_notice_list"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="20dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_news_title"
+                tools:listitem="@layout/item_notice" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/205

<br>

## 🛠️ 작업 내용

- `NoticeUiState` 클래스를 추가하여 공지사항 화면의 UI 상태를 관리 (Loading, Success, Error)
- `NoticeViewModel`에서 `NoticeUiState`를 사용하여 UI 상태를 업데이트
- `NewsFragment`에서 `NoticeUiState`를 관찰하여 UI 업데이트
- `SwipeRefreshLayout`을 추가하여 공지사항 목록을 스와이프하여 새로고침하는 기능 추가

<br>

## 🙇🏻 중점 리뷰 요청


<br>


## 📸 이미지 첨부 (Optional)
https://github.com/user-attachments/assets/a9758fb8-31d4-43b6-ab0f-1ea04172397c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 뉴스 목록에 당겨서 새로고침(풀-투-리프레시) 기능이 추가되었습니다.

* **개선 사항**
  * 공지사항 목록이 로딩, 성공, 오류 상태로 더 명확하게 구분되어 표시됩니다.
  * 새로고침 시 로딩 애니메이션이 동작하며, 성공적으로 불러오면 자동으로 애니메이션이 종료됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->