### PR TITLE
[FE] 왼쪽 모달 화면 피드백 변경

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -20,7 +20,7 @@ const Sidebar = ({ open, setOpen }) => {
     React.useEffect(() => {
         if (open) {
             // 열 때: 사이드바 너비 변화 후 텍스트 표시
-            const timer = setTimeout(() => setTextVisible(true), 150);
+            const timer = setTimeout(() => setTextVisible(true), 300);
             return () => clearTimeout(timer);
         } else {
             // 닫을 때: 텍스트 먼저 숨기고 사이드바 축소
@@ -59,10 +59,13 @@ const Sidebar = ({ open, setOpen }) => {
                         if (sidebarOpen) {
                             onToggle();
                         } else {
-                            // 사이드바가 닫혀있으면 먼저 사이드바를 열고, 하위 메뉴도 열기
+                            // 사이드바가 닫혀있으면 먼저 사이드바를 열고, 하위 메뉴도 무조건 열기
                             setOpen(true);
                             setTimeout(() => {
-                                onToggle();
+                                // 현재 닫혀있으면 열고, 이미 열려있어도 열린 상태로 유지
+                                if (!open) {
+                                    onToggle();
+                                }
                                 // 지도에 사이드바 변화 알림
                                 window.dispatchEvent(new CustomEvent('sidebarToggle'));
                             }, 100);


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #244 

<br>

## 🛠️ 작업 내용

- 왼쪽 모달 화면 피드백 변경했습니다.

<br>

## 📸 이미지 첨부

### 🛠️ 변경 전

https://github.com/user-attachments/assets/96486511-02df-4290-8831-ea25e961c073

### 🛠️ 변경 후


https://github.com/user-attachments/assets/54a86f09-69ca-41f3-94f1-a87a14e799bb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 사이드바의 전환 효과와 레이아웃이 개선되어 열고 닫을 때 더 부드러운 시각적 변화를 제공합니다.
  * 사이드바가 열릴 때 패딩이 줄어들고, 닫힐 때 아이콘 및 버튼 정렬이 변경되었습니다.
  * 메뉴 및 서브메뉴의 텍스트 오버플로우와 공백 처리가 향상되었습니다.
  * 구분선이 항상 표시됩니다.

* **버그 수정**
  * 서브메뉴 클릭 시 사이드바가 닫혀 있으면 자동으로 열리도록 동작이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->