### PR TITLE
[BE] 학생회 공지사항 수정 및 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -3,6 +3,7 @@ package com.daedan.festabook.announcement.controller;
 import com.daedan.festabook.announcement.dto.AnnouncementGroupedResponses;
 import com.daedan.festabook.announcement.dto.AnnouncementRequest;
 import com.daedan.festabook.announcement.dto.AnnouncementResponse;
+import com.daedan.festabook.announcement.dto.AnnouncementUpdateRequest;
 import com.daedan.festabook.announcement.service.AnnouncementService;
 import com.daedan.festabook.global.argumentresolver.OrganizationId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,10 +64,9 @@ public class AnnouncementController {
     })
     public AnnouncementResponse updateAnnouncement(
             @PathVariable Long announcementId,
-            @Parameter(hidden = true) @OrganizationId Long organizationId,
-            @RequestBody AnnouncementRequest request
+            @RequestBody AnnouncementUpdateRequest request
     ) {
-        return announcementService.updateAnnouncement(announcementId, organizationId, request);
+        return announcementService.updateAnnouncement(announcementId, request);
     }
 
     @DeleteMapping("/{announcementId}")

--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -63,9 +63,10 @@ public class AnnouncementController {
     })
     public AnnouncementResponse updateAnnouncement(
             @PathVariable Long announcementId,
+            @Parameter(hidden = true) @OrganizationId Long organizationId,
             @RequestBody AnnouncementRequest request
     ) {
-        return announcementService.updateAnnouncement(announcementId, request);
+        return announcementService.updateAnnouncement(announcementId, organizationId, request);
     }
 
     @DeleteMapping("/{announcementId}")

