### PR TITLE
[AN] 화면 회전 및 다크모드 테마 막기

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -22,7 +23,9 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.main.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait"
+            tools:ignore="DiscouragedApi, LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
+++ b/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
 import com.daedan.festabook.service.NotificationHelper
 import com.naver.maps.map.NaverMapSdk
 import timber.log.Timber
@@ -15,6 +16,7 @@ class FestaBookApp : Application() {
         setupNaverSdk()
         setupNotificationChannel()
         appContainer = AppContainer(this)
+        setLightTheme()
     }
 
     private fun setupNotificationChannel() {
@@ -43,5 +45,9 @@ class FestaBookApp : Application() {
     private fun setupNaverSdk() {
         NaverMapSdk.getInstance(this).client =
             NaverMapSdk.NcpKeyClient(BuildConfig.NAVER_MAP_CLIENT_ID)
+    }
+
+    private fun setLightTheme() {
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/242

<br>

## 🛠️ 작업 내용

- 화면 회전과 다크모드를 막았습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 앱이 항상 라이트 테마로 표시되도록 기본 테마가 라이트 모드로 고정되었습니다.
  * 메인 화면이 세로 방향으로 고정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->