### PR TITLE
[BE] place 단건 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -78,5 +79,17 @@ public class PlaceController {
             @PathVariable Long placeId
     ) {
         return placeService.getPlaceWithDetailByPlaceId(placeId);
+    }
+
+    @DeleteMapping("/{placeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deleteByPlaceId(
+            @PathVariable Long placeId
+    ) {
+        placeService.deleteByPlaceId(placeId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceAnnouncementJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceAnnouncementJpaRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlaceAnnouncementJpaRepository extends JpaRepository<PlaceAnnouncement, Long> {
 
     List<PlaceAnnouncement> findAllByPlaceId(Long placeId);
+
+    void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceDetailJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceDetailJpaRepository.java
@@ -13,4 +13,6 @@ public interface PlaceDetailJpaRepository extends JpaRepository<PlaceDetail, Lon
     List<PlaceDetail> findAllByPlaceIn(List<Place> places);
 
     boolean existsByPlace(Place place);
+
+    void deleteByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceFavoriteJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceFavoriteJpaRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlaceFavoriteJpaRepository extends JpaRepository<PlaceFavorite, Long> {
 
     boolean existsByPlaceIdAndDeviceId(Long placeId, Long deviceId);
+
+    void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
@@ -10,4 +10,6 @@ public interface PlaceImageJpaRepository extends JpaRepository<PlaceImage, Long>
     List<PlaceImage> findAllByPlaceIdOrderBySequenceAsc(Long placeId);
 
     List<PlaceImage> findAllByPlaceInAndSequence(List<Place> places, int sequence);
+
+    void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
@@ -12,6 +12,7 @@ import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceDetailJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import java.util.List;
@@ -28,6 +29,7 @@ public class PlaceService {
     private final PlaceImageJpaRepository placeImageJpaRepository;
     private final PlaceDetailJpaRepository placeDetailJpaRepository;
     private final OrganizationJpaRepository organizationJpaRepository;
+    private final PlaceFavoriteJpaRepository placeFavoriteJpaRepository;
     private final PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
 
     public PlaceResponse createPlace(Long organizationId, PlaceRequest request) {
@@ -64,6 +66,15 @@ public class PlaceService {
         List<PlaceImage> placeImages = placeImageJpaRepository.findAllByPlaceIdOrderBySequenceAsc(placeId);
         List<PlaceAnnouncement> placeAnnouncements = placeAnnouncementJpaRepository.findAllByPlaceId(placeId);
         return PlaceResponse.fromWithDetail(place, placeDetail, placeImages, placeAnnouncements);
+    }
+
+    @Transactional
+    public void deleteByPlaceId(Long placeId) {
+        placeDetailJpaRepository.deleteByPlaceId(placeId);
+        placeImageJpaRepository.deleteAllByPlaceId(placeId);
+        placeAnnouncementJpaRepository.deleteAllByPlaceId(placeId);
+        placeFavoriteJpaRepository.deleteAllByPlaceId(placeId);
+        placeJpaRepository.deleteById(placeId);
     }
 
     // TODO: ExceptionHandler 등록 후 예외 변경

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -1,11 +1,15 @@
 package com.daedan.festabook.place.controller;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.daedan.festabook.device.domain.Device;
+import com.daedan.festabook.device.domain.DeviceFixture;
+import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
 import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
@@ -15,6 +19,8 @@ import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
 import com.daedan.festabook.place.domain.PlaceCategory;
 import com.daedan.festabook.place.domain.PlaceDetail;
 import com.daedan.festabook.place.domain.PlaceDetailFixture;
+import com.daedan.festabook.place.domain.PlaceFavorite;
+import com.daedan.festabook.place.domain.PlaceFavoriteFixture;
 import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.domain.PlaceImageFixture;
@@ -22,6 +28,7 @@ import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceDetailJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
@@ -58,6 +65,12 @@ class PlaceControllerTest {
 
     @Autowired
     private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @Autowired
+    private PlaceFavoriteJpaRepository placeFavoriteJpaRepository;
+
+    @Autowired
+    private DeviceJpaRepository deviceJpaRepository;
 
     @LocalServerPort
     private int port;
@@ -466,6 +479,81 @@ class PlaceControllerTest {
                     .statusCode(HttpStatus.NOT_FOUND.value())
                     .body("size()", equalTo(expectedFieldSize))
                     .body("message", equalTo("존재하지 않는 플레이스입니다."));
+        }
+    }
+
+    @Nested
+    class deleteByPlaceId {
+
+        @Test
+        void 성공() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            organizationJpaRepository.save(organization);
+
+            Place place = PlaceFixture.create(organization);
+            placeJpaRepository.save(place);
+
+            PlaceDetail placeDetail = PlaceDetailFixture.create(place);
+            placeDetailJpaRepository.save(placeDetail);
+
+            Device device1 = DeviceFixture.create();
+            Device device2 = DeviceFixture.create();
+            deviceJpaRepository.saveAll(List.of(device1, device2));
+
+            PlaceImage placeImage1 = PlaceImageFixture.create(place);
+            PlaceImage placeImage2 = PlaceImageFixture.create(place);
+            placeImageJpaRepository.saveAll(List.of(placeImage1, placeImage2));
+
+            PlaceAnnouncement placeAnnouncement1 = PlaceAnnouncementFixture.create(place);
+            PlaceAnnouncement placeAnnouncement2 = PlaceAnnouncementFixture.create(place);
+            placeAnnouncementJpaRepository.saveAll(List.of(placeAnnouncement1, placeAnnouncement2));
+
+            PlaceFavorite placeFavorite1 = PlaceFavoriteFixture.create(place, device1);
+            PlaceFavorite placeFavorite2 = PlaceFavoriteFixture.create(place, device2);
+            placeFavoriteJpaRepository.saveAll(List.of(placeFavorite1, placeFavorite2));
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(ORGANIZATION_HEADER_NAME, organization.getId())
+                    .when()
+                    .delete("/places/{placeId}", place.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            assertSoftly(s -> {
+                s.assertThat(placeJpaRepository.findById(place.getId())).isEmpty();
+
+                s.assertThat(placeDetailJpaRepository.findById(placeDetail.getId())).isEmpty();
+
+                s.assertThat(placeImageJpaRepository.findById(placeImage1.getId())).isEmpty();
+                s.assertThat(placeImageJpaRepository.findById(placeImage2.getId())).isEmpty();
+
+                s.assertThat(placeAnnouncementJpaRepository.findById(placeAnnouncement1.getId())).isEmpty();
+                s.assertThat(placeAnnouncementJpaRepository.findById(placeAnnouncement2.getId())).isEmpty();
+
+                s.assertThat(placeFavoriteJpaRepository.findById(placeFavorite1.getId())).isEmpty();
+                s.assertThat(placeFavoriteJpaRepository.findById(placeFavorite2.getId())).isEmpty();
+            });
+        }
+
+        @Test
+        void 성공_place가_존재하지_않는_경우_204를_응답한다() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            organizationJpaRepository.save(organization);
+
+            Long invalidPlaceId = 0L;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(ORGANIZATION_HEADER_NAME, organization.getId())
+                    .when()
+                    .delete("/places/{placeId}", invalidPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -539,7 +539,7 @@ class PlaceControllerTest {
         }
 
         @Test
-        void 성공_place가_존재하지_않는_경우_204를_응답한다() {
+        void 성공_place가_존재하지_않는_경우_204를_응답() {
             // given
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
@@ -27,6 +27,7 @@ import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceDetailJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import java.util.List;
@@ -55,6 +56,9 @@ class PlaceServiceTest {
 
     @Mock
     private OrganizationJpaRepository organizationJpaRepository;
+
+    @Mock
+    private PlaceFavoriteJpaRepository placeFavoriteJpaRepository;
 
     @Mock
     private PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
@@ -266,6 +270,31 @@ class PlaceServiceTest {
             assertThatThrownBy(() -> placeService.getPlaceWithDetailByPlaceId(inValidPlaceId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 플레이스입니다.");
+        }
+    }
+
+    @Nested
+    class deleteByPlaceId {
+
+        @Test
+        void 성공() {
+            // given
+            Long expectedPlaceId = 1L;
+
+            // when
+            placeService.deleteByPlaceId(expectedPlaceId);
+
+            // then
+            then(placeDetailJpaRepository).should()
+                    .deleteByPlaceId(expectedPlaceId);
+            then(placeImageJpaRepository).should()
+                    .deleteAllByPlaceId(expectedPlaceId);
+            then(placeAnnouncementJpaRepository).should()
+                    .deleteAllByPlaceId(expectedPlaceId);
+            then(placeFavoriteJpaRepository).should()
+                    .deleteAllByPlaceId(expectedPlaceId);
+            then(placeJpaRepository).should()
+                    .deleteById(expectedPlaceId);
         }
     }
 }


### PR DESCRIPTION
- 이미지, 상세 정보, 공지, 즐겨찾기와 함께 삭제

## #️⃣ 이슈 번호

#193 

<br>

## 🛠️ 작업 내용

- 플레이스 삭제 기능 추가
- 플레이스 삭제 시, 세부 정보, 이미지, 공지, 즐겨찾기 모두 함께 삭제

<br>

## 🙇🏻 중점 리뷰 요청

- 테스트가 적절한지 궁금합니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1438" height="709" alt="image" src="https://github.com/user-attachments/assets/24c9b18f-c225-4586-8bbc-8b8fcff25314" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 장소를 ID로 삭제할 수 있는 DELETE 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 장소 삭제 시 관련된 세부 정보, 이미지, 공지사항, 즐겨찾기 등 연관된 모든 데이터가 함께 삭제됩니다.

* **테스트**
  * 장소 삭제 기능 및 연관 데이터 삭제 동작을 검증하는 테스트가 추가되었습니다.
  * 존재하지 않는 장소 삭제 시 204 No Content 응답을 확인하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->