### PR TITLE
[FE] 학생회 페이지 수정 api 연결 및 구현 - 이미지 저장 로직 구현 후 다시 진행

### DIFF
--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -79,38 +79,6 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
         });
     };
 
-    const handleSetMainImage = (index) => {
-        setForm(prev => ({ ...prev, mainImageIndex: index }));
-    };
-
-    const handleStartEditNotice = (notice) => {
-        setEditingNotice({ id: notice.id, text: notice.text });
-    };
-
-    const handleCancelEditNotice = () => {
-        setEditingNotice({ id: null, text: '' });
-    };
-
-    const handleSaveNoticeEdit = () => {
-        const newNotices = form.notices.map(n =>
-            n.id === editingNotice.id ? { ...n, text: editingNotice.text } : n
-        );
-        setForm(prev => ({ ...prev, notices: newNotices }));
-        handleCancelEditNotice();
-    };
-
-    const handleDeleteNotice = (id, text) => {
-        openModal('confirm', {
-            title: '공지 삭제 확인',
-            message: `'${text}' 공지를 정말 삭제하시겠습니까?`,
-            onConfirm: () => {
-                const newNotices = form.notices.filter(n => n.id !== id);
-                setForm(prev => ({ ...prev, notices: newNotices }));
-                showToast('공지가 삭제되었습니다.');
-            }
-        });
-    };
-
     // form이 수정된 값
     const handleSave = () => {
         onSave(form);

--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -117,7 +117,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
 
     // 메인 플레이스 카테고리만 필터링
     const filteredCategories = Object.entries(placeCategories).filter(([key, value]) => {
-        return !isMainPlace(key);
+        return isMainPlace(key);
     });
     
     return (
@@ -255,6 +255,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
 // 기존 BoothModal을 CreateBoothModal과 EditBoothModal로 분리
 const BoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
     const isEditMode = !!booth;
+    console.log(booth, isEditMode);
     
     if (isEditMode) {
         return (

--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -2,28 +2,56 @@ import React, { useState, useEffect } from 'react';
 import { useModal } from '../../hooks/useModal';
 import Modal from '../common/Modal';
 import { placeCategories } from '../../constants/categories';
+import { isMainPlace, getDefaultValueIfNull } from '../../utils/booth';
 
-const BoothModal = ({ booth, onSave, onClose }) => {
+// 새 플레이스 생성용 모달 (카테고리만 선택)
+const CreateBoothModal = ({ onSave, onClose }) => {
+    const [form, setForm] = useState({ category: Object.keys(placeCategories)[0] });
+
+    const handleChange = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    
+    const handleSave = () => { 
+        onSave(form); 
+        onClose(); 
+    };
+    
+    return (
+        <Modal isOpen={true} onClose={onClose} maxWidth="max-w-md">
+            <h3 className="text-xl font-bold mb-6">새 플레이스 추가</h3>
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">카테고리</label>
+                    <select 
+                        name="category" 
+                        value={form.category || ''} 
+                        onChange={handleChange} 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
+                    >
+                        {Object.entries(placeCategories).map(([key, value]) => (
+                            <option key={key} value={key}>{value}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+            <div className="mt-6 flex justify-between w-full">
+                <div className="space-x-3">
+                    <button onClick={onClose} className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg">취소</button>
+                    <button onClick={handleSave} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg">생성</button>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+// 기존 플레이스 수정용 모달 (모든 필드 편집 가능)
+const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
     const { openModal, showToast } = useModal();
-    const isEditMode = !!booth;
-
     const [form, setForm] = useState({});
     const [editingNotice, setEditingNotice] = useState({ id: null, text: '' });
 
     useEffect(() => {
         setForm(booth || { title: '', category: Object.keys(placeCategories)[0], notices: [], images: [], mainImageIndex: -1 });
     }, [booth]);
-    
-    useEffect(() => {
-        if (!isEditMode) { // Only for new booths
-            if (form.category === 'SMOKING' || form.category === 'TRASH_CAN') {
-                setForm(prev => ({
-                    ...prev,
-                    title: placeCategories[prev.category]
-                }));
-            }
-        }
-    }, [form.category, isEditMode]);
 
     const handleChange = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
     
@@ -70,7 +98,6 @@ const BoothModal = ({ booth, onSave, onClose }) => {
         handleCancelEditNotice();
     };
 
-
     const handleDeleteNotice = (id, text) => {
         openModal('confirm', {
             title: '공지 삭제 확인',
@@ -83,84 +110,137 @@ const BoothModal = ({ booth, onSave, onClose }) => {
         });
     };
 
-    const handleSave = () => { onSave(form); onClose(); };
+    const handleSave = () => { 
+        onSave(form); 
+        onClose(); 
+    };
+
+    // 메인 플레이스 카테고리만 필터링
+    const filteredCategories = Object.entries(placeCategories).filter(([key, value]) => {
+        return !isMainPlace(key);
+    });
     
     return (
         <Modal isOpen={true} onClose={onClose} maxWidth="max-w-2xl">
-            <h3 className="text-xl font-bold mb-6">{isEditMode ? '플레이스 수정' : '새 플레이스 추가'}</h3>
-            <div className={`space-y-4 ${isEditMode ? 'max-h-[60vh] overflow-y-auto pr-2' : ''}`}>
+            <h3 className="text-xl font-bold mb-6">플레이스 수정</h3>
+            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">카테고리</label>
-                    <select name="category" value={form.category || ''} onChange={handleChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 bg-white">
-                        {Object.entries(placeCategories).map(([key, value]) => (
+                    <select 
+                        name="category" 
+                        value={form.category || ''} 
+                        onChange={handleChange} 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
+                    >
+                        {filteredCategories.map(([key, value]) => (
                             <option key={key} value={key}>{value}</option>
                         ))}
                     </select>
                 </div>
-                {isEditMode && (
-                    <>
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">설명</label>
-                            <textarea name="description" value={form.description} onChange={handleChange} rows="3" placeholder="플레이스에 대한 상세 설명을 입력해주세요." className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                        </div>
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">위치</label>
-                            <input name="location" type="text" value={form.location} onChange={handleChange} placeholder="예: 학생회관 앞" className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                        </div>
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">운영 주체</label>
-                            <input name="host" type="text" value={form.host} onChange={handleChange} placeholder="예: 컴퓨터공학과 학생회" className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 mb-1">운영 시작 시간</label>
-                                <input name="startTime" type="time" value={form.startTime} onChange={handleChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                            </div>
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 mb-1">운영 종료 시간</label>
-                                <input name="endTime" type="time" value={form.endTime} onChange={handleChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
-                            </div>
-                        </div>
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700">사진 (클릭하여 대표 사진 변경)</label>
-                            <div className="mt-2 grid grid-cols-3 gap-4">
-                               {form.images && form.images.map((img, index) => (
-                                   <div key={index} className="relative cursor-pointer" onClick={() => handleSetMainImage(index)}>
-                                       <img src={img} alt={`booth-${index}`} className={`w-full h-24 object-cover rounded-md border-2 ${form.mainImageIndex === index ? 'border-blue-500' : 'border-transparent'}`}/>
-                                       {form.mainImageIndex === index && <span className="main-image-indicator">대표</span>}
-                                   </div>
-                               ))}
-                            </div>
-                            <input type="file" accept="image/*" multiple onChange={handlePhotoChange} className="mt-2 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"/>
-                        </div>
-                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">개별 공지사항</label>
-                            <ul className="mt-2 space-y-1">
-                                {form.notices && form.notices.map(notice => (
-                                    <li key={notice.id} className="flex justify-between items-center text-sm bg-gray-100 p-2 rounded-md">
-                                        {editingNotice.id === notice.id ? (
-                                            <>
-                                                <input type="text" value={editingNotice.text} onChange={(e) => setEditingNotice(prev => ({...prev, text: e.target.value}))} className="flex-1 block w-full border border-gray-300 rounded-md shadow-sm py-1 px-2 mr-2"/>
-                                                <div className="flex items-center space-x-3">
-                                                    <button onClick={handleSaveNoticeEdit} className="text-green-600 hover:text-green-800"><i className="fas fa-check"></i></button>
-                                                    <button onClick={handleCancelEditNotice} className="text-gray-500 hover:text-gray-700"><i className="fas fa-times"></i></button>
-                                                    <button onClick={() => handleDeleteNotice(notice.id, notice.text)} className="text-red-500 hover:text-red-700"><i className="fas fa-trash"></i></button>
-                                                </div>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <span>{notice.text}</span>
-                                                <div className="space-x-3">
-                                                    <button onClick={() => handleStartEditNotice(notice)} className="text-blue-600 hover:text-blue-800 text-sm">수정</button>
-                                                </div>
-                                            </>
-                                        )}
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    </>
-                )}
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">플레이스명</label>
+                    <input 
+                        name="title" 
+                        type="text" 
+                        value={form.title || ''} 
+                        onChange={handleChange} 
+                        placeholder="플레이스 이름을 입력해주세요." 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">설명</label>
+                    <textarea 
+                        name="description" 
+                        value={form.description || ''} 
+                        onChange={handleChange} 
+                        rows="3" 
+                        placeholder="플레이스에 대한 상세 설명을 입력해주세요." 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">위치</label>
+                    <input 
+                        name="location" 
+                        type="text" 
+                        value={form.location || ''} 
+                        onChange={handleChange} 
+                        placeholder="예: 학생회관 앞" 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">운영 주체</label>
+                    <input 
+                        name="host" 
+                        type="text" 
+                        value={form.host || ''} 
+                        onChange={handleChange} 
+                        placeholder="예: 컴퓨터공학과 학생회" 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">운영 시작 시간</label>
+                        <input 
+                            name="startTime" 
+                            type="time" 
+                            value={form.startTime || ''} 
+                            onChange={handleChange} 
+                            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">운영 종료 시간</label>
+                        <input 
+                            name="endTime" 
+                            type="time" 
+                            value={form.endTime || ''} 
+                            onChange={handleChange} 
+                            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                        />
+                    </div>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-gray-700">사진 (클릭하여 대표 사진 변경)</label>
+                    <div className="mt-2 grid grid-cols-3 gap-4">
+                       {form.images && form.images.map((img, index) => (
+                           <div key={index} className="relative cursor-pointer" onClick={() => handleSetMainImage(index)}>
+                               <img src={img} alt={`booth-${index}`} className={`w-full h-24 object-cover rounded-md border-2 ${form.mainImageIndex === index ? 'border-blue-500' : 'border-transparent'}`}/>
+                               {form.mainImageIndex === index && <span className="main-image-indicator">대표</span>}
+                           </div>
+                       ))}
+                    </div>
+                    <input type="file" accept="image/*" multiple onChange={handlePhotoChange} className="mt-2 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"/>
+                </div>
+                 <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">개별 공지사항</label>
+                    <ul className="mt-2 space-y-1">
+                        {form.notices && form.notices.map(notice => (
+                            <li key={notice.id} className="flex justify-between items-center text-sm bg-gray-100 p-2 rounded-md">
+                                {editingNotice.id === notice.id ? (
+                                    <>
+                                        <input type="text" value={editingNotice.text} onChange={(e) => setEditingNotice(prev => ({...prev, text: e.target.value}))} className="flex-1 block w-full border border-gray-300 rounded-md shadow-sm py-1 px-2 mr-2"/>
+                                        <div className="flex items-center space-x-3">
+                                            <button onClick={handleSaveNoticeEdit} className="text-green-600 hover:text-green-800"><i className="fas fa-check"></i></button>
+                                            <button onClick={handleCancelEditNotice} className="text-gray-500 hover:text-gray-700"><i className="fas fa-times"></i></button>
+                                            <button onClick={() => handleDeleteNotice(notice.id, notice.text)} className="text-red-500 hover:text-red-700"><i className="fas fa-trash"></i></button>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <>
+                                        <span>{notice.text}</span>
+                                        <div className="space-x-3">
+                                            <button onClick={() => handleStartEditNotice(notice)} className="text-blue-600 hover:text-blue-800 text-sm">수정</button>
+                                        </div>
+                                    </>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
             </div>
             <div className="mt-6 flex justify-between w-full">
                 <div className="space-x-3">
@@ -170,6 +250,29 @@ const BoothModal = ({ booth, onSave, onClose }) => {
             </div>
         </Modal>
     );
+};
+
+// 기존 BoothModal을 CreateBoothModal과 EditBoothModal로 분리
+const BoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
+    const isEditMode = !!booth;
+    
+    if (isEditMode) {
+        return (
+            <EditBoothModal 
+                booth={booth} 
+                onSave={onSave} 
+                onClose={onClose} 
+                isMainPlace={isMainPlace} 
+            />
+        );
+    } else {
+        return (
+            <CreateBoothModal 
+                onSave={onSave} 
+                onClose={onClose} 
+            />
+        );
+    }
 };
 
 export default BoothModal;

--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -54,6 +54,16 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
         setForm(booth || { title: '', category: Object.keys(placeCategories)[0], notices: [], images: [], mainImageIndex: -1 });
     }, [booth]);
 
+    const category = form.category;
+    const title = form.title;
+    const startTime = form.startTime;
+    const endTime = form.endTime;
+    const location = form.location;
+    const host = form.host;
+    const description = form.description;
+    const placeAnnouncements = form.placeAnnouncements;
+    const placeImages = form.placeImages;
+
     const handleChange = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
 
     const handlePhotoChange = (e) => {
@@ -78,7 +88,6 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
             }));
         });
     };
-
     // form이 수정된 값
     const handleSave = () => {
         onSave(form);
@@ -119,13 +128,13 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                     <label className="block text-sm font-medium text-gray-700 mb-1">카테고리</label>
                     <select
                         name="category"
-                        value={form.category || ''}
+                        value={category || ''}
                         onChange={handleChange}
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
                     >
-                        {filteredCategories.map(([key, value]) => (
+                        {filteredCategories && filteredCategories.length > 0 ? filteredCategories.map(([key, value]) => (
                             <option key={key} value={key}>{value}</option>
-                        ))}
+                        )) : <></>}
                     </select>
                 </div>
                 <div>
@@ -133,7 +142,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                     <input
                         name="title"
                         type="text"
-                        value={form.title || ''}
+                        value={title || ''}
                         onChange={handleChange}
                         placeholder="플레이스 이름을 입력해주세요."
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
@@ -143,7 +152,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                     <label className="block text-sm font-medium text-gray-700 mb-1">설명</label>
                     <textarea
                         name="description"
-                        value={form.description || ''}
+                        value={description || ''}
                         onChange={handleChange}
                         rows="3"
                         placeholder="플레이스에 대한 상세 설명을 입력해주세요."
@@ -155,7 +164,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                     <input
                         name="location"
                         type="text"
-                        value={form.location || ''}
+                        value={location || ''}
                         onChange={handleChange}
                         placeholder="예: 학생회관 앞"
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
@@ -166,7 +175,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                     <input
                         name="host"
                         type="text"
-                        value={form.host || ''}
+                        value={host || ''}
                         onChange={handleChange}
                         placeholder="예: 컴퓨터공학과 학생회"
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
@@ -178,7 +187,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                         <input
                             name="startTime"
                             type="time"
-                            value={form.startTime || ''}
+                            value={startTime || ''}
                             onChange={handleChange}
                             className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                         />
@@ -188,7 +197,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                         <input
                             name="endTime"
                             type="time"
-                            value={form.endTime || ''}
+                            value={endTime || ''}
                             onChange={handleChange}
                             className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                         />
@@ -197,8 +206,8 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                 <div>
                     <label className="block text-sm font-medium text-gray-700">사진 (클릭하여 대표 사진 변경)</label>
                     <div className="mt-2 grid grid-cols-3 gap-4">
-                        {form.placeImages && form.placeImages.map((img, index) => (
-                            renderImage(form.placeImages[0].id, form.title, img, index)
+                        {placeImages && placeImages.map((img, index) => (
+                            renderImage(placeImages[0].id, title, img, index)
                         ))}
                     </div>
                     <input type="file" accept="image/*" multiple onChange={handlePhotoChange} className="mt-2 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" />
@@ -206,7 +215,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">개별 공지사항</label>
                     <ul className="list-disc list-inside text-sm mt-2 space-y-1">
-                        {form.placeAnnouncements.map(announcement => renderAnnouncement(announcement))}
+                        {placeAnnouncements && placeAnnouncements.length > 0 ? placeAnnouncements.map(announcement => renderAnnouncement(announcement)) : <></>}
                     </ul>
                 </div>
             </div>

--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useModal } from '../../hooks/useModal';
 import Modal from '../common/Modal';
 import { placeCategories } from '../../constants/categories';
+// import api from '../utils/api';
 import { isMainPlace, getDefaultValueIfNull } from '../../utils/booth';
 
 // 새 플레이스 생성용 모달 (카테고리만 선택)
@@ -9,22 +10,22 @@ const CreateBoothModal = ({ onSave, onClose }) => {
     const [form, setForm] = useState({ category: Object.keys(placeCategories)[0] });
 
     const handleChange = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
-    
-    const handleSave = () => { 
-        onSave(form); 
-        onClose(); 
+
+    const handleSave = () => {
+        onSave(form);
+        onClose();
     };
-    
+
     return (
         <Modal isOpen={true} onClose={onClose} maxWidth="max-w-md">
             <h3 className="text-xl font-bold mb-6">새 플레이스 추가</h3>
             <div className="space-y-4">
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">카테고리</label>
-                    <select 
-                        name="category" 
-                        value={form.category || ''} 
-                        onChange={handleChange} 
+                    <select
+                        name="category"
+                        value={form.category || ''}
+                        onChange={handleChange}
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
                     >
                         {Object.entries(placeCategories).map(([key, value]) => (
@@ -54,7 +55,7 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
     }, [booth]);
 
     const handleChange = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
-    
+
     const handlePhotoChange = (e) => {
         const files = Array.from(e.target.files);
         if (files.length === 0) return;
@@ -71,15 +72,15 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
         Promise.all(fileReadPromises).then(newImages => {
             const updatedImages = [...(form.images || []), ...newImages];
             setForm(prev => ({
-                ...prev, 
+                ...prev,
                 images: updatedImages,
                 mainImageIndex: prev.mainImageIndex === -1 && updatedImages.length > 0 ? 0 : prev.mainImageIndex
             }));
         });
     };
-    
+
     const handleSetMainImage = (index) => {
-        setForm(prev => ({...prev, mainImageIndex: index}));
+        setForm(prev => ({ ...prev, mainImageIndex: index }));
     };
 
     const handleStartEditNotice = (notice) => {
@@ -91,10 +92,10 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
     };
 
     const handleSaveNoticeEdit = () => {
-        const newNotices = form.notices.map(n => 
+        const newNotices = form.notices.map(n =>
             n.id === editingNotice.id ? { ...n, text: editingNotice.text } : n
         );
-        setForm(prev => ({...prev, notices: newNotices}));
+        setForm(prev => ({ ...prev, notices: newNotices }));
         handleCancelEditNotice();
     };
 
@@ -104,32 +105,54 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
             message: `'${text}' 공지를 정말 삭제하시겠습니까?`,
             onConfirm: () => {
                 const newNotices = form.notices.filter(n => n.id !== id);
-                setForm(prev => ({...prev, notices: newNotices}));
+                setForm(prev => ({ ...prev, notices: newNotices }));
                 showToast('공지가 삭제되었습니다.');
             }
         });
     };
 
-    const handleSave = () => { 
-        onSave(form); 
-        onClose(); 
+    // form이 수정된 값
+    const handleSave = () => {
+        onSave(form);
+
+        // 모달 닫기
+        onClose();
     };
 
     // 메인 플레이스 카테고리만 필터링
     const filteredCategories = Object.entries(placeCategories).filter(([key, value]) => {
         return isMainPlace(key);
     });
-    
+
+    // 이미지 렌더링
+    const renderImage = (mainIdx, title, image, idx) => {
+        const alt = `${title} ${idx + 1}`;
+        const isMainImage = (image.id === mainIdx);
+
+
+        return <div key={image.imageUrl} className="relative">
+            <img src={image.imageUrl} alt={alt} className="w-full h-24 object-cover rounded-md" />
+            {isMainImage && <span className="main-image-indicator">대표</span>}
+        </div>
+    }
+
+    // 공지 렌더링
+    const renderAnnouncement = (announcement) => {
+        let content = announcement.content;
+
+        return <li key={announcement.id}>{announcement.title} - {content}</li>
+    }
+
     return (
         <Modal isOpen={true} onClose={onClose} maxWidth="max-w-2xl">
             <h3 className="text-xl font-bold mb-6">플레이스 수정</h3>
             <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">카테고리</label>
-                    <select 
-                        name="category" 
-                        value={form.category || ''} 
-                        onChange={handleChange} 
+                    <select
+                        name="category"
+                        value={form.category || ''}
+                        onChange={handleChange}
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
                     >
                         {filteredCategories.map(([key, value]) => (
@@ -139,106 +162,83 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">플레이스명</label>
-                    <input 
-                        name="title" 
-                        type="text" 
-                        value={form.title || ''} 
-                        onChange={handleChange} 
-                        placeholder="플레이스 이름을 입력해주세요." 
-                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    <input
+                        name="title"
+                        type="text"
+                        value={form.title || ''}
+                        onChange={handleChange}
+                        placeholder="플레이스 이름을 입력해주세요."
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                     />
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">설명</label>
-                    <textarea 
-                        name="description" 
-                        value={form.description || ''} 
-                        onChange={handleChange} 
-                        rows="3" 
-                        placeholder="플레이스에 대한 상세 설명을 입력해주세요." 
-                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    <textarea
+                        name="description"
+                        value={form.description || ''}
+                        onChange={handleChange}
+                        rows="3"
+                        placeholder="플레이스에 대한 상세 설명을 입력해주세요."
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                     />
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">위치</label>
-                    <input 
-                        name="location" 
-                        type="text" 
-                        value={form.location || ''} 
-                        onChange={handleChange} 
-                        placeholder="예: 학생회관 앞" 
-                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    <input
+                        name="location"
+                        type="text"
+                        value={form.location || ''}
+                        onChange={handleChange}
+                        placeholder="예: 학생회관 앞"
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                     />
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">운영 주체</label>
-                    <input 
-                        name="host" 
-                        type="text" 
-                        value={form.host || ''} 
-                        onChange={handleChange} 
-                        placeholder="예: 컴퓨터공학과 학생회" 
-                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    <input
+                        name="host"
+                        type="text"
+                        value={form.host || ''}
+                        onChange={handleChange}
+                        placeholder="예: 컴퓨터공학과 학생회"
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                     />
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">운영 시작 시간</label>
-                        <input 
-                            name="startTime" 
-                            type="time" 
-                            value={form.startTime || ''} 
-                            onChange={handleChange} 
-                            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                        <input
+                            name="startTime"
+                            type="time"
+                            value={form.startTime || ''}
+                            onChange={handleChange}
+                            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                         />
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">운영 종료 시간</label>
-                        <input 
-                            name="endTime" 
-                            type="time" 
-                            value={form.endTime || ''} 
-                            onChange={handleChange} 
-                            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                        <input
+                            name="endTime"
+                            type="time"
+                            value={form.endTime || ''}
+                            onChange={handleChange}
+                            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
                         />
                     </div>
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700">사진 (클릭하여 대표 사진 변경)</label>
                     <div className="mt-2 grid grid-cols-3 gap-4">
-                       {form.images && form.images.map((img, index) => (
-                           <div key={index} className="relative cursor-pointer" onClick={() => handleSetMainImage(index)}>
-                               <img src={img} alt={`booth-${index}`} className={`w-full h-24 object-cover rounded-md border-2 ${form.mainImageIndex === index ? 'border-blue-500' : 'border-transparent'}`}/>
-                               {form.mainImageIndex === index && <span className="main-image-indicator">대표</span>}
-                           </div>
-                       ))}
-                    </div>
-                    <input type="file" accept="image/*" multiple onChange={handlePhotoChange} className="mt-2 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"/>
-                </div>
-                 <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">개별 공지사항</label>
-                    <ul className="mt-2 space-y-1">
-                        {form.notices && form.notices.map(notice => (
-                            <li key={notice.id} className="flex justify-between items-center text-sm bg-gray-100 p-2 rounded-md">
-                                {editingNotice.id === notice.id ? (
-                                    <>
-                                        <input type="text" value={editingNotice.text} onChange={(e) => setEditingNotice(prev => ({...prev, text: e.target.value}))} className="flex-1 block w-full border border-gray-300 rounded-md shadow-sm py-1 px-2 mr-2"/>
-                                        <div className="flex items-center space-x-3">
-                                            <button onClick={handleSaveNoticeEdit} className="text-green-600 hover:text-green-800"><i className="fas fa-check"></i></button>
-                                            <button onClick={handleCancelEditNotice} className="text-gray-500 hover:text-gray-700"><i className="fas fa-times"></i></button>
-                                            <button onClick={() => handleDeleteNotice(notice.id, notice.text)} className="text-red-500 hover:text-red-700"><i className="fas fa-trash"></i></button>
-                                        </div>
-                                    </>
-                                ) : (
-                                    <>
-                                        <span>{notice.text}</span>
-                                        <div className="space-x-3">
-                                            <button onClick={() => handleStartEditNotice(notice)} className="text-blue-600 hover:text-blue-800 text-sm">수정</button>
-                                        </div>
-                                    </>
-                                )}
-                            </li>
+                        {form.placeImages && form.placeImages.map((img, index) => (
+                            renderImage(form.placeImages[0].id, form.title, img, index)
                         ))}
+                    </div>
+                    <input type="file" accept="image/*" multiple onChange={handlePhotoChange} className="mt-2 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">개별 공지사항</label>
+                    <ul className="list-disc list-inside text-sm mt-2 space-y-1">
+                        {form.placeAnnouncements.map(announcement => renderAnnouncement(announcement))}
                     </ul>
                 </div>
             </div>
@@ -256,21 +256,21 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
 const BoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
     const isEditMode = !!booth;
     console.log(booth, isEditMode);
-    
+
     if (isEditMode) {
         return (
-            <EditBoothModal 
-                booth={booth} 
-                onSave={onSave} 
-                onClose={onClose} 
-                isMainPlace={isMainPlace} 
+            <EditBoothModal
+                booth={booth}
+                onSave={onSave}
+                onClose={onClose}
+                isMainPlace={isMainPlace}
             />
         );
     } else {
         return (
-            <CreateBoothModal 
-                onSave={onSave} 
-                onClose={onClose} 
+            <CreateBoothModal
+                onSave={onSave}
+                onClose={onClose}
             />
         );
     }

--- a/frontend/src/components/modals/BoothModal.jsx
+++ b/frontend/src/components/modals/BoothModal.jsx
@@ -138,16 +138,30 @@ const EditBoothModal = ({ booth, onSave, onClose, isMainPlace }) => {
     // 이미지 렌더링
     const renderImage = (mainIdx, title, image, idx) => {
         const alt = `${title} ${idx + 1}`;
-        // 대표 이미지 여부 판단, 예: mainImageIndex === idx 혹은 image.id === mainImageId
-        const isMainImage = (idx === mainIdx);
+        const isMainImage = (image.id === mainIdx);
+        const defaultImage = 'https://image.tmdb.org/t/p/w1280/ndDYIa9VXFbWpC2pWj9j5OaZsfE.jpg';
+
+        const src = image.imageUrl && image.imageUrl.trim() !== '' ? image.imageUrl : defaultImage;
+
+        const handleImgError = (e) => {
+            console.log(e)
+            e.target.onerror = null; // 무한 루프 방지
+            e.target.src = defaultImage;
+        };
 
         return (
             <div key={image.id || idx} className="relative">
-                <img src={image.imageUrl} alt={alt} className="w-full h-24 object-cover rounded-md" />
+                <img
+                    src={src}
+                    alt={alt}
+                    className="w-full h-24 object-cover rounded-md"
+                    onError={handleImgError}
+                />
                 {isMainImage && <span className="main-image-indicator">대표</span>}
             </div>
         );
     };
+
 
     const renderAnnouncement = (announcement) => {
         let content = announcement.content;

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -43,7 +43,7 @@ const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast
             </div>
             <div className="flex items-center gap-4 justify-end mt-2">
                 <button onClick={() => openModal('copyLink', { link: `https://example.com/edit?key=${newBooth.editKey}` })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
-                <button onClick={() => openModal('booth', { newBooth, onSave: handleSave, isMainPlace: isMainPlace(newBooth.category) })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
+                <button onClick={() => openModal('booth', { booth: newBooth, onSave: handleSave, isMainPlace: isMainPlace })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
                 <button onClick={() => openDeleteModal(newBooth)}
                     className="text-red-600 hover:text-red-800 text-sm font-semibold">삭제</button>
             </div>

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -2,77 +2,38 @@ import React, { useState, useEffect } from 'react';
 import { useModal } from '../hooks/useModal';
 import { placeCategories } from '../constants/categories';
 import api from '../utils/api';
+import { isMainPlace, getDefaultValueIfNull, defaultBooth } from '../utils/booth';
 
-const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast, updateBooth }) => {
+const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast, updateBooth, isMainPlace }) => {
 
-    const defaultBooth = (booth) => {
-        return {
-            id: booth.id,
-            category: booth.category,
-            placeImages: booth.placeImages,
-            placeAnnouncements: booth.placeAnnouncements,
-
-            title: getDefaultValueIfNull('플레이스 이름을 지정하여 주십시오.', booth.title),
-            description: getDefaultValueIfNull('플레이스 설명이 아직 없습니다.', booth.description),
-            startTime: getDefaultValueIfNull('00:00', booth.startTime),
-            endTime: getDefaultValueIfNull('00:00', booth.endTime),
-            location: getDefaultValueIfNull('미지정', booth.location),
-            host: getDefaultValueIfNull('미지정', booth.host),
-        }
-    }
-
-    const getDefaultValueIfNull = (defaultValue, nullableValue) => {
-        return nullableValue === null ? defaultValue : nullableValue;
-    }
-
-    React.useEffect(() => {
-        if (
-            booth.title === null ||
-            booth.description === null ||
-            booth.startTime === null ||
-            booth.endTime === null ||
-            booth.location === null ||
-            booth.host === null
-        ) {
-            const newBooth = defaultBooth(booth);
-            updateBooth(newBooth.id, newBooth);
-        }
-    }, [
-        booth.id,
-        booth.title,
-        booth.description,
-        booth.startTime,
-        booth.endTime,
-        booth.location,
-        booth.host,
-        updateBooth
-    ]);
+    const newBooth = defaultBooth(booth);
+    console.log(newBooth);
 
     return (
         <div className="p-6 bg-gray-50">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="md:col-span-2">
                     <h4 className="font-semibold text-lg mb-2">상세 정보</h4>
-                    <p className="text-gray-700 whitespace-pre-wrap mb-4">{booth.description}</p>
+                    <p className="text-gray-700 whitespace-pre-wrap mb-4">{newBooth.description}</p>
                     <div className="text-sm text-gray-600 space-y-1">
-                        <p><i className="fas fa-map-marker-alt w-4 mr-2"></i>위치: {booth.location}</p>
-                        <p><i className="fas fa-user-friends w-4 mr-2"></i>운영 주체: {booth.host}</p>
-                        <p><i className="fas fa-clock w-4 mr-2"></i>운영 시간: {booth.startTime} - {booth.endTime}</p>
+                        <p><i className="fas fa-map-marker-alt w-4 mr-2"></i>위치: {newBooth.location}</p>
+                        <p><i className="fas fa-user-friends w-4 mr-2"></i>운영 주체: {newBooth.host}</p>
+                        <p><i className="fas fa-clock w-4 mr-2"></i>운영 시간: {newBooth.startTime} - {newBooth.endTime}</p>
                     </div>
                     <h4 className="font-semibold text-lg mt-4 mb-2">공지사항</h4>
-                    {booth.notices && booth.notices.length > 0 ? (
+                    {newBooth.notices && newBooth.notices.length > 0 ? (
                         <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
-                            {booth.notices.map(notice => <li key={notice.id}>{notice.text}</li>)}
+                            {newBooth.notices.map(notice => <li key={notice.id}>{notice.text}</li>)}
                         </ul>
                     ) : <p className="text-sm text-gray-500">공지사항 없음</p>}
                 </div>
                 <div>
                     <h4 className="font-semibold text-lg mb-2">사진</h4>
                     <div className="grid grid-cols-2 gap-2 mb-10">
-                        {booth.images && booth.images.length > 0 ? booth.images.map((img, index) => (
+                        {newBooth.images && newBooth.images.length > 0 ? newBooth.images.map((img, index) => (
                             <div key={index} className="relative">
-                                <img src={img} alt={`${booth.title} ${index + 1}`} className="w-full h-24 object-cover rounded-md" />
-                                {index === booth.mainImageIndex && <span className="main-image-indicator">대표</span>}
+                                <img src={img} alt={`${newBooth.title} ${index + 1}`} className="w-full h-24 object-cover rounded-md" />
+                                {index === newBooth.mainImageIndex && <span className="main-image-indicator">대표</span>}
                             </div>
                         )) : (
                             <p className="text-sm text-gray-500">사진 없음</p>
@@ -81,9 +42,9 @@ const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast
                 </div>
             </div>
             <div className="flex items-center gap-4 justify-end mt-2">
-                <button onClick={() => openModal('copyLink', { link: `https://example.com/edit?key=${booth.editKey}` })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
-                <button onClick={() => openModal('booth', { booth, onSave: handleSave })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
-                <button onClick={() => openDeleteModal(booth)}
+                <button onClick={() => openModal('copyLink', { link: `https://example.com/edit?key=${newBooth.editKey}` })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
+                <button onClick={() => openModal('booth', { newBooth, onSave: handleSave, isMainPlace: isMainPlace(newBooth.category) })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
+                <button onClick={() => openDeleteModal(newBooth)}
                     className="text-red-600 hover:text-red-800 text-sm font-semibold">삭제</button>
             </div>
         </div>
@@ -95,24 +56,6 @@ const BoothsPage = () => {
     const [booths, setBooths] = useState([]);
     const [expandedIds, setExpandedIds] = useState([]);
     const [loading, setLoading] = useState(false);
-
-    // defaultBooth 메서드 (유저가 만든 것 사용)
-    const getDefaultValueIfNull = (defaultValue, nullableValue) => nullableValue === null ? defaultValue : nullableValue;
-    const defaultBooth = (booth) => ({
-        id: booth.id,
-        category: booth.category,
-        placeImages: booth.placeImages,
-        placeAnnouncements: booth.placeAnnouncements,
-        // 흡연구역, 쓰레기통은 title을 category명으로 세팅
-        title: ['SMOKING', 'TRASH_CAN'].includes(booth.category)
-            ? placeCategories[booth.category]
-            : getDefaultValueIfNull('플레이스 이름을 지정하여 주십시오.', booth.title),
-        description: getDefaultValueIfNull('플레이스 설명이 아직 없습니다.', booth.description),
-        startTime: getDefaultValueIfNull('00:00', booth.startTime),
-        endTime: getDefaultValueIfNull('00:00', booth.endTime),
-        location: getDefaultValueIfNull('미지정', booth.location),
-        host: getDefaultValueIfNull('미지정', booth.host),
-    });
 
     // 1. Booth 목록 불러오기
     useEffect(() => {
@@ -199,10 +142,6 @@ const BoothsPage = () => {
         showToast('플레이스 정보가 수정되었습니다.');
     };
 
-    const isMainPlace = (category) => {
-        return !['SMOKING', 'TRASH_CAN'].includes(category);
-    }
-
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
@@ -256,6 +195,7 @@ const BoothsPage = () => {
                                                                 openModal={openModal}
                                                                 handleSave={handleSave}
                                                                 showToast={showToast}
+                                                                isMainPlace={isMainPlace}
                                                                 updateBooth={(id, data) => setBooths(prev => prev.map(b => b.id === id ? { ...b, ...data } : b))}
                                                             />
                                                         )}

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -80,7 +80,7 @@ const BoothsPage = () => {
     const [expandedIds, setExpandedIds] = useState([]);
     const [loading, setLoading] = useState(false);
 
-    // 1. Booth 목록 불러오기
+    // Booth 목록 불러오기 및 수정이 발생하면 재렌더링 useEffect
     useEffect(() => {
         setLoading(true);
         api.get('/places')
@@ -99,7 +99,7 @@ const BoothsPage = () => {
         );
     };
 
-    // 2. Booth 생성
+    // Booth 생성 api 요청
     const handleCreate = async (data) => {
         if (!data.category) { showToast('카테고리는 필수 항목입니다.'); return; }
         try {
@@ -120,7 +120,7 @@ const BoothsPage = () => {
         }
     };
 
-    // 3. Booth 삭제
+    // Booth 삭제 api 요청
     const handleDelete = async (id) => {
         try {
             setLoading(true);
@@ -139,6 +139,7 @@ const BoothsPage = () => {
         }
     };
 
+    // 플레이스를 삭제하는 Modal 렌더링
     const openDeleteModal = (booth) => {
         openModal('confirm', {
             title: '플레이스 삭제 확인',
@@ -230,7 +231,6 @@ const BoothsPage = () => {
                             </tbody>
                         </table>
                     </div>
-
 
                     <div className='text-xl font-bold ml-1 mt-10 mb-2'>
                         기타 플레이스

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -33,13 +33,28 @@ const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, isMainPla
     const renderImage = (mainIdx, title, image, idx) => {
         const alt = `${title} ${idx + 1}`;
         const isMainImage = (image.id === mainIdx);
+        const defaultImage = 'https://image.tmdb.org/t/p/w1280/ndDYIa9VXFbWpC2pWj9j5OaZsfE.jpg';
 
+        const src = image.imageUrl && image.imageUrl.trim() !== '' ? image.imageUrl : defaultImage;
 
-        return <div key={image.imageUrl} className="relative">
-            <img src={image.imageUrl} alt={alt} className="w-full h-24 object-cover rounded-md" />
-            {isMainImage && <span className="main-image-indicator">대표</span>}
-        </div>
-    }
+        const handleImgError = (e) => {
+            console.log(e)
+            e.target.onerror = null; // 무한 루프 방지
+            e.target.src = defaultImage;
+        };
+
+        return (
+            <div key={image.id || idx} className="relative">
+                <img
+                    src={src}
+                    alt={alt}
+                    className="w-full h-24 object-cover rounded-md"
+                    onError={handleImgError}
+                />
+                {isMainImage && <span className="main-image-indicator">대표</span>}
+            </div>
+        );
+    };
 
     return (
         <div className="p-6 bg-gray-50">

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -7,12 +7,35 @@ import { isMainPlace, getDefaultValueIfNull, defaultBooth } from '../utils/booth
 const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast, updateBooth, isMainPlace }) => {
 
     const newBooth = defaultBooth(booth);
-    console.log(newBooth);
+
+    const renderAnnouncement = (announcement) => {
+        // const maxTitle = 20;
+        let content = announcement.content;
+
+        // TODO 글자수 제한을 두려면 수정할 것
+        // if (announcement.content.length > maxTitle) {
+        //     content = announcement.content.substring(0, maxTitle);
+        // }
+
+        return <li key={announcement.id}>{announcement.title} - {content}</li>
+    }
+
+    const renderImage = (mainIdx, title, image, idx) => {
+        const alt = `${title} ${idx + 1}`;
+        const isMainImage = (image.id === mainIdx);
+
+
+        return <div key={image.imageUrl} className="relative">
+            <img src={image.imageUrl} alt={alt} className="w-full h-24 object-cover rounded-md" />
+            {isMainImage && <span className="main-image-indicator">대표</span>}
+        </div>
+    }
 
     return (
         <div className="p-6 bg-gray-50">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="md:col-span-2">
+
                     <h4 className="font-semibold text-lg mb-2">상세 정보</h4>
                     <p className="text-gray-700 whitespace-pre-wrap mb-4">{newBooth.description}</p>
                     <div className="text-sm text-gray-600 space-y-1">
@@ -20,24 +43,24 @@ const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast
                         <p><i className="fas fa-user-friends w-4 mr-2"></i>운영 주체: {newBooth.host}</p>
                         <p><i className="fas fa-clock w-4 mr-2"></i>운영 시간: {newBooth.startTime} - {newBooth.endTime}</p>
                     </div>
+
                     <h4 className="font-semibold text-lg mt-4 mb-2">공지사항</h4>
-                    {newBooth.notices && newBooth.notices.length > 0 ? (
+                    {newBooth.placeAnnouncements && newBooth.placeAnnouncements.length > 0 ? (
                         <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
-                            {newBooth.notices.map(notice => <li key={notice.id}>{notice.text}</li>)}
+                            {newBooth.placeAnnouncements.map(announcement => renderAnnouncement(announcement))}
                         </ul>
                     ) : <p className="text-sm text-gray-500">공지사항 없음</p>}
                 </div>
                 <div>
+
                     <h4 className="font-semibold text-lg mb-2">사진</h4>
                     <div className="grid grid-cols-2 gap-2 mb-10">
-                        {newBooth.images && newBooth.images.length > 0 ? newBooth.images.map((img, index) => (
-                            <div key={index} className="relative">
-                                <img src={img} alt={`${newBooth.title} ${index + 1}`} className="w-full h-24 object-cover rounded-md" />
-                                {index === newBooth.mainImageIndex && <span className="main-image-indicator">대표</span>}
-                            </div>
+                        {newBooth.placeImages && newBooth.placeImages.length > 0 ? newBooth.placeImages.map((image, idx) => (
+                            renderImage(newBooth.placeImages[0].id, newBooth.title, image, idx)
                         )) : (
                             <p className="text-sm text-gray-500">사진 없음</p>
                         )}
+
                     </div>
                 </div>
             </div>
@@ -122,7 +145,7 @@ const BoothsPage = () => {
             message: (
                 <>
                     {booth.title} 플레이스를 정말 삭제하시겠습니까?
-                    <br /> 
+                    <br />
                     <div className="font-bold text-red-500 text-xs">
                         플레이스의 즐겨찾기 정보, 이미지, 세부 정보, 세부 공지사항도 모두 삭제됩니다.
                     </div>

--- a/frontend/src/pages/BoothsPage.jsx
+++ b/frontend/src/pages/BoothsPage.jsx
@@ -4,9 +4,19 @@ import { placeCategories } from '../constants/categories';
 import api from '../utils/api';
 import { isMainPlace, getDefaultValueIfNull, defaultBooth } from '../utils/booth';
 
-const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast, updateBooth, isMainPlace }) => {
+// 플레이스 상세 정보
+const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, isMainPlace }) => {
 
     const newBooth = defaultBooth(booth);
+
+    const title = newBooth.title;
+    const startTime = newBooth.startTime;
+    const endTime = newBooth.endTime;
+    const location = newBooth.location;
+    const host = newBooth.host;
+    const description = newBooth.description;
+    const placeAnnouncements = newBooth.placeAnnouncements;
+    const placeImages = newBooth.placeImages;
 
     const renderAnnouncement = (announcement) => {
         // const maxTitle = 20;
@@ -37,17 +47,17 @@ const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast
                 <div className="md:col-span-2">
 
                     <h4 className="font-semibold text-lg mb-2">상세 정보</h4>
-                    <p className="text-gray-700 whitespace-pre-wrap mb-4">{newBooth.description}</p>
+                    <p className="text-gray-700 whitespace-pre-wrap mb-4">{description}</p>
                     <div className="text-sm text-gray-600 space-y-1">
-                        <p><i className="fas fa-map-marker-alt w-4 mr-2"></i>위치: {newBooth.location}</p>
-                        <p><i className="fas fa-user-friends w-4 mr-2"></i>운영 주체: {newBooth.host}</p>
-                        <p><i className="fas fa-clock w-4 mr-2"></i>운영 시간: {newBooth.startTime} - {newBooth.endTime}</p>
+                        <p><i className="fas fa-map-marker-alt w-4 mr-2"></i>위치: {location}</p>
+                        <p><i className="fas fa-user-friends w-4 mr-2"></i>운영 주체: {host}</p>
+                        <p><i className="fas fa-clock w-4 mr-2"></i>운영 시간: {startTime} - {endTime}</p>
                     </div>
 
                     <h4 className="font-semibold text-lg mt-4 mb-2">공지사항</h4>
-                    {newBooth.placeAnnouncements && newBooth.placeAnnouncements.length > 0 ? (
+                    {placeAnnouncements && placeAnnouncements.length > 0 ? (
                         <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
-                            {newBooth.placeAnnouncements.map(announcement => renderAnnouncement(announcement))}
+                            {placeAnnouncements.map(announcement => renderAnnouncement(announcement))}
                         </ul>
                     ) : <p className="text-sm text-gray-500">공지사항 없음</p>}
                 </div>
@@ -55,17 +65,18 @@ const BoothDetails = ({ booth, openModal, handleSave, openDeleteModal, showToast
 
                     <h4 className="font-semibold text-lg mb-2">사진</h4>
                     <div className="grid grid-cols-2 gap-2 mb-10">
-                        {newBooth.placeImages && newBooth.placeImages.length > 0 ? newBooth.placeImages.map((image, idx) => (
-                            renderImage(newBooth.placeImages[0].id, newBooth.title, image, idx)
-                        )) : (
-                            <p className="text-sm text-gray-500">사진 없음</p>
-                        )}
-
+                        {placeImages && placeImages.length > 0 ?
+                            placeImages.map((image, idx) => (renderImage(placeImages[0].id, title, image, idx)))
+                            : (<p className="text-sm text-gray-500">사진 없음</p>)}
                     </div>
                 </div>
             </div>
             <div className="flex items-center gap-4 justify-end mt-2">
-                <button onClick={() => openModal('copyLink', { link: `https://example.com/edit?key=${newBooth.editKey}` })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
+
+                <button onClick={() => openModal('copyLink', {
+                    // 이 링크는 부스 운영자가 받을 링크임
+                    link: `https://example.com/edit?key=${newBooth.editKey}`
+                })} className="text-green-600 hover:text-green-800 text-sm font-semibold">권한 링크 복사</button>
                 <button onClick={() => openModal('booth', { booth: newBooth, onSave: handleSave, isMainPlace: isMainPlace })} className="text-blue-600 hover:text-blue-800 text-sm font-semibold">수정</button>
                 <button onClick={() => openDeleteModal(newBooth)}
                     className="text-red-600 hover:text-red-800 text-sm font-semibold">삭제</button>
@@ -218,7 +229,6 @@ const BoothsPage = () => {
                                                                 openDeleteModal={openDeleteModal}
                                                                 openModal={openModal}
                                                                 handleSave={handleSave}
-                                                                showToast={showToast}
                                                                 isMainPlace={isMainPlace}
                                                                 updateBooth={(id, data) => setBooths(prev => prev.map(b => b.id === id ? { ...b, ...data } : b))}
                                                             />

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -2,6 +2,7 @@
 import axios from 'axios';
 
 const API_HOST = 'http://festabook.woowacourse.com';
+// const API_HOST = 'http://localhost:8080';
 
 const api = axios.create({
   baseURL: API_HOST,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,8 +1,8 @@
 // src/utils/api.js
 import axios from 'axios';
 
-const API_HOST = 'http://festabook.woowacourse.com';
-// const API_HOST = 'http://localhost:8080';
+// const API_HOST = 'http://festabook.woowacourse.com';
+const API_HOST = 'http://localhost:8080';
 
 const api = axios.create({
   baseURL: API_HOST,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,8 +1,7 @@
 // src/utils/api.js
 import axios from 'axios';
 
-// const API_HOST = 'http://festabook.woowacourse.com';
-const API_HOST = 'http://localhost:8080';
+const API_HOST = 'http://festabook.woowacourse.com';
 
 const api = axios.create({
   baseURL: API_HOST,

--- a/frontend/src/utils/booth.js
+++ b/frontend/src/utils/booth.js
@@ -1,0 +1,47 @@
+import { placeCategories } from '../constants/categories';
+
+/**
+ * booth 관련 유틸리티 함수들
+ */
+
+/**
+ * 카테고리가 메인 플레이스인지 확인
+ * @param {string} category - 플레이스 카테고리
+ * @returns {boolean} - 메인 플레이스 여부
+ */
+export const isMainPlace = (category) => {
+    return !['SMOKING', 'TRASH_CAN'].includes(category);
+};
+
+/**
+ * 기본값이 null인 경우 기본값을 반환
+ * @param {string} defaultValue - 기본값
+ * @param {*} nullableValue - null일 수 있는 값
+ * @returns {string} - 기본값 또는 원래 값
+ */
+export const getDefaultValueIfNull = (defaultValue, nullableValue) => {
+    return nullableValue === null ? defaultValue : nullableValue;
+};
+
+/**
+ * booth 객체에 기본값 적용
+ * @param {Object} booth - booth 객체
+ * @returns {Object} - 기본값이 적용된 booth 객체
+ */
+export const defaultBooth = (booth) => {
+    return {
+        id: booth.id,
+        category: booth.category,
+        placeImages: booth.placeImages,
+        placeAnnouncements: booth.placeAnnouncements,
+        // 흡연구역, 쓰레기통은 title을 category명으로 세팅
+        title: ['SMOKING', 'TRASH_CAN'].includes(booth.category)
+            ? placeCategories[booth.category]
+            : getDefaultValueIfNull('플레이스 이름을 지정하여 주십시오.', booth.title),
+        description: getDefaultValueIfNull('플레이스 설명이 아직 없습니다.', booth.description),
+        startTime: getDefaultValueIfNull('00:00', booth.startTime),
+        endTime: getDefaultValueIfNull('00:00', booth.endTime),
+        location: getDefaultValueIfNull('미지정', booth.location),
+        host: getDefaultValueIfNull('미지정', booth.host),
+    };
+}; 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#195 

<br>

## 🛠️ 작업 내용

- 학생회 페이지에 공지와 이미지가 출력되지 않던 버그 수정
- 학생회 페이지 컴포넌트 내의 로직 함수로 추출

<br>

## 📸 이미지 첨부 (Optional)

<img width="1106" height="1003" alt="image" src="https://github.com/user-attachments/assets/cf7a3591-e77e-4142-9763-b7c11f56de7c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 부스 생성 및 편집 모달이 각각 별도의 화면으로 분리되어, 생성 시 간단한 카테고리 선택만 필요하며, 편집 시에는 부스의 세부 정보를 더욱 상세하게 수정할 수 있습니다.
  * 이미지 업로드가 파일 선택 후 서버로 전송되는 방식으로 개선되었습니다.

* **버그 수정**
  * 이미지 표시 및 로딩 오류 시 대체 이미지가 제공되어 사용자 경험이 향상되었습니다.

* **리팩터링**
  * 부스 정보의 기본값 처리 및 주요 장소 구분 로직이 유틸리티 함수로 통합되어 코드 일관성이 높아졌습니다.
  * 중복 코드가 제거되고, 부스 데이터의 처리 및 화면 렌더링이 더욱 체계적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->