### PR TITLE
[AN] 일정 화면 북마크 제거

### DIFF
--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -106,7 +106,7 @@
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:orientation="vertical">
 
                 <include layout="@layout/item_schedule_tab_page_skeleton" />

--- a/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
@@ -2,7 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -17,11 +17,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
@@ -49,5 +45,5 @@
 
             </LinearLayout>
         </com.facebook.shimmer.ShimmerFrameLayout>
-    </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/item_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page.xml
@@ -113,9 +113,11 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="20dp"
+                android:clickable="false"
                 android:contentDescription="@string/all_book_mark"
                 android:onClick="@{() -> onBookmarkCheckedListener.onBookmarkChecked(scheduleEvent.id)}"
                 android:src="@drawable/ic_bookmark_normal"
+                android:visibility="invisible"
                 app:layout_constraintBottom_toBottomOf="@id/cl_schedule_event_card"
                 app:layout_constraintEnd_toEndOf="@id/cl_schedule_event_card" />
 

--- a/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
@@ -4,17 +4,21 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <View
+        android:id="@+id/view_space"
+        android:layout_width="match_parent"
+        android:layout_height="20dp"
+        app:layout_constraintBottom_toTopOf="@id/cl_schedule_event_card_skeleton" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_schedule_event_card_skeleton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
-        android:layout_marginTop="20dp"
         android:background="@drawable/bg_gray300_radius_10dp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/iv_schedule_event_time_line_circle_skeleton"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/view_space">
 
         <TextView
             android:id="@+id/tv_schedule_event_title_skeleton"


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/209

<br>

## 🛠️ 작업 내용

- 일정 화면 북마크 임시 숨김 처리
- 일정 화면 skeleton ui 마지막 아이템 margin이 반영 안되는 문제 해결

<br>

## 🙇🏻 중점 리뷰 요청



<br>

## 📸 이미지 첨부 (Optional)
<img width="300" height="618" alt="image" src="https://github.com/user-attachments/assets/26f5df21-4bea-474e-b572-1a8474338d23" />
<img width="300" height="618" alt="image" src="https://github.com/user-attachments/assets/23a984b1-40b8-4bd5-9741-0cb2bc89c0b8" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 일정 스켈레톤 화면에서 레이아웃 높이 조정으로 세로 공간 활용이 개선되었습니다.
  * 일정 탭 페이지 레이아웃이 ConstraintLayout으로 변경되어 향후 레이아웃 정렬이 더 유연해졌습니다.
  * 일정 탭 아이템의 북마크 아이콘이 기본적으로 보이지 않고 클릭할 수 없도록 변경되었습니다.
  * 일정 탭 스켈레톤 아이템에 여백용 View가 추가되어 상단 간격이 더 일관성 있게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->