### PR TITLE
[BE] Place null 처리 작업 이후 Geographies API null 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/organization/dto/CoordinateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/dto/CoordinateResponse.java
@@ -8,6 +8,9 @@ public record CoordinateResponse(
 ) {
 
     public static CoordinateResponse from(Coordinate coordinate) {
+        if (coordinate == null) {
+            return null;
+        }
         return new CoordinateResponse(
                 coordinate.getLatitude(),
                 coordinate.getLongitude()

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
@@ -8,6 +8,7 @@ import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceCategory;
 import com.daedan.festabook.place.domain.PlaceCoordinateRequestFixture;
 import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceCoordinateRequest;
@@ -115,6 +116,26 @@ class PlaceGeographyControllerTest {
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("$", hasSize(expectedSize));
+        }
+
+        @Test
+        void 성공_Coordinate가_없을_경우_null() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            organizationJpaRepository.save(organization);
+
+            Place place = PlaceFixture.create(organization, PlaceCategory.BAR, null);
+            placeJpaRepository.saveAll(List.of(place));
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header("organization", organization.getId())
+                    .when()
+                    .get("/places/geographies")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("[0].markerCoordinate", equalTo(null));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFixture.java
@@ -53,6 +53,18 @@ public class PlaceFixture {
     }
 
     public static Place create(
+            Organization organization,
+            PlaceCategory category,
+            Coordinate coordinate
+    ) {
+        return new Place(
+                organization,
+                category,
+                coordinate
+        );
+    }
+
+    public static Place create(
             Long id,
             Organization organization,
             Double latitude,

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceGeographyServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceGeographyServiceTest.java
@@ -72,6 +72,27 @@ class PlaceGeographyServiceTest {
                         .isEqualTo(place2.getCoordinate().getLongitude());
             });
         }
+
+        @Test
+        void 성공_Coordinate가_없을_경우_null() {
+            // given
+            Organization organization = OrganizationFixture.create(1L);
+
+            Place place = PlaceFixture.create(organization, PlaceCategory.BAR, null);
+
+            given(placeJpaRepository.findAllByOrganizationId(organization.getId()))
+                    .willReturn(List.of(place));
+
+            // when
+            PlaceGeographyResponses result = placeGeographyService.getAllPlaceGeographyByOrganizationId(
+                    organization.getId()
+            );
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.responses().getFirst().markerCoordinate()).isNull();
+            });
+        }
     }
 
     @Nested


### PR DESCRIPTION
## #️⃣ 이슈 번호

#254

<br>

## 🛠️ 작업 내용

- Place null 처리 작업 이후 Geographies API null 처리

<br>

## 🙇🏻 중점 리뷰 요청

<img width="1326" height="1126" alt="image" src="https://github.com/user-attachments/assets/3e0f4737-63a5-47e3-bbdd-3995b2997383" />

- Coordinate가 null인 경우 지금처럼 반환하는게 좋을지, 정상 데이터 형식 그대로 latitude랑 longitude만 null로 보내주는게 좋을지 추천해 주세요.

<br>

