### PR TITLE
[FE] 공지사항 조회/추가/수정/삭제 API 연결

### DIFF
--- a/frontend/src/components/modals/NoticeModal.jsx
+++ b/frontend/src/components/modals/NoticeModal.jsx
@@ -1,66 +1,137 @@
-import React, { useState, useEffect } from 'react';
-import Modal from '../common/Modal';
+import React, { useState, useEffect } from "react";
+import Modal from "../common/Modal";
 
 const NoticeModal = ({ notice, onSave, onClose }) => {
-    const [title, setTitle] = useState('');
-    const [content, setContent] = useState('');
-    const [agreePush, setAgreePush] = useState(false);
-    useEffect(() => { setTitle(notice?.title || ''); setContent(notice?.content || ''); }, [notice]);
-    const handleSave = () => { onSave({ title, content }); onClose(); };
-    return (
-        <Modal isOpen={true} onClose={onClose}>
-            <h3 className="text-xl font-bold mb-6">{notice ? '공지사항 수정' : '새 공지사항'}</h3>
-            <div className="space-y-4">
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">제목</label>
-                    <input type="text" value={title} onChange={e => setTitle(e.target.value)} placeholder="[20자 이내로 작성해주세요]" className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">내용</label>
-                    <textarea value={content} onChange={e => setContent(e.target.value)} rows="6" placeholder="공지 내용을 입력해주세요." className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                </div>
-                {!notice && (
-                  <div className="flex items-center mt-2">
-                    <input id="push-agree" type="checkbox" checked={agreePush} onChange={e => setAgreePush(e.target.checked)} className="mr-2" />
-                    <label htmlFor="push-agree" className="text-sm text-gray-700 select-none">정말로 푸시 알림을 사용자에게 전송하시겠습니까?</label>
-                  </div>
-                )}
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [agreePush, setAgreePush] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
+  useEffect(() => {
+    setTitle(notice?.title || "");
+    setContent(notice?.content || "");
+  }, [notice]);
+  const handleSave = () => {
+    onSave({ title, content, isPinned });
+    onClose();
+  };
+  return (
+    <Modal isOpen={true} onClose={onClose}>
+      <h3 className="text-xl font-bold mb-6">
+        {notice ? "공지사항 수정" : "새 공지사항"}
+      </h3>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            제목
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="[20자 이내로 작성해주세요]"
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            내용
+          </label>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows="6"
+            placeholder="공지 내용을 입력해주세요."
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+        {!notice && (
+          <div className="flex flex-col gap-2 mt-2">
+            <div className="flex items-center">
+              <input
+                id="pin-notice"
+                type="checkbox"
+                checked={isPinned}
+                onChange={(e) => setIsPinned(e.target.checked)}
+                className="mr-2"
+              />
+              <label
+                htmlFor="pin-notice"
+                className="text-sm text-gray-700 select-none"
+              >
+                상단 고정
+              </label>
             </div>
-            {!notice && (
-              <p className="text-xs text-gray-500 mt-4">
-                  <i className="fas fa-info-circle mr-1"></i>
-                  새롭게 작성된 공지는 사용자에게 푸시 알림으로 전송됩니다.
-              </p>
-            )}
-            <div className="mt-6 flex justify-between w-full">
-                <div className="space-x-3">
-                    <button onClick={onClose} className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg">취소</button>
-                    <button
-                        onClick={handleSave}
-                        className={`font-bold py-2 px-4 rounded-lg transition-colors duration-200 ${(!notice && !agreePush) ? 'bg-gray-300 text-gray-400 cursor-not-allowed' : 'bg-gray-800 hover:bg-gray-900 text-white'}`}
-                        disabled={!notice && !agreePush}
-                    >저장</button>
-                </div>
+            <div className="flex items-center">
+              <input
+                id="push-agree"
+                type="checkbox"
+                checked={agreePush}
+                onChange={(e) => setAgreePush(e.target.checked)}
+                className="mr-2"
+              />
+              <label
+                htmlFor="push-agree"
+                className="text-sm text-gray-700 select-none"
+              >
+                푸시 알림을 사용자에게 전송하시겠습니까?
+              </label>
             </div>
-        </Modal>
-    );
+          </div>
+        )}
+      </div>
+      {!notice && (
+        <p className="text-xs text-gray-500 mt-4">
+          <i className="fas fa-info-circle mr-1"></i>
+          새롭게 작성된 공지는 사용자에게 푸시 알림으로 전송됩니다.
+        </p>
+      )}
+      <div className="mt-6 flex justify-between w-full">
+        <div className="space-x-3">
+          <button
+            onClick={onClose}
+            className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSave}
+            className={`font-bold py-2 px-4 rounded-lg transition-colors duration-200 ${
+              !notice && !agreePush
+                ? "bg-gray-300 text-gray-400 cursor-not-allowed"
+                : "bg-gray-800 hover:bg-gray-900 text-white"
+            }`}
+            disabled={!notice && !agreePush}
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
 };
 
 // 공지사항 상세보기 모달
 export const NoticeDetailModal = ({ notice, onClose }) => (
-    <Modal isOpen={true} onClose={onClose}>
-        <h3 className="text-xl font-bold mb-6">공지사항 상세</h3>
-        <div className="space-y-4">
-            <div>
-                <div className="text-lg font-semibold mb-2">{notice.title}</div>
-                <div className="text-gray-500 text-sm mb-4">{notice.date}</div>
-                <div className="whitespace-pre-line text-gray-800">{notice.content}</div>
-            </div>
+  <Modal isOpen={true} onClose={onClose}>
+    <h3 className="text-xl font-bold mb-6">공지사항 상세</h3>
+    <div className="space-y-4">
+      <div>
+        <div className="text-lg font-semibold mb-2">{notice.title}</div>
+        <div className="text-gray-500 text-sm mb-4">{notice.date}</div>
+        <div className="whitespace-pre-line text-gray-800">
+          {notice.content}
         </div>
-        <div className="mt-6 flex justify-end w-full">
-            <button onClick={onClose} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg">닫기</button>
-        </div>
-    </Modal>
+      </div>
+    </div>
+    <div className="mt-6 flex justify-end w-full">
+      <button
+        onClick={onClose}
+        className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg"
+      >
+        닫기
+      </button>
+    </div>
+  </Modal>
 );
 
 export default NoticeModal;