--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -75,7 +75,7 @@ public class AnnouncementController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })
-    public void deleteAnnouncement(
+    public void deleteAnnouncementByAnnouncementId(
             @PathVariable Long announcementId
     ) {
         announcementService.deleteAnnouncementByAnnouncementId(announcementId);

--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -12,7 +12,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +53,30 @@ public class AnnouncementController {
             @Parameter(hidden = true) @OrganizationId Long organizationId
     ) {
         return announcementService.getGroupedAnnouncementByOrganizationId(organizationId);
+    }
+
+    @PatchMapping("/{announcementId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 공지 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public AnnouncementResponse updateAnnouncement(
+            @PathVariable Long announcementId,
+            @RequestBody AnnouncementRequest request
+    ) {
+        return announcementService.updateAnnouncement(announcementId, request);
+    }
+
+    @DeleteMapping("/{announcementId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 공지 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deleteAnnouncement(
+            @PathVariable Long announcementId
+    ) {
+        announcementService.deleteAnnouncementByAnnouncementId(announcementId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
@@ -73,7 +73,7 @@ public class Announcement {
         return !isPinned;
     }
 
-    public void updateTitleAndContent(String title, String content) {
+    public void update(String title, String content) {
         this.title = title;
         this.content = content;
     }

--- a/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
@@ -73,7 +73,7 @@ public class Announcement {
         return !isPinned;
     }
 
-    public void update(String title, String content) {
+    public void updateTitleAndContent(String title, String content) {
         this.title = title;
         this.content = content;
     }

--- a/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
@@ -72,4 +72,9 @@ public class Announcement {
     public boolean isUnpinned() {
         return !isPinned;
     }
+
+    public void updateTitleAndContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/announcement/dto/AnnouncementUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/dto/AnnouncementUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.daedan.festabook.announcement.dto;
+
+public record AnnouncementUpdateRequest(
+        String title,
+        String content
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AnnouncementJpaRepository extends JpaRepository<Announcement, Long> {
 
     List<Announcement> findAllByOrganizationId(Long organizationId);
+
+    Long countByOrganizationIdAndIsPinnedTrue(Long organizationId);
 }

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -53,6 +53,24 @@ public class AnnouncementService {
         );
     }
 
+    @Transactional
+    public AnnouncementResponse updateAnnouncement(Long announcementId, AnnouncementRequest request) {
+        Announcement announcement = getAnnouncementById(announcementId);
+        announcement.updateTitleAndContent(request.title(), request.content());
+        return AnnouncementResponse.from(announcement);
+    }
+
+    @Transactional
+    public void deleteAnnouncementByAnnouncementId(Long announcementId) {
+        announcementJpaRepository.deleteById(announcementId);
+    }
+
+    private Announcement getAnnouncementById(Long announcementId) {
+        // TODO : 커스텀 예외 설정
+        return announcementJpaRepository.findById(announcementId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 공지입니다.", HttpStatus.BAD_REQUEST));
+    }
+
     private Organization getOrganizationById(Long organizationId) {
         // TODO: 커스텀 예외 설정
         return organizationJpaRepository.findById(organizationId)

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -61,7 +61,7 @@ public class AnnouncementService {
     @Transactional
     public AnnouncementResponse updateAnnouncement(Long announcementId, AnnouncementUpdateRequest request) {
         Announcement announcement = getAnnouncementById(announcementId);
-        announcement.update(request.title(), request.content());
+        announcement.updateTitleAndContent(request.title(), request.content());
         return AnnouncementResponse.from(announcement);
     }
 

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -4,6 +4,7 @@ import com.daedan.festabook.announcement.domain.Announcement;
 import com.daedan.festabook.announcement.dto.AnnouncementGroupedResponses;
 import com.daedan.festabook.announcement.dto.AnnouncementRequest;
 import com.daedan.festabook.announcement.dto.AnnouncementResponse;
+import com.daedan.festabook.announcement.dto.AnnouncementUpdateRequest;
 import com.daedan.festabook.announcement.infrastructure.AnnouncementJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.notification.dto.NotificationMessage;
@@ -58,14 +59,9 @@ public class AnnouncementService {
     }
 
     @Transactional
-    public AnnouncementResponse updateAnnouncement(Long announcementId, Long organizationId,
-                                                   AnnouncementRequest request) {
+    public AnnouncementResponse updateAnnouncement(Long announcementId, AnnouncementUpdateRequest request) {
         Announcement announcement = getAnnouncementById(announcementId);
-        if (announcement.isUnpinned() && !request.isPinned()) {
-            validatePinnedLimit(organizationId);
-        }
-
-        announcement.updateTitleAndContent(request.title(), request.content());
+        announcement.update(request.title(), request.content());
         return AnnouncementResponse.from(announcement);
     }
 

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -73,13 +73,11 @@ public class AnnouncementService {
     }
 
     private Announcement getAnnouncementById(Long announcementId) {
-        // TODO : 커스텀 예외 설정
         return announcementJpaRepository.findById(announcementId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 공지입니다.", HttpStatus.BAD_REQUEST));
     }
 
     private Organization getOrganizationById(Long organizationId) {
-        // TODO: 커스텀 예외 설정
         return organizationJpaRepository.findById(organizationId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 조직입니다.", HttpStatus.BAD_REQUEST));
     }

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -23,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AnnouncementService {
 
+    private static final int MAX_PINNED_ANNOUNCEMENTS = 3;
+
     private final AnnouncementJpaRepository announcementJpaRepository;
     private final OrganizationJpaRepository organizationJpaRepository;
     private final OrganizationNotificationManager notificationManager;
@@ -94,8 +96,11 @@ public class AnnouncementService {
 
     private void validatePinnedLimit(Long organizationId) {
         Long pinnedCount = announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(organizationId);
-        if (pinnedCount >= 3) {
-            throw new BusinessException("공지글은 최대 3개까지 고정할 수 있습니다.", HttpStatus.BAD_REQUEST);
+        if (pinnedCount >= MAX_PINNED_ANNOUNCEMENTS) {
+            throw new BusinessException(
+                    String.format("공지글은 최대 %d개까지 고정할 수 있습니다.", MAX_PINNED_ANNOUNCEMENTS),
+                    HttpStatus.BAD_REQUEST
+            );
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -1,6 +1,5 @@
 package com.daedan.festabook.announcement.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -323,8 +322,6 @@ class AnnouncementControllerTest {
                     .delete("/announcements/{announcementId}", announcement.getId())
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
-
-            assertThat(announcementJpaRepository.findById(announcement.getId())).isEmpty();
         }
 
         @Test

--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -102,10 +102,10 @@ class AnnouncementControllerTest {
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);
 
-            // 고정 공지 3개 생성
-            announcementJpaRepository.saveAll(AnnouncementFixture.createList(3, true, organization));
+            boolean isPinned = true;
+            announcementJpaRepository.saveAll(AnnouncementFixture.createList(3, isPinned, organization));
 
-            AnnouncementRequest request = AnnouncementRequestFixture.create(true);
+            AnnouncementRequest request = AnnouncementRequestFixture.create(isPinned);
 
             // when & then
             RestAssured
@@ -289,7 +289,7 @@ class AnnouncementControllerTest {
         void 실패_존재하지_않는_공지() {
             // given
             Long notExistId = 0L;
-            AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.create("수정된 제목", "수정된 내용");
+            AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.create();
 
             // when & then
             RestAssured
@@ -299,7 +299,8 @@ class AnnouncementControllerTest {
                     .when()
                     .patch("/announcements/{announcementId}", notExistId)
                     .then()
-                    .statusCode(HttpStatus.BAD_REQUEST.value());
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("존재하지 않는 공지입니다."));
         }
     }
 
@@ -327,7 +328,7 @@ class AnnouncementControllerTest {
         }
 
         @Test
-        void 실패_존재하지_않는_공지() {
+        void 성공_존재하지_않는_공지지만_예외_없음() {
             // given
             Long notExistId = 0L;
 

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementRequestFixture.java
@@ -17,6 +17,16 @@ public class AnnouncementRequestFixture {
     }
 
     public static AnnouncementRequest create(
+            boolean isPinned
+    ) {
+        return new AnnouncementRequest(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                isPinned
+        );
+    }
+
+    public static AnnouncementRequest create(
             String title,
             String content,
             boolean isPinned

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementUpdateRequestFixture.java
@@ -1,0 +1,23 @@
+package com.daedan.festabook.announcement.domain;
+
+import com.daedan.festabook.announcement.dto.AnnouncementUpdateRequest;
+
+public class AnnouncementUpdateRequestFixture {
+
+    private static final String DEFAULT_TITLE = "폭우가 내립니다.";
+    private static final String DEFAULT_CONTENT = "우산을 챙겨주세요.";
+
+    public static AnnouncementUpdateRequest create() {
+        return new AnnouncementUpdateRequest(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT
+        );
+    }
+
+    public static AnnouncementUpdateRequest create(String title, String content) {
+        return new AnnouncementUpdateRequest(
+                title,
+                content
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepositoryTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepositoryTest.java
@@ -1,12 +1,13 @@
 package com.daedan.festabook.announcement.infrastructure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.daedan.festabook.announcement.domain.Announcement;
 import com.daedan.festabook.announcement.domain.AnnouncementFixture;
 import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +26,7 @@ class AnnouncementJpaRepositoryTest {
     class countByOrganizationIdAndPinned {
 
         @Test
-        void 특정_조직의_고정_공지사항_개수_반환() {
+        void 성공_특정_조직의_고정_공지사항_개수_반환() {
             // given
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);
@@ -42,7 +43,20 @@ class AnnouncementJpaRepositoryTest {
             Long result = announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(organization.getId());
 
             // then
-            Assertions.assertThat(result).isEqualTo(expectedPinned);
+            assertThat(result).isEqualTo(expectedPinned);
+        }
+
+        @Test
+        void 성공_특정_조직의_고정_공지사항이_없는_경우() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            organizationJpaRepository.save(organization);
+
+            // when
+            Long result = announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(organization.getId());
+
+            // then
+            assertThat(result).isEqualTo(0L);
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepositoryTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.daedan.festabook.announcement.infrastructure;
+
+import com.daedan.festabook.announcement.domain.Announcement;
+import com.daedan.festabook.announcement.domain.AnnouncementFixture;
+import com.daedan.festabook.organization.domain.Organization;
+import com.daedan.festabook.organization.domain.OrganizationFixture;
+import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class AnnouncementJpaRepositoryTest {
+
+    @Autowired
+    private OrganizationJpaRepository organizationJpaRepository;
+
+    @Autowired
+    private AnnouncementJpaRepository announcementJpaRepository;
+
+    @Nested
+    class countByOrganizationIdAndPinned {
+
+        @Test
+        void 특정_조직의_고정_공지사항_개수_반환() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            organizationJpaRepository.save(organization);
+
+            Long expectedPinned = 3L;
+            List<Announcement> pinnedAnnouncements = AnnouncementFixture.createList(expectedPinned.intValue(), true,
+                    organization);
+            List<Announcement> notPinnedAnnouncements = AnnouncementFixture.createList(2, false, organization);
+
+            announcementJpaRepository.saveAll(pinnedAnnouncements);
+            announcementJpaRepository.saveAll(notPinnedAnnouncements);
+
+            // when
+            Long result = announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(organization.getId());
+
+            // then
+            Assertions.assertThat(result).isEqualTo(expectedPinned);
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepositoryTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/infrastructure/AnnouncementJpaRepositoryTest.java
@@ -8,12 +8,15 @@ import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
 import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class AnnouncementJpaRepositoryTest {
 
     @Autowired
@@ -31,10 +34,13 @@ class AnnouncementJpaRepositoryTest {
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);
 
-            Long expectedPinned = 3L;
-            List<Announcement> pinnedAnnouncements = AnnouncementFixture.createList(expectedPinned.intValue(), true,
+            int pinnedSize = 3;
+            int unpinnedSize = 2;
+            Long expectedPinnedCount = 3L;
+
+            List<Announcement> pinnedAnnouncements = AnnouncementFixture.createList(pinnedSize, true, organization);
+            List<Announcement> notPinnedAnnouncements = AnnouncementFixture.createList(unpinnedSize, false,
                     organization);
-            List<Announcement> notPinnedAnnouncements = AnnouncementFixture.createList(2, false, organization);
 
             announcementJpaRepository.saveAll(pinnedAnnouncements);
             announcementJpaRepository.saveAll(notPinnedAnnouncements);
@@ -43,7 +49,7 @@ class AnnouncementJpaRepositoryTest {
             Long result = announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(organization.getId());
 
             // then
-            assertThat(result).isEqualTo(expectedPinned);
+            assertThat(result).isEqualTo(expectedPinnedCount);
         }
 
         @Test
@@ -56,7 +62,7 @@ class AnnouncementJpaRepositoryTest {
             Long result = announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(organization.getId());
 
             // then
-            assertThat(result).isEqualTo(0L);
+            assertThat(result).isZero();
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -251,16 +251,16 @@ class AnnouncementServiceTest {
         }
 
         @Test
-        void 예외_존재하지_않는_조직_ID() {
+        void 예외_존재하지_않는_공지사항_ID() {
             // given
-            Long invalidDeviceId = 0L;
+            Long invalidAnnouncementId = 0L;
             AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.create();
 
-            given(announcementJpaRepository.findById(invalidDeviceId))
+            given(announcementJpaRepository.findById(invalidAnnouncementId))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> announcementService.updateAnnouncement(invalidDeviceId, request))
+            assertThatThrownBy(() -> announcementService.updateAnnouncement(invalidAnnouncementId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 공지입니다.");
         }

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -124,10 +124,31 @@ class AnnouncementServiceTest {
         }
 
         @ParameterizedTest(name = "고정 공지 개수: {0}")
+        @ValueSource(longs = {0L, 1L, 2L})
+        void 성공_고정_공지_개수_제한_미만(Long pinnedCount) {
+            // given
+            AnnouncementRequest request = AnnouncementRequestFixture.create(true);
+            Organization organization = OrganizationFixture.create(DEFAULT_ORGANIZATION_ID);
+
+            given(announcementJpaRepository.countByOrganizationIdAndIsPinnedTrue(DEFAULT_ORGANIZATION_ID))
+                    .willReturn(pinnedCount);
+            given(organizationJpaRepository.findById(DEFAULT_ORGANIZATION_ID))
+                    .willReturn(Optional.of(organization));
+
+            // when
+            announcementService.createAnnouncement(DEFAULT_ORGANIZATION_ID, request);
+
+            // then
+            then(announcementJpaRepository).should().save(any(Announcement.class));
+            then(organizationNotificationManager).should()
+                    .sendToOrganizationTopic(any(), any());
+        }
+
+        @ParameterizedTest(name = "고정 공지 개수: {0}")
         @ValueSource(longs = {
                 3L, 4L, 10L
         })
-        void 예외_고정_공지_개수_초과(Long maxPinnedCount) {
+        void 예외_고정_공지_개수_제한_초과(Long maxPinnedCount) {
             // given
             AnnouncementRequest request = AnnouncementRequestFixture.create(true);
 

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -139,7 +139,9 @@ class AnnouncementServiceTest {
             announcementService.createAnnouncement(DEFAULT_ORGANIZATION_ID, request);
 
             // then
-            then(announcementJpaRepository).should().save(any(Announcement.class));
+            then(announcementJpaRepository).should()
+                    .save(any(Announcement.class));
+
             then(organizationNotificationManager).should()
                     .sendToOrganizationTopic(any(), any());
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #188 #200 

<br>

## 🛠️ 작업 내용

- 공지사항 수정 API 추가했습니다.
- 공지사항 삭제 API 추가했습니다.
- 공지사항 고정 3개 이상 생성 시 예외처리 추가했습니다.

<br>

## 📸 이미지 첨부

<img width="223" height="504" alt="스크린샷 2025-07-25 오전 12 19 54" src="https://github.com/user-attachments/assets/70edc6d4-54c2-4a66-a023-ddac44dd74ec" />

위 사진 처럼 공지 수정에는 핀 수정을 두지 않았습니다. 이후 핀 등록 API 추가 생성할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 공지사항 개별 수정 및 삭제 기능이 추가되었습니다.
  * 공지사항 고정 개수(최대 3개) 제한이 적용되었습니다.

* **버그 수정**
  * 고정 공지사항 개수 초과 시 오류 메시지가 반환됩니다.

* **테스트**
  * 공지사항 생성, 수정, 삭제 및 고정 개수 제한에 대한 테스트가 추가되었습니다.
  * 관련 테스트 픽스처 및 리포지터리 테스트가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->