### PR TITLE
[BE] Place 수정 api 구현 - 이미지 저장 구현 후 다시 진행

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
@@ -5,6 +5,7 @@ import com.daedan.festabook.place.dto.PlacePreviewResponses;
 import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
+import com.daedan.festabook.place.dto.PlaceUpdateRequest;
 import com.daedan.festabook.place.service.PlacePreviewService;
 import com.daedan.festabook.place.service.PlaceService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -43,6 +45,19 @@ public class PlaceController {
             @RequestBody PlaceRequest request
     ) {
         return placeService.createPlace(organizationId, request);
+    }
+
+    @PutMapping("/{placeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스의 모든 정보 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void updatePlace(
+            @PathVariable Long placeId,
+            @RequestBody PlaceUpdateRequest request
+    ) {
+        placeService.updatePlace(placeId, request);
     }
 
     @GetMapping

--- a/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
@@ -69,4 +69,8 @@ public class Place {
     public void updateCoordinate(Coordinate coordinate) {
         this.coordinate = coordinate;
     }
+
+    public void updateCategory(PlaceCategory placeCategory) {
+        this.category = placeCategory;
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceDetail.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceDetail.java
@@ -77,4 +77,13 @@ public class PlaceDetail {
                 endTime
         );
     }
+
+    public void update(PlaceDetail newPlaceDetail) {
+        this.title = newPlaceDetail.getTitle();
+        this.description = newPlaceDetail.getDescription();
+        this.location = newPlaceDetail.getLocation();
+        this.host = newPlaceDetail.getHost();
+        this.startTime = newPlaceDetail.getStartTime();
+        this.endTime = newPlaceDetail.getEndTime();
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceUpdateRequest.java
@@ -1,0 +1,45 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceCategory;
+import com.daedan.festabook.place.domain.PlaceDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+
+public record PlaceUpdateRequest(
+
+        @Schema(description = "플레이스 카테고리", example = "BAR")
+        PlaceCategory placeCategory,
+
+        @Schema(description = "플레이스 이름", example = "미소 된장술밥 주점")
+        String title,
+
+        @Schema(description = "플레이스 설명", example = "미소된장으로 만든 술밥을 판매중입니다.")
+        String description,
+
+        @Schema(description = "플레이스 간단한 위치 정보", example = "공대식당 맞은편")
+        String location,
+
+        @Schema(description = "플레이스 호스트", example = "미소")
+        String host,
+
+        @Schema(description = "플레이스 문여는 시간", example = "13:00")
+        LocalTime startTime,
+
+        @Schema(description = "플레이스 문닫는 시간", example = "23:00")
+        LocalTime endTime
+) {
+
+    public PlaceDetail toPlaceDetail(Place place) {
+        return new PlaceDetail(
+                place,
+                title,
+                description,
+                location,
+                host,
+                startTime,
+                endTime
+        );
+    }
+}
+

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
@@ -10,6 +10,7 @@ import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
+import com.daedan.festabook.place.dto.PlaceUpdateRequest;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceDetailJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
@@ -75,6 +76,26 @@ public class PlaceService {
         placeAnnouncementJpaRepository.deleteAllByPlaceId(placeId);
         placeFavoriteJpaRepository.deleteAllByPlaceId(placeId);
         placeJpaRepository.deleteById(placeId);
+    }
+
+    @Transactional
+    public void updatePlace(Long placeId, PlaceUpdateRequest request) {
+        Place place = getPlaceByPlaceId(placeId);
+        place.updateCategory(request.placeCategory());
+
+        PlaceDetail newPlaceDetail = request.toPlaceDetail(place);
+        PlaceDetail existingDetail = placeDetailJpaRepository.findByPlaceId(placeId).orElse(null);
+
+        updatePlaceDetail(existingDetail, newPlaceDetail);
+    }
+
+    private void updatePlaceDetail(PlaceDetail existingDetail, PlaceDetail newPlaceDetail) {
+        if (existingDetail == null) {
+            placeDetailJpaRepository.save(newPlaceDetail);
+            return;
+        }
+
+        existingDetail.update(newPlaceDetail);
     }
 
     // TODO: ExceptionHandler 등록 후 예외 변경

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceDetailTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceDetailTest.java
@@ -1,0 +1,69 @@
+package com.daedan.festabook.place.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlaceDetailTest {
+
+    @Nested
+    class update {
+
+        @Test
+        void 성공() {
+            // given
+            PlaceDetail placeDetail = PlaceDetailFixture.create();
+
+            PlaceDetail newPlaceDetail = new PlaceDetail(
+                    PlaceFixture.create(),
+                    "업데이트할 이름",
+                    "업데이트할 설명",
+                    "업데이트할 위치",
+                    "업데이트할 호스트",
+                    LocalTime.of(12, 30),
+                    LocalTime.of(13, 30)
+            );
+
+            // when
+            placeDetail.update(newPlaceDetail);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(placeDetail.getTitle()).isEqualTo(newPlaceDetail.getTitle());
+                s.assertThat(placeDetail.getDescription()).isEqualTo(newPlaceDetail.getDescription());
+                s.assertThat(placeDetail.getLocation()).isEqualTo(newPlaceDetail.getLocation());
+                s.assertThat(placeDetail.getHost()).isEqualTo(newPlaceDetail.getHost());
+                s.assertThat(placeDetail.getStartTime()).isEqualTo(newPlaceDetail.getStartTime());
+                s.assertThat(placeDetail.getEndTime()).isEqualTo(newPlaceDetail.getEndTime());
+            });
+        }
+
+        @Test
+        void 성공_플레이스는_변경되지_안_됨() {
+            // given
+            PlaceDetail placeDetail = PlaceDetailFixture.create();
+
+            PlaceDetail newPlaceDetail = new PlaceDetail(
+                    PlaceFixture.create(),
+                    "업데이트할 이름",
+                    "업데이트할 설명",
+                    "업데이트할 위치",
+                    "업데이트할 호스트",
+                    LocalTime.of(12, 30),
+                    LocalTime.of(13, 30)
+            );
+
+            // when
+            placeDetail.update(newPlaceDetail);
+
+            // then
+            assertThat(placeDetail.getPlace()).isNotEqualTo(newPlaceDetail.getPlace());
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceDetailTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceDetailTest.java
@@ -45,7 +45,7 @@ class PlaceDetailTest {
         }
 
         @Test
-        void 성공_플레이스는_변경되지_안_됨() {
+        void 성공_플레이스는_변경되지_않음() {
             // given
             PlaceDetail placeDetail = PlaceDetailFixture.create();
 

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFixture.java
@@ -77,6 +77,18 @@ public class PlaceFixture {
         );
     }
 
+    public static Place create(
+            Long placeId,
+            PlaceCategory category
+    ) {
+        return new Place(
+                placeId,
+                DEFAULT_ORGANIZATION,
+                category,
+                DEFAULT_COORDINATE
+        );
+    }
+
     public static Place createWithNullDefaults(
             Long id,
             Organization organization,

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
@@ -47,16 +47,16 @@ class PlaceTest {
         void 성공() {
             // given
             Organization organization = OrganizationFixture.create();
-            PlaceCategory before = PlaceCategory.BAR;
-            Place place = PlaceFixture.create(organization, before);
+            PlaceCategory beforeCategory = PlaceCategory.BAR;
+            Place place = PlaceFixture.create(organization, beforeCategory);
 
-            PlaceCategory after = PlaceCategory.BAR;
+            PlaceCategory afterCategory = PlaceCategory.BOOTH;
 
             // when
-            place.updateCategory(after);
+            place.updateCategory(afterCategory);
 
             // then
-            assertThat(place.getCategory()).isEqualTo(after);
+            assertThat(place.getCategory()).isEqualTo(afterCategory);
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
@@ -8,6 +8,7 @@ import com.daedan.festabook.organization.domain.OrganizationFixture;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -36,6 +37,26 @@ class PlaceTest {
 
             // then
             assertThat(result).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class updateCategory {
+
+        @Test
+        void 성공() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            PlaceCategory before = PlaceCategory.BAR;
+            Place place = PlaceFixture.create(organization, before);
+
+            PlaceCategory after = PlaceCategory.BAR;
+
+            // when
+            place.updateCategory(after);
+
+            // then
+            assertThat(place.getCategory()).isEqualTo(after);
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceUpdateRequestFixture.java
@@ -1,10 +1,11 @@
-package com.daedan.festabook.place.domain;
+package com.daedan.festabook.place.dto;
 
+import com.daedan.festabook.place.domain.PlaceCategory;
 import java.time.LocalTime;
 
-public class PlaceDetailFixture {
+public class PlaceUpdateRequestFixture {
 
-    private static final Place DEFAULT_PLACE = PlaceFixture.create();
+    private static final PlaceCategory DEFAULT_CATEGORY = PlaceCategory.BOOTH;
     private static final String DEFAULT_TITLE = "코딩하며 한잔";
     private static final String DEFAULT_DESCRIPTION = "시원한 맥주와 맛있는 치킨!";
     private static final String DEFAULT_LOCATION = "공학관 앞";
@@ -12,21 +13,9 @@ public class PlaceDetailFixture {
     private static final LocalTime DEFAULT_START_TIME = LocalTime.of(9, 0);
     private static final LocalTime DEFAULT_END_TIME = LocalTime.of(18, 0);
 
-    public static PlaceDetail create() {
-        return new PlaceDetail(
-                DEFAULT_PLACE,
-                DEFAULT_TITLE,
-                DEFAULT_DESCRIPTION,
-                DEFAULT_LOCATION,
-                DEFAULT_HOST,
-                DEFAULT_START_TIME,
-                DEFAULT_END_TIME
-        );
-    }
-
-    public static PlaceDetail create(Place place) {
-        return new PlaceDetail(
-                place,
+    public static PlaceUpdateRequest create() {
+        return new PlaceUpdateRequest(
+                DEFAULT_CATEGORY,
                 DEFAULT_TITLE,
                 DEFAULT_DESCRIPTION,
                 DEFAULT_LOCATION,

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
@@ -26,6 +26,7 @@ import com.daedan.festabook.place.dto.PlaceRequestFixture;
 import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
 import com.daedan.festabook.place.dto.PlaceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceUpdateRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceDetailJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
@@ -353,6 +354,19 @@ class PlaceServiceTest {
             // then
             then(placeDetailJpaRepository).should()
                     .save(any());
+        }
+
+        @Test
+        void 실패_플레이스가_존재하지_않는다면_예외가_발생() {
+            // given
+            Long invalidPlaceId = 0L;
+
+            PlaceUpdateRequest placeUpdateRequest = PlaceUpdateRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> placeService.updatePlace(invalidPlaceId, placeUpdateRequest))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 플레이스입니다.");
         }
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#193 

<br>

## 🛠️ 작업 내용

- place 수정 api 구현 (이미지는 다음 차례)

<br>

## 📸 이미지 첨부 (Optional)

<img width="1432" height="398" alt="image" src="https://github.com/user-attachments/assets/e246c406-cdfe-4ad4-b72d-e97555ce129f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 장소의 모든 정보를 한 번에 수정할 수 있는 API 엔드포인트(HTTP PUT)가 추가되었습니다.

* **버그 수정**
  * 장소의 카테고리 및 세부 정보 업데이트 기능이 개선되었습니다.

* **문서화**
  * API 문서에 장소 수정 요청에 대한 예시 및 설명이 추가되었습니다.

* **테스트**
  * 장소 정보 및 세부 정보 수정에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
  * 테스트용 데이터 생성 도우미(픽스처)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->