--- a/frontend/src/pages/NoticesPage.jsx
+++ b/frontend/src/pages/NoticesPage.jsx
@@ -1,21 +1,75 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useData } from '../hooks/useData';
 import { useModal } from '../hooks/useModal';
+import api from '../utils/api';
+
+function formatDate(dateString) {
+    if (!dateString) return '';
+    const d = new Date(dateString);
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const hh = String(d.getHours()).padStart(2, '0');
+    const min = String(d.getMinutes()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
+}
 
 const NoticesPage = () => {
-    const { notices, togglePinNotice, addNotice, updateNotice, deleteNotice } = useData();
+    const { togglePinNotice } = useData();
     const { openModal, showToast } = useModal();
-    const sortedNotices = [...notices].sort((a, b) => b.pinned - a.pinned || new Date(b.date) - new Date(a.date));
+    const [pinned, setPinned] = useState([]);
+    const [unpinned, setUnpinned] = useState([]);
 
-    const handleSave = (id, data) => {
+    useEffect(() => {
+        api.get('/announcements').then(res => {
+            setPinned(res.data.pinned || []);
+            setUnpinned(res.data.unpinned || []);
+        });
+    }, []);
+
+    const handleSave = async (id, data) => {
         if (!data.title || !data.content) { showToast('제목과 내용을 모두 입력해주세요.'); return; }
-        if (id) { updateNotice(id, data); showToast('공지사항이 수정되었습니다.'); } 
-        else { addNotice(data); showToast('새 공지사항이 등록되었습니다.'); }
+        if (id) {
+            try {
+                await api.patch(`/announcements/${id}`, data);
+                // 공지 수정 후 목록 재로딩
+                const res = await api.get('/announcements');
+                setPinned(res.data.pinned || []);
+                setUnpinned(res.data.unpinned || []);
+                showToast('공지사항이 수정되었습니다.');
+            } catch {
+                showToast('공지사항 수정에 실패했습니다.');
+            }
+        } else {
+            try {
+                await api.post('/announcements', data);
+                // 공지 추가 후 목록 재로딩
+                const res = await api.get('/announcements');
+                setPinned(res.data.pinned || []);
+                setUnpinned(res.data.unpinned || []);
+                showToast('새 공지사항이 등록되었습니다.');
+            } catch {
+                showToast('공지사항 등록에 실패했습니다.');
+            }
+        }
+    };
+
+    const handleDelete = async (id) => {
+        try {
+            await api.delete(`/announcements/${id}`);
+            // 공지 삭제 후 목록 재로딩
+            const res = await api.get('/announcements');
+            setPinned(res.data.pinned || []);
+            setUnpinned(res.data.unpinned || []);
+            showToast('공지사항이 삭제되었습니다.');
+        } catch {
+            showToast('공지사항 삭제에 실패했습니다.');
+        }
     };
     
     return (
         <div>
-            <div className="flex justify-between items-center mb-6"><h2 className="text-3xl font-bold">공지사항 관리</h2><button onClick={() => openModal('notice', { onSave: (data) => handleSave(null, data) })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center"><i className="fas fa-plus mr-2"></i> 새 공지사항</button></div>
+            <div className="flex justify-between items-center mb-6"><h2 className="text-3xl font-bold">공지사항</h2><button onClick={() => openModal('notice', { onSave: (data) => handleSave(null, data) })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center"><i className="fas fa-plus mr-2"></i> 새 공지사항</button></div>
             <p className="text-sm text-gray-500 mb-2">※ 고정은 최대 3개만 가능합니다.</p>
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-x-auto">
                 <table className="min-w-full w-full">
@@ -29,22 +83,25 @@ const NoticesPage = () => {
                         </tr>
                     </thead>
                     <tbody>
-                        {sortedNotices.map(notice => (
+                        {/* 고정 공지 */}
+                        {pinned.map(notice => (
                             <React.Fragment key={notice.id}>
                                 <tr className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50">
                                     <td className="p-4 text-center align-top">
                                         <button onClick={() => {
-                                            const pinnedCount = sortedNotices.filter(n => n.pinned).length;
-                                            if (!notice.pinned && pinnedCount >= 3) {
+                                            const pinnedCount = pinned.length;
+                                            if (!notice.isPinned && pinnedCount >= 3) {
                                                 showToast('고정은 최대 3개까지만 가능합니다.');
                                                 return;
                                             }
                                             togglePinNotice(notice.id, showToast);
-                                        }} title="고정 토글"><i className={`fas fa-thumbtack pin-icon ${notice.pinned ? 'pinned' : ''}`}></i></button>
+                                        }} title="고정 토글">
+                                            <i className={`fas fa-thumbtack pin-icon ${notice.isPinned ? 'pinned' : ''}`}></i>
+                                        </button>
                                     </td>
                                     <td className="p-4 align-top max-w-xs truncate" title={notice.title}>{notice.title}</td>
                                     <td className="p-4 align-top text-gray-800 max-w-xs truncate" style={{maxWidth: '320px'}} title={notice.content}>{notice.content}</td>
-                                    <td className="p-4 text-gray-600 align-top">{notice.date}</td>
+                                    <td className="p-4 text-gray-600 align-top">{formatDate(notice.createdAt)}</td>
                                     <td className="p-4 align-top min-w-[120px]">
                                         <div className="flex flex-row items-center space-x-6 flex-wrap">
                                             <button onClick={() => openModal('notice', { notice, onSave: (data) => handleSave(notice.id, data) })} className="text-blue-600 hover:text-blue-800 font-bold">수정</button>
@@ -53,8 +110,43 @@ const NoticesPage = () => {
                                                     title: '공지사항 삭제 확인',
                                                     message: `'${notice.title}' 공지사항을 정말 삭제하시겠습니까?`,
                                                     onConfirm: () => {
-                                                        deleteNotice(notice.id);
-                                                        showToast('공지사항이 삭제되었습니다.');
+                                                        handleDelete(notice.id);
+                                                    }
+                                                });
+                                            }} className="text-red-600 hover:text-red-800 font-bold">삭제</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </React.Fragment>
+                        ))}
+                        {/* 일반 공지 */}
+                        {unpinned.map(notice => (
+                            <React.Fragment key={notice.id}>
+                                <tr className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50">
+                                    <td className="p-4 text-center align-top">
+                                        <button onClick={() => {
+                                            const pinnedCount = pinned.length;
+                                            if (!notice.isPinned && pinnedCount >= 3) {
+                                                showToast('고정은 최대 3개까지만 가능합니다.');
+                                                return;
+                                            }
+                                            togglePinNotice(notice.id, showToast);
+                                        }} title="고정 토글">
+                                            <i className={`fas fa-thumbtack pin-icon ${notice.isPinned ? 'pinned' : ''}`}></i>
+                                        </button>
+                                    </td>
+                                    <td className="p-4 align-top max-w-xs truncate" title={notice.title}>{notice.title}</td>
+                                    <td className="p-4 align-top text-gray-800 max-w-xs truncate" style={{maxWidth: '320px'}} title={notice.content}>{notice.content}</td>
+                                    <td className="p-4 text-gray-600 align-top">{formatDate(notice.createdAt)}</td>
+                                    <td className="p-4 align-top min-w-[120px]">
+                                        <div className="flex flex-row items-center space-x-6 flex-wrap">
+                                            <button onClick={() => openModal('notice', { notice, onSave: (data) => handleSave(notice.id, data) })} className="text-blue-600 hover:text-blue-800 font-bold">수정</button>
+                                            <button onClick={() => {
+                                                openModal('confirm', {
+                                                    title: '공지사항 삭제 확인',
+                                                    message: `'${notice.title}' 공지사항을 정말 삭제하시겠습니까?`,
+                                                    onConfirm: () => {
+                                                        handleDelete(notice.id);
                                                     }
                                                 });
                                             }} className="text-red-600 hover:text-red-800 font-bold">삭제</button>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #188 #215 

<br>

## 🛠️ 작업 내용

- 학생회 페이지 공지사항 조회/추가/수정/삭제 API 연결했습니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1594" height="763" alt="스크린샷 2025-07-25 오전 2 05 20" src="https://github.com/user-attachments/assets/458777c5-bfbb-47dc-b13a-f3f5f18ec98e" />

---

<img width="576" height="593" alt="스크린샷 2025-07-25 오전 2 05 30" src="https://github.com/user-attachments/assets/6b967989-d111-4d1b-a669-efecc1584423" />

---

<img width="570" height="481" alt="스크린샷 2025-07-25 오전 2 05 38" src="https://github.com/user-attachments/assets/3ecb48a3-f96b-44f0-9854-d4ed82840c7c" />

---

<img width="432" height="207" alt="스크린샷 2025-07-25 오전 2 05 44" src="https://github.com/user-attachments/assets/9a85eea5-d8bc-449a-b92d-a3af929f2a99" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 공지사항 작성 시 "상단 고정"(핀) 옵션 추가 및 최대 3개까지 상단 고정 가능.
  * 공지사항 목록에서 상단 고정/해제 버튼 제공 및 고정/비고정 공지사항을 분리하여 표시.

* **버그 수정**
  * 푸시 알림 동의 체크박스 문구 및 레이아웃 개선.

* **리팩터링**
  * 공지사항 데이터 처리 방식을 API 직접 호출 및 로컬 상태 관리로 변경.
  * 공지사항 생성, 수정, 삭제 시 성공/실패 알림(토스트) 제공.
  * 날짜 표기 형식 통일 및 코드 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->