### PR TITLE
[BE] PlacePreview, PlaceGeography null 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponses.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponses.java
@@ -11,6 +11,7 @@ public record PlaceGeographyResponses(
     public static PlaceGeographyResponses from(List<Place> places) {
         return new PlaceGeographyResponses(
                 places.stream()
+                        .filter(place -> place.getCoordinate() != null)
                         .map(PlaceGeographyResponse::from)
                         .toList()
         );

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlacePreviewResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlacePreviewResponse.java
@@ -18,7 +18,7 @@ public record PlacePreviewResponse(
         if (placeDetail == null) {
             return new PlacePreviewResponse(
                     place.getId(),
-                    null,
+                    placeImage != null ? placeImage.getImageUrl() : null,
                     place.getCategory(),
                     null,
                     null,

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlacePreviewResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlacePreviewResponse.java
@@ -15,6 +15,16 @@ public record PlacePreviewResponse(
 ) {
 
     public static PlacePreviewResponse from(Place place, PlaceDetail placeDetail, PlaceImage placeImage) {
+        if (placeDetail == null) {
+            return new PlacePreviewResponse(
+                    place.getId(),
+                    null,
+                    place.getCategory(),
+                    null,
+                    null,
+                    null
+            );
+        }
         return new PlacePreviewResponse(
                 place.getId(),
                 placeImage != null ? placeImage.getImageUrl() : null,

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -307,7 +307,7 @@ class PlaceControllerTest {
         }
 
         @Test
-        void 성공_카테고리만_있을_경우_나머지_필드_null_반환() {
+        void 성공_Coordinate가_없는_경우_나머지_필드_null_반환() {
             // given
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.nullValue;
 import com.daedan.festabook.device.domain.Device;
 import com.daedan.festabook.device.domain.DeviceFixture;
 import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
+import com.daedan.festabook.organization.domain.Coordinate;
 import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
@@ -311,7 +312,8 @@ class PlaceControllerTest {
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);
 
-            Place place = PlaceFixture.create(organization, PlaceCategory.BAR, null);
+            Coordinate coordinate = null;
+            Place place = PlaceFixture.create(organization, PlaceCategory.BAR, coordinate);
             placeJpaRepository.save(place);
 
             // when & then

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -304,6 +304,30 @@ class PlaceControllerTest {
                     .body("[0].imageUrl", equalTo(placeImage1.getImageUrl()))
                     .body("[1].imageUrl", equalTo(null));
         }
+
+        @Test
+        void 성공_카테고리만_있을_경우_나머지_필드_null_반환() {
+            // given
+            Organization organization = OrganizationFixture.create();
+            organizationJpaRepository.save(organization);
+
+            Place place = PlaceFixture.create(organization, PlaceCategory.BAR, null);
+            placeJpaRepository.save(place);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(ORGANIZATION_HEADER_NAME, organization.getId())
+                    .when()
+                    .get("/places/previews")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("[0].imageUrl", nullValue())
+                    .body("[0].category", equalTo(place.getCategory().name()))
+                    .body("[0].title", nullValue())
+                    .body("[0].description", nullValue())
+                    .body("[0].location", nullValue());
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -307,7 +307,7 @@ class PlaceControllerTest {
         }
 
         @Test
-        void 성공_Coordinate가_없는_경우_나머지_필드_null_반환() {
+        void 성공_Detail이_없는_경우_나머지_필드_null_반환() {
             // given
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
@@ -3,7 +3,6 @@ package com.daedan.festabook.place.controller;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
 
 import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
@@ -120,13 +119,15 @@ class PlaceGeographyControllerTest {
         }
 
         @Test
-        void 성공_Coordinate가_없을_경우_null() {
+        void 성공_Coordinate가_없을_경우_응답에_포함하지_않음() {
             // given
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);
 
             Place place = PlaceFixture.create(organization, PlaceCategory.BAR, null);
-            placeJpaRepository.saveAll(List.of(place));
+            placeJpaRepository.save(place);
+
+            int expectedSize = 0;
 
             // when & then
             RestAssured
@@ -136,8 +137,7 @@ class PlaceGeographyControllerTest {
                     .get("/places/geographies")
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("[0].markerCoordinate.latitude", nullValue())
-                    .body("[0].markerCoordinate.longitude", nullValue());
+                    .body("$", hasSize(expectedSize));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceGeographyServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceGeographyServiceTest.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.place.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
@@ -74,7 +75,7 @@ class PlaceGeographyServiceTest {
         }
 
         @Test
-        void 성공_Coordinate가_없을_경우_null() {
+        void 성공_Coordinate가_없을_경우_응답에_포함하지_않음() {
             // given
             Organization organization = OrganizationFixture.create(1L);
 
@@ -89,10 +90,7 @@ class PlaceGeographyServiceTest {
             );
 
             // then
-            assertSoftly(s -> {
-                s.assertThat(result.responses().getFirst().markerCoordinate().latitude()).isNull();
-                s.assertThat(result.responses().getFirst().markerCoordinate().longitude()).isNull();
-            });
+            assertThat(result.responses()).isEmpty();
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
@@ -115,7 +115,7 @@ class PlacePreviewServiceTest {
         }
 
         @Test
-        void 성공_카테고리만_있을_경우_나머지_필드_null_반환() {
+        void 성공_Coordinate가_없는_경우_나머지_필드_null_반환() {
             // given
             Long organizationId = 1L;
             Organization organization = OrganizationFixture.create(organizationId);

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
+import com.daedan.festabook.organization.domain.Coordinate;
 import com.daedan.festabook.organization.domain.Organization;
 import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.place.domain.Place;
@@ -120,7 +121,8 @@ class PlacePreviewServiceTest {
             Organization organization = OrganizationFixture.create(organizationId);
 
             PlaceCategory placeCategory = PlaceCategory.BAR;
-            Place place = PlaceFixture.create(organization, placeCategory, null);
+            Coordinate coordinate = null;
+            Place place = PlaceFixture.create(organization, placeCategory, coordinate);
 
             given(placeJpaRepository.findAllByOrganizationId(organization.getId()))
                     .willReturn(List.of(place));

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
@@ -115,7 +115,7 @@ class PlacePreviewServiceTest {
         }
 
         @Test
-        void 성공_Coordinate가_없는_경우_나머지_필드_null_반환() {
+        void 성공_Detail이_없는_경우_나머지_필드_null_반환() {
             // given
             Long organizationId = 1L;
             Organization organization = OrganizationFixture.create(organizationId);

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
+import com.daedan.festabook.organization.domain.Organization;
+import com.daedan.festabook.organization.domain.OrganizationFixture;
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceCategory;
 import com.daedan.festabook.place.domain.PlaceDetail;
 import com.daedan.festabook.place.domain.PlaceDetailFixture;
 import com.daedan.festabook.place.domain.PlaceFixture;
@@ -107,6 +110,30 @@ class PlacePreviewServiceTest {
             assertSoftly(s -> {
                 s.assertThat(result.responses().get(0).imageUrl()).isEqualTo(placeImage1.getImageUrl());
                 s.assertThat(result.responses().get(1).imageUrl()).isEqualTo(null);
+            });
+        }
+
+        @Test
+        void 성공_카테고리만_있을_경우_나머지_필드_null_반환() {
+            Long organizationId = 1L;
+            Organization organization = OrganizationFixture.create(organizationId);
+
+            PlaceCategory placeCategory = PlaceCategory.BAR;
+            Place place = PlaceFixture.create(organization, placeCategory, null);
+
+            given(placeJpaRepository.findAllByOrganizationId(organization.getId()))
+                    .willReturn(List.of(place));
+
+            // when
+            PlacePreviewResponses result = placePreviewService.getAllPreviewPlaceByOrganizationId(organizationId);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.responses().getFirst().imageUrl()).isNull();
+                s.assertThat(result.responses().getFirst().category()).isEqualTo(placeCategory);
+                s.assertThat(result.responses().getFirst().title()).isNull();
+                s.assertThat(result.responses().getFirst().description()).isNull();
+                s.assertThat(result.responses().getFirst().location()).isNull();
             });
         }
     }

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlacePreviewServiceTest.java
@@ -115,6 +115,7 @@ class PlacePreviewServiceTest {
 
         @Test
         void 성공_카테고리만_있을_경우_나머지_필드_null_반환() {
+            // given
             Long organizationId = 1L;
             Organization organization = OrganizationFixture.create(organizationId);
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#266 

<br>

## 🛠️ 작업 내용

- GET /places/geographies 엔드포인트 Coordinate null일 때 응답에 포함되지 않도록 변경
- GET /places/previews 엔드포인트 null 처리 (fix)

<br>

## 📸 이미지 첨부 (Optional)
- GET /places/geographies 엔드포인트 Coordinate null일 때 응답에 포함되지 않도록 변경
<img width="701" height="271" alt="스크린샷 2025-07-30 오후 8 20 26" src="https://github.com/user-attachments/assets/b1fd1a2f-fe8e-4e3f-afce-d44ed271a3d8" />

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 좌표 정보가 없는 장소는 지리 정보 응답에서 제외됩니다.
  * 장소 상세 정보가 없는 경우, 미리보기 응답에서 카테고리만 반환되고 나머지 필드는 null로 처리됩니다.

* **테스트**
  * 좌표가 없는 장소가 응답에서 제외되는지 확인하는 테스트가 추가 및 수정되었습니다.
  * 카테고리만 있는 장소의 미리보기 응답 필드가 올바르게 null로 반환되는지 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->