### PR TITLE
[FE] 학생회 페이지 플레이스 생성 및 목록 조회 기능 추가

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -85,7 +85,7 @@ const Sidebar = () => {
                 <NavLink target="dashboard" icon="fa-tachometer-alt">대시보드</NavLink>
                 <NavLink target="home" icon="fa-home">홈</NavLink>
                 <NavLink target="schedule" icon="fa-calendar-alt">일정</NavLink>
-                <SubMenu icon="fa-map-marked-alt" title="지도" links={[{ target: 'booths', title: '플레이스 관리' }, { target: 'map-settings', title: '지도 설정' }]} open={openMenus[0]} onToggle={() => handleSubMenuToggle(0)} />
+                <SubMenu icon="fa-map-marked-alt" title="지도" links={[{ target: 'booths', title: '플레이스' }, { target: 'map-settings', title: '지도 설정' }]} open={openMenus[0]} onToggle={() => handleSubMenuToggle(0)} />
                 <SubMenu icon="fa-bullhorn" title="소식" links={[{ target: 'notices', title: '공지 사항' }, { target: 'lost-found', title: '분실물' }, { target: 'qna', title: 'QnA' }]} open={openMenus[1]} onToggle={() => handleSubMenuToggle(1)} />
             </nav>
         </aside>

--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -97,12 +97,6 @@ const BoothModal = ({ booth, onSave, onClose }) => {
                         ))}
                     </select>
                 </div>
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">플레이스명</label>
-                    <input name="title" type="text" value={form.title || ''} onChange={handleChange} placeholder="예: 컴퓨터공학과 주점" 
-                    disabled={!isEditMode && (form.category === 'SMOKING' || form.category === 'TRASH_CAN')}
-                    className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100" />
-                </div>
                 {isEditMode && (
                     <>
                         <div>

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -3,7 +3,7 @@ import { useData } from '../hooks/useData';
 import { useModal } from '../hooks/useModal';
 import { placeCategories } from '../constants/categories';
 
-const BoothDetails = ({ booth }) => {
+const BoothDetails = ({ booth, openModal, handleSave, showToast, updateBooth }) => {
     return (
         <div className="p-6 bg-gray-50">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -24,7 +24,7 @@ const BoothDetails = ({ booth }) => {
                 </div>
                 <div>
                      <h4 className="font-semibold text-lg mb-2">사진</h4>
-                     <div className="grid grid-cols-2 gap-2">
+                     <div className="grid grid-cols-2 gap-2 mb-10">
                         {booth.images && booth.images.length > 0 ? booth.images.map((img, index) => (
                             <div key={index} className="relative">
                                 <img src={img} alt={`${booth.title} ${index+1}`} className="w-full h-24 object-cover rounded-md"/>
@@ -36,7 +36,20 @@ const BoothDetails = ({ booth }) => {
                      </div>
                 </div>
             </div>
-            {/* 수정 버튼 제거 */}
+            <div className="flex items-center gap-4 justify-end mt-2">
+                <button onClick={() => openModal('copyLink', { link: `https://example.com/edit?key=${booth.editKey}` })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
+                <button onClick={() => openModal('booth', { booth, onSave: handleSave })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
+                <button onClick={() => {
+                    openModal('confirm', {
+                        title: '플레이스 삭제 확인',
+                        message: `'${booth.title}' 플레이스를 정말 삭제하시겠습니까?`,
+                        onConfirm: () => {
+                            updateBooth(booth.id, { ...booth, _delete: true });
+                            showToast('플레이스가 삭제되었습니다.');
+                        }
+                    });
+                }} className="text-red-600 hover:text-red-800 text-sm font-semibold">삭제</button>
+            </div>
         </div>
     );
 };
@@ -80,7 +93,7 @@ const BoothsPage = () => {
 
     return (
         <div>
-            <div className="flex justify-between items-center mb-6"><h2 className="text-3xl font-bold">플레이스 관리</h2><button onClick={() => openModal('booth', { onSave: handleSave })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center"><i className="fas fa-plus mr-2"></i> 새 플레이스 추가</button></div>
+            <div className="flex justify-between items-center mb-6"><h2 className="text-3xl font-bold">플레이스</h2><button onClick={() => openModal('booth', { onSave: handleSave })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center"><i className="fas fa-plus mr-2"></i> 새 플레이스 추가</button></div>
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-x-auto">
                 <table className="min-w-full w-full">
                     <thead className="table-header">
@@ -107,25 +120,21 @@ const BoothsPage = () => {
                                                 <i className={`fas ${expandedIds.includes(booth.id) ? 'fa-chevron-up' : 'fa-chevron-down'} mr-1`}></i>
                                                 상세보기
                                             </button>
-                                            <button onClick={() => openModal('copyLink', { link: `https://example.com/edit?key=${booth.editKey}` })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
-                                            <button onClick={() => openModal('booth', { booth, onSave: handleSave })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
-                                            <button onClick={() => {
-                                                openModal('confirm', {
-                                                    title: '플레이스 삭제 확인',
-                                                    message: `'${booth.title}' 플레이스를 정말 삭제하시겠습니까?`,
-                                                    onConfirm: () => {
-                                                        updateBooth(booth.id, { ...booth, _delete: true });
-                                                        showToast('플레이스가 삭제되었습니다.');
-                                                    }
-                                                });
-                                            }} className="text-red-600 hover:text-red-800 text-sm font-semibold">삭제</button>
                                         </div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td colSpan="3" className="p-0">
                                         <div className={`details-row-container ${expandedIds.includes(booth.id) ? 'open' : ''}`}>
-                                            <BoothDetails booth={booth} />
+                                            {expandedIds.includes(booth.id) && (
+                                                <BoothDetails 
+                                                    booth={booth} 
+                                                    openModal={openModal}
+                                                    handleSave={handleSave}
+                                                    showToast={showToast}
+                                                    updateBooth={updateBooth}
+                                                />
+                                            )}
                                         </div>
                                     </td>
                                 </tr>


### PR DESCRIPTION
## #️⃣ 이슈 번호

#195 

<br>

## 🛠️ 작업 내용

- 플레이스 생성 및 전체 조회 기능 api 연결

<br>

## 📸 이미지 첨부 (Optional)

<img width="832" height="842" alt="image" src="https://github.com/user-attachments/assets/7615fd98-c690-4b6b-b596-732bcf99b672" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 부스(플레이스) 목록이 이제 API에서 불러와지며, 새 부스 추가 시 API를 통해 생성됩니다.
  * 부스 상세 정보에서 복사, 편집, 삭제 버튼이 제공됩니다.
  * 부스 삭제 시 삭제 확인 모달이 표시됩니다.

* **버그 수정**
  * 부스 데이터의 누락된 필드가 기본값으로 자동 보완됩니다.

* **리팩터링**
  * 부스 목록 페이지가 React 상태 관리와 API 연동 방식으로 구조가 개선되었습니다.

* **스타일**
  * 사이드바의 "플레이스 관리" 메뉴명이 "플레이스"로 변경되었습니다.

* **기타**
  * 부스 생성/수정 시 입력 필드에서 플레이스명 입력란이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->