### PR TITLE
[AN] 지도 초기화가 안되는 버그 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/PlaceGeographyResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/PlaceGeographyResponse.kt
@@ -22,15 +22,34 @@ data class PlaceGeographyResponse(
         @SerialName("longitude")
         val longitude: Double,
     )
+
+    enum class PlaceCategory {
+        FOOD_TRUCK,
+        BOOTH,
+        BAR,
+        TRASH_CAN,
+        TOILET,
+        SMOKING,
+    }
 }
 
 fun PlaceGeographyResponse.toDomain() =
     PlaceGeography(
         id = id,
-        category = category,
+        category = category.toDomain(),
         markerCoordinate =
             Coordinate(
                 latitude = markerCoordinate.latitude,
                 longitude = markerCoordinate.longitude,
             ),
     )
+
+fun PlaceGeographyResponse.PlaceCategory.toDomain() =
+    when (this) {
+        PlaceGeographyResponse.PlaceCategory.BOOTH -> PlaceCategory.BOOTH
+        PlaceGeographyResponse.PlaceCategory.BAR -> PlaceCategory.BAR
+        PlaceGeographyResponse.PlaceCategory.FOOD_TRUCK -> PlaceCategory.FOOD_TRUCK
+        PlaceGeographyResponse.PlaceCategory.SMOKING -> PlaceCategory.SMOKING_AREA
+        PlaceGeographyResponse.PlaceCategory.TOILET -> PlaceCategory.TOILET
+        PlaceGeographyResponse.PlaceCategory.TRASH_CAN -> PlaceCategory.TRASH_CAN
+    }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/model/InitialMapSettingUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/model/InitialMapSettingUiModel.kt
@@ -6,7 +6,6 @@ data class InitialMapSettingUiModel(
     val zoom: Int,
     val initialCenter: CoordinateUiModel,
     val border: List<CoordinateUiModel>,
-    val placeCoordinates: List<PlaceCoordinateUiModel> = emptyList<PlaceCoordinateUiModel>(),
 )
 
 fun OrganizationGeography.toUiModel() =

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapManager.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapManager.kt
@@ -30,7 +30,7 @@ class MapManager(
             overlayImageManager,
         )
 
-    private fun setPlaceLocation(coordinates: List<PlaceCoordinateUiModel>) {
+    fun setPlaceLocation(coordinates: List<PlaceCoordinateUiModel>) {
         clusterManager.buildCluster {
             coordinates.forEachIndexed { idx, place ->
                 Marker().generate(place)
@@ -58,7 +58,6 @@ class MapManager(
             setInitialPolygon(settingUiModel.border)
             setContentPaddingBottom(initialPadding)
             setLogoMarginBottom(initialPadding - LOGO_MARGIN_TOP_PX)
-            setPlaceLocation(settingUiModel.placeCoordinates)
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapUtil.kt
@@ -1,0 +1,14 @@
+package com.daedan.festabook.presentation.placeList.placeMap
+
+import com.naver.maps.map.MapFragment
+import com.naver.maps.map.NaverMap
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+suspend fun MapFragment.getMap() =
+    suspendCancellableCoroutine<NaverMap> { cont ->
+        getMapAsync { map ->
+            cont.resumeWith(
+                Result.success(map),
+            )
+        }
+    }


### PR DESCRIPTION
## #️⃣ 이슈 번호

>https://github.com/woowacourse-teams/2025-festabook/issues/248

<br>

## 🛠️ 작업 내용

- 흡연구역 카테고리 추가 시, 지도가 초기화되지 않는 버그를 수정하였습니다
- 또한 각자의 api 별로 에러 핸들링이 가능하게끔 뷰모델의 라이브데이터를 뚫었습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지도 프래그먼트에서 네이버 지도를 비동기로 가져오는 기능이 추가되었습니다.

* **버그 수정**
  * 지도에 장소 위치를 표시하는 기능의 접근성이 개선되었습니다.

* **리팩터링**
  * 지도 초기화 및 설정 과정이 코루틴 기반의 비동기 처리로 개선되었습니다.
  * 장소 좌표 데이터 관리 방식이 분리되어, 지도와 리스트에서 독립적으로 활용됩니다.
  * 장소 카테고리 매핑 로직이 명확하게 분리되었습니다.

* **기타 변경**
  * 초기 지도 설정 모델에서 장소 좌표 속성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->