### PR TITLE
[BE] 이미지 저장 로직 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/SwaggerConfig.java
@@ -22,6 +22,7 @@ public class SwaggerConfig {
     private static final String ORGANIZATION_SCHEME_NAME = "조직(Organization) ID 값";
     private static final List<String[]> API_GROUPS = List.of(
             new String[]{"전체", "/**"},
+            new String[]{"이미지", "/images/**"},
             new String[]{"일정 API", "/event-dates/**"},
             new String[]{"플레이스 API", "/places/**"},
             new String[]{"공지 API", "/announcements/**"},

--- a/backend/src/main/java/com/daedan/festabook/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/SwaggerConfig.java
@@ -22,7 +22,7 @@ public class SwaggerConfig {
     private static final String ORGANIZATION_SCHEME_NAME = "조직(Organization) ID 값";
     private static final List<String[]> API_GROUPS = List.of(
             new String[]{"전체", "/**"},
-            new String[]{"이미지", "/images/**"},
+            new String[]{"이미지 API", "/images/**"},
             new String[]{"일정 API", "/event-dates/**"},
             new String[]{"플레이스 API", "/places/**"},
             new String[]{"공지 API", "/announcements/**"},

--- a/backend/src/main/java/com/daedan/festabook/image/controller/ImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/image/controller/ImageController.java
@@ -1,0 +1,37 @@
+package com.daedan.festabook.image.controller;
+
+import com.daedan.festabook.image.dto.ImageResponse;
+import com.daedan.festabook.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+@Tag(name = "이미지", description = "이미지 관련 API")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "특정 플레이스의 이미지 생성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+    })
+    public ImageResponse createPlaceImage(
+            @RequestParam MultipartFile image
+    ) {
+        return imageService.uploadImage(image);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/image/domain/ImageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/image/domain/ImageManager.java
@@ -1,0 +1,8 @@
+package com.daedan.festabook.image.domain;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageManager {
+
+    String upload(MultipartFile image);
+}

--- a/backend/src/main/java/com/daedan/festabook/image/dto/ImageResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/image/dto/ImageResponse.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.image.dto;
+
+public record ImageResponse(
+        String imageUrl
+) {
+
+    public static ImageResponse from(String imageUrl) {
+        return new ImageResponse(imageUrl);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/image/infrastructure/StubImageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/image/infrastructure/StubImageManager.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.image.infrastructure;
+
+import com.daedan.festabook.image.domain.ImageManager;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class StubImageManager implements ImageManager {
+
+    private static final String STUB_IMAGE_URL = "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/480D221274460.jpg";
+
+    @Override
+    public String upload(MultipartFile image) {
+        return STUB_IMAGE_URL;
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/image/service/ImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/image/service/ImageService.java
@@ -1,0 +1,19 @@
+package com.daedan.festabook.image.service;
+
+import com.daedan.festabook.image.domain.ImageManager;
+import com.daedan.festabook.image.dto.ImageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageManager imageManager;
+
+    public ImageResponse uploadImage(MultipartFile image) {
+        String imageUrl = imageManager.upload(image);
+        return ImageResponse.from(imageUrl);
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/image/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/image/controller/ImageControllerTest.java
@@ -53,7 +53,6 @@ class ImageControllerTest {
             RestAssured
                     .given()
                     .multiPart(multipartName, fileName, imageByteValue, mimeType)
-                    .body(imageByteValue)
                     .post("/images")
                     .then()
                     .statusCode(HttpStatus.CREATED.value())

--- a/backend/src/test/java/com/daedan/festabook/image/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/image/controller/ImageControllerTest.java
@@ -1,0 +1,76 @@
+package com.daedan.festabook.image.controller;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.daedan.festabook.image.domain.ImageManager;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ImageControllerTest {
+
+    @MockitoBean
+    private ImageManager imageManager;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class createPlaceImage {
+
+        @Test
+        void 성공() {
+            // given
+            byte[] imageByteValue = "테스트용 이미지 바이트".getBytes();
+            String mimeType = "image/jpeg";
+            String fileName = "fake-image.jpg";
+            String multipartName = "image";
+
+            int expectedFiledSize = 1;
+            String expectedImageUrl = "https://example.org/image/1298301849012840";
+
+            given(imageManager.upload(any()))
+                    .willReturn(expectedImageUrl);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .multiPart(multipartName, fileName, imageByteValue, mimeType)
+                    .body(imageByteValue)
+                    .post("/images")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("size()", equalTo(expectedFiledSize))
+                    .body("imageUrl", equalTo(expectedImageUrl));
+        }
+    }
+
+    // TODO: 실제 구현체 생기면 제거할 것
+    @Component
+    static class MockImageManager implements ImageManager {
+
+        @Override
+        public String upload(MultipartFile image) {
+            return "";
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/image/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/image/controller/ImageControllerTest.java
@@ -15,9 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -61,16 +59,6 @@ class ImageControllerTest {
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFiledSize))
                     .body("imageUrl", equalTo(expectedImageUrl));
-        }
-    }
-
-    // TODO: 실제 구현체 생기면 제거할 것
-    @Component
-    static class MockImageManager implements ImageManager {
-
-        @Override
-        public String upload(MultipartFile image) {
-            return "";
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/image/service/ImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/image/service/ImageServiceTest.java
@@ -1,0 +1,50 @@
+package com.daedan.festabook.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.daedan.festabook.image.domain.ImageManager;
+import com.daedan.festabook.image.dto.ImageResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ImageServiceTest {
+
+    @Mock
+    private ImageManager imageManager;
+
+    @InjectMocks
+    private ImageService imageService;
+
+    @Nested
+    class uploadImage {
+
+        @Test
+        void 성공() {
+            // given
+            String imageName = "비타민";
+            byte[] imageByteValue = {};
+            MockMultipartFile image = new MockMultipartFile(imageName, imageByteValue);
+
+            String imageUrl = "https://example.org/image/48329082390482309";
+
+            given(imageManager.upload(image))
+                    .willReturn(imageUrl);
+
+            // when
+            ImageResponse imageResponse = imageService.uploadImage(image);
+
+            // then
+            assertThat(imageResponse.imageUrl()).isEqualTo(imageUrl);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

#193 

<br>

## 🛠️ 작업 내용

- 이미지 저장 api 구현

<br>

## 📸 이미지 첨부 (Optional)

<img width="967" height="136" alt="image" src="https://github.com/user-attachments/assets/8ac6e3c9-15f6-4097-8804-938b10a035cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미지 업로드 API가 추가되어, 사용자가 이미지를 업로드할 수 있습니다.
  * Swagger 문서에 이미지 관련 API 그룹이 별도로 표시됩니다.

* **테스트**
  * 이미지 업로드 기능에 대한 컨트롤러 및 서비스 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->