### PR TITLE
[FE] 백엔드 서버 엔드포인트 연결

### DIFF
--- a/frontend/src/components/modals/ScheduleModal.jsx
+++ b/frontend/src/components/modals/ScheduleModal.jsx
@@ -5,7 +5,7 @@ const ScheduleModal = ({ event, onSave, onClose }) => {
     const [form, setForm] = useState({ title: '', startTime: '', endTime: '', location: '' });
     useEffect(() => { setForm(event || { title: '', startTime: '', endTime: '', location: '' }); }, [event]);
     const handleChange = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
-    const handleSave = () => { onSave(form); onClose(); };
+    const handleSave = () => { onSave(form, onClose); }; // onClose 콜백 전달
 
     return (
         <Modal isOpen={true} onClose={onClose}>

--- a/frontend/src/contexts/DataProvider.jsx
+++ b/frontend/src/contexts/DataProvider.jsx
@@ -1,13 +1,54 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { DataContext } from './DataContext';
 import { initialData } from '../data/initialData';
 import { getCurrentDate } from '../utils/date';
+import { scheduleAPI } from '../utils/api';
 
 export const DataProvider = ({ children }) => {
     const [data, setData] = useState(initialData);
+    const [eventDates, setEventDates] = useState([]); // 서버에서 가져온 축제 날짜들
+    const [isLoadingDates, setIsLoadingDates] = useState(false);
+    const [isLoadingEvents, setIsLoadingEvents] = useState(false);
+    
+    const fetchEventDates = async () => {
+        try {
+            setIsLoadingDates(true);
+            const dates = await scheduleAPI.getEventDates();
+            setEventDates(dates);
+            
+            // 서버 데이터를 기반으로 schedule 객체 재구성 (이벤트는 로드하지 않음)
+            const scheduleFromServer = {};
+            dates.forEach(dateObj => {
+                // undefined로 설정하여 실제 로드가 필요함을 표시
+                scheduleFromServer[dateObj.date] = undefined;
+            });
+            
+            setData(prev => ({
+                ...prev,
+                schedule: scheduleFromServer
+            }));
+        } catch (error) {
+            console.error('Failed to fetch event dates:', error);
+            // 초기 로드 실패 시 빈 배열로 설정
+            setEventDates([]);
+            setData(prev => ({
+                ...prev,
+                schedule: {}
+            }));
+        } finally {
+            setIsLoadingDates(false);
+        }
+    };
+    
+    // 컴포넌트 마운트 시 축제 날짜 목록 조회
+    useEffect(() => {
+        fetchEventDates();
+    }, []);
+
     const getNextId = (arr) => (arr.length > 0 ? Math.max(...arr.map(item => item.id)) + 1 : 1);
 
     const dataActions = {
+        // 기존 액션들
         addNotice: (notice) => setData(d => ({ ...d, notices: [{ id: getNextId(d.notices), ...notice, date: getCurrentDate(), pinned: false }, ...d.notices] })),
         updateNotice: (id, updated) => setData(d => ({ ...d, notices: d.notices.map(n => n.id === id ? { ...n, ...updated } : n) })),
         deleteNotice: (id) => setData(d => ({ ...d, notices: d.notices.filter(n => n.id !== id) })),
@@ -33,22 +74,221 @@ export const DataProvider = ({ children }) => {
         addQnaItem: (item) => setData(d => ({ ...d, qnaItems: [...d.qnaItems, { id: getNextId(d.qnaItems), ...item }] })),
         updateQnaItem: (id, updated) => setData(d => ({...d, qnaItems: d.qnaItems.map(q => q.id === id ? {...q, ...updated} : q)})),
         deleteQnaItem: (id) => setData(d => ({ ...d, qnaItems: d.qnaItems.filter(q => q.id !== id) })),
-        addScheduleDate: (date) => setData(d => ({ ...d, schedule: { ...d.schedule, [date]: [] } })),
-        addScheduleEvent: (date, event) => {
-            const allEvents = Object.values(data.schedule).flat();
-            const newEvent = { id: getNextId(allEvents), ...event, status: '예정' };
-            setData(d => ({ ...d, schedule: { ...d.schedule, [date]: [...(d.schedule[date] || []), newEvent] } }));
+        
+        // 서버 연동 축제 날짜 관리 액션들
+        addScheduleDate: async (date, showToast) => {
+            try {
+                setIsLoadingDates(true);
+                const updatedDates = await scheduleAPI.addEventDate(date);
+                setEventDates(updatedDates);
+                
+                // 새로 추가된 날짜를 schedule에 반영
+                const scheduleFromServer = {};
+                updatedDates.forEach(dateObj => {
+                    if (data.schedule[dateObj.date] !== undefined) {
+                        // 기존에 로드된 데이터가 있으면 유지
+                        scheduleFromServer[dateObj.date] = data.schedule[dateObj.date];
+                    } else {
+                        // 새로운 날짜는 undefined로 설정
+                        scheduleFromServer[dateObj.date] = undefined;
+                    }
+                });
+                
+                setData(prev => ({
+                    ...prev,
+                    schedule: scheduleFromServer
+                }));
+                
+                showToast('새로운 날짜가 추가되었습니다.');
+            } catch (error) {
+                console.error('Failed to add event date:', error);
+                showToast(error.message || '날짜 추가에 실패했습니다.');
+            } finally {
+                setIsLoadingDates(false);
+            }
         },
-        updateScheduleEvent: (date, id, updated) => setData(d => ({ ...d, schedule: { ...d.schedule, [date]: d.schedule[date].map(e => e.id === id ? { ...e, ...updated } : e) } })),
-        deleteScheduleEvent: (date, id) => setData(d => ({ ...d, schedule: { ...d.schedule, [date]: d.schedule[date].filter(e => e.id !== id) } })),
-        deleteScheduleDate: (date) => setData(d => {
-            const newSchedule = { ...d.schedule };
-            delete newSchedule[date];
-            return { ...d, schedule: newSchedule };
-        }),
+        
+        deleteScheduleDate: async (date, showToast) => {
+            try {
+                setIsLoadingDates(true);
+                // 날짜에 해당하는 eventDateId 찾기
+                const eventDateObj = eventDates.find(ed => ed.date === date);
+                if (!eventDateObj) {
+                    showToast('삭제할 날짜를 찾을 수 없습니다.');
+                    return;
+                }
+                
+                const updatedDates = await scheduleAPI.deleteEventDate(eventDateObj.id);
+                setEventDates(updatedDates);
+                
+                // 삭제된 날짜를 schedule에서 제거
+                const scheduleFromServer = {};
+                updatedDates.forEach(dateObj => {
+                    if (data.schedule[dateObj.date] !== undefined) {
+                        // 기존에 로드된 데이터가 있으면 유지
+                        scheduleFromServer[dateObj.date] = data.schedule[dateObj.date];
+                    } else {
+                        // 새로운 날짜는 undefined로 설정
+                        scheduleFromServer[dateObj.date] = undefined;
+                    }
+                });
+                
+                setData(prev => ({
+                    ...prev,
+                    schedule: scheduleFromServer
+                }));
+                
+                showToast('날짜가 삭제되었습니다.');
+            } catch (error) {
+                console.error('Failed to delete event date:', error);
+                showToast(error.message || '날짜 삭제에 실패했습니다.');
+            } finally {
+                setIsLoadingDates(false);
+            }
+        },
+        
+        // 기존 이벤트 관리 액션들 (서버 연동으로 변경)
+        loadEventsForDate: async (date, showToast) => {
+            console.log('loadEventsForDate called for:', date); // 디버깅용
+            try {
+                setIsLoadingEvents(true);
+                const eventDateObj = eventDates.find(ed => ed.date === date);
+                console.log('Found eventDateObj:', eventDateObj); // 디버깅용
+                if (!eventDateObj) return;
+                
+                const events = await scheduleAPI.getEventsByDateId(eventDateObj.id);
+                console.log('Loaded events:', events); // 디버깅용
+                
+                setData(prev => ({
+                    ...prev,
+                    schedule: {
+                        ...prev.schedule,
+                        [date]: events
+                    }
+                }));
+            } catch (error) {
+                console.error('Failed to load events:', error);
+                if (showToast) showToast(error.message || '일정 조회에 실패했습니다.');
+            } finally {
+                setIsLoadingEvents(false);
+            }
+        },
+
+        addScheduleEvent: async (date, eventData, showToast) => {
+            try {
+                setIsLoadingEvents(true);
+                const eventDateObj = eventDates.find(ed => ed.date === date);
+                if (!eventDateObj) {
+                    showToast('해당 날짜를 찾을 수 없습니다.');
+                    return;
+                }
+
+                const eventRequest = {
+                    startTime: eventData.startTime,
+                    endTime: eventData.endTime,
+                    title: eventData.title,
+                    location: eventData.location,
+                    eventDateId: eventDateObj.id
+                };
+
+                await scheduleAPI.createEvent(eventRequest);
+                
+                // 성공 후 해당 날짜의 일정 다시 조회
+                const events = await scheduleAPI.getEventsByDateId(eventDateObj.id);
+                setData(prev => ({
+                    ...prev,
+                    schedule: {
+                        ...prev.schedule,
+                        [date]: events
+                    }
+                }));
+                
+                showToast('새 이벤트가 추가되었습니다.');
+            } catch (error) {
+                console.error('Failed to add event:', error);
+                showToast(error.message || '일정 추가에 실패했습니다.');
+            } finally {
+                setIsLoadingEvents(false);
+            }
+        },
+        
+        updateScheduleEvent: async (date, eventId, eventData, showToast) => {
+            try {
+                setIsLoadingEvents(true);
+                const eventDateObj = eventDates.find(ed => ed.date === date);
+                if (!eventDateObj) {
+                    showToast('해당 날짜를 찾을 수 없습니다.');
+                    return;
+                }
+
+                const eventRequest = {
+                    startTime: eventData.startTime,
+                    endTime: eventData.endTime,
+                    title: eventData.title,
+                    location: eventData.location,
+                    eventDateId: eventDateObj.id
+                };
+
+                await scheduleAPI.updateEvent(eventId, eventRequest);
+                
+                // 성공 후 해당 날짜의 일정 다시 조회
+                const events = await scheduleAPI.getEventsByDateId(eventDateObj.id);
+                setData(prev => ({
+                    ...prev,
+                    schedule: {
+                        ...prev.schedule,
+                        [date]: events
+                    }
+                }));
+                
+                showToast('이벤트가 수정되었습니다.');
+            } catch (error) {
+                console.error('Failed to update event:', error);
+                showToast(error.message || '일정 수정에 실패했습니다.');
+            } finally {
+                setIsLoadingEvents(false);
+            }
+        },
+        
+        deleteScheduleEvent: async (date, eventId, showToast) => {
+            try {
+                setIsLoadingEvents(true);
+                const eventDateObj = eventDates.find(ed => ed.date === date);
+                if (!eventDateObj) {
+                    showToast('해당 날짜를 찾을 수 없습니다.');
+                    return;
+                }
+
+                await scheduleAPI.deleteEvent(eventId);
+                
+                // 성공 후 해당 날짜의 일정 다시 조회
+                const events = await scheduleAPI.getEventsByDateId(eventDateObj.id);
+                setData(prev => ({
+                    ...prev,
+                    schedule: {
+                        ...prev.schedule,
+                        [date]: events
+                    }
+                }));
+                
+                showToast('이벤트가 삭제되었습니다.');
+            } catch (error) {
+                console.error('Failed to delete event:', error);
+                showToast(error.message || '일정 삭제에 실패했습니다.');
+            } finally {
+                setIsLoadingEvents(false);
+            }
+        },
+        
         addBooth: (booth) => setData(d => ({ ...d, booths: [{ id: getNextId(d.booths), ...booth}, ...d.booths] })),
         updateBooth: (id, updated) => setData(d => ({ ...d, booths: d.booths.map(b => b.id === id ? { ...b, ...updated } : b) })),
         deleteBooth: (id) => setData(d => ({ ...d, booths: d.booths.filter(b => b.id !== id) })),
+        
+        // 새로운 상태 제공
+        fetchEventDates,
+        isLoadingDates,
+        isLoadingEvents,
+        eventDates
     };
 
     return <DataContext.Provider value={{ ...data, ...dataActions }}>{children}</DataContext.Provider>;

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -1,22 +1,39 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useData } from '../hooks/useData';
 import { useModal } from '../hooks/useModal';
 import { getCurrentDate } from '../utils/date';
 
 const SchedulePage = () => {
-    const { schedule, addScheduleDate, addScheduleEvent, updateScheduleEvent, deleteScheduleEvent, deleteScheduleDate } = useData();
+    const { schedule, addScheduleDate, addScheduleEvent, updateScheduleEvent, deleteScheduleEvent, deleteScheduleDate, isLoadingDates, isLoadingEvents, loadEventsForDate } = useData();
     const { openModal, showToast } = useModal();
     const [activeDate, setActiveDate] = useState(Object.keys(schedule).sort()[0] || null);
     const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
 
-    const handleSave = (eventData) => {
-        if (!eventData.title || !eventData.startTime || !eventData.endTime || !eventData.location) { showToast('제목, 시간, 장소는 필수 항목입니다.'); return; }
-        if (eventData.id) {
-            updateScheduleEvent(activeDate, eventData.id, eventData);
-            showToast('이벤트가 수정되었습니다.');
-        } else {
-            addScheduleEvent(activeDate, eventData);
-            showToast('새 이벤트가 추가되었습니다.');
+    // activeDate 변경 시 해당 날짜의 이벤트 로드
+    useEffect(() => {
+        if (activeDate && schedule[activeDate] === undefined) {
+            console.log('Loading events for date:', activeDate); // 디버깅용
+            loadEventsForDate(activeDate, showToast);
+        }
+    }, [activeDate, schedule, loadEventsForDate, showToast]);
+
+    const handleSave = async (eventData, onClose) => {
+        // 필수 필드 검증
+        if (!eventData.title || !eventData.startTime || !eventData.endTime || !eventData.location) { 
+            showToast('제목, 시간, 장소는 필수 항목입니다.'); 
+            return; // 모달을 닫지 않음
+        }
+        
+        try {
+            if (eventData.id) {
+                await updateScheduleEvent(activeDate, eventData.id, eventData, showToast);
+            } else {
+                await addScheduleEvent(activeDate, eventData, showToast);
+            }
+            onClose(); // 성공시에만 모달 닫기
+        } catch (error) {
+            // 에러는 이미 DataProvider에서 toast로 표시됨
+            console.error('Event save failed:', error);
         }
     };
 
@@ -24,18 +41,16 @@ const SchedulePage = () => {
         openModal('confirm', {
             title: '이벤트 삭제 확인',
             message: `'${event.title}' 이벤트를 정말 삭제하시겠습니까?`,
-            onConfirm: () => {
-                deleteScheduleEvent(activeDate, event.id);
-                showToast('이벤트가 삭제되었습니다.');
+            onConfirm: async () => {
+                await deleteScheduleEvent(activeDate, event.id, showToast);
             }
         });
     };
 
-    const handleAddDate = (date) => {
+    const handleAddDate = async (date) => {
         if (date && !schedule[date]) {
-            addScheduleDate(date);
+            await addScheduleDate(date, showToast);
             setActiveDate(date);
-            showToast('새로운 날짜가 추가되었습니다.');
         } else if (schedule[date]) {
             showToast('이미 존재하는 날짜입니다.');
         } else {
@@ -47,9 +62,8 @@ const SchedulePage = () => {
         openModal('confirm', {
             title: '날짜 삭제 확인',
             message: `'${date}' 날짜의 모든 이벤트가 삭제됩니다. 정말 삭제하시겠습니까?`,
-            onConfirm: () => {
-                deleteScheduleDate(date);
-                showToast('날짜가 삭제되었습니다.');
+            onConfirm: async () => {
+                await deleteScheduleDate(date, showToast);
                 // 삭제 후 다른 날짜로 activeDate 이동
                 const dates = Object.keys(schedule).sort().filter(d => d !== date);
                 setActiveDate(dates[0] || null);
@@ -73,8 +87,23 @@ const SchedulePage = () => {
 
     return (
         <div>
-            <div className="flex justify-between items-center mb-6"><h2 className="text-3xl font-bold">일정 관리</h2><button onClick={() => openModal('schedule', { onSave: handleSave, activeDate })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center font-bold" disabled={!activeDate}><i className="fas fa-plus mr-2"></i> 새 이벤트 추가</button></div>
+            <div className="flex justify-between items-center mb-6">
+                <h2 className="text-3xl font-bold">일정 관리</h2>
+                <button 
+                    onClick={() => openModal('schedule', { onSave: handleSave, activeDate })} 
+                    className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center font-bold disabled:opacity-50 disabled:cursor-not-allowed" 
+                    disabled={!activeDate || isLoadingDates || isLoadingEvents}
+                >
+                    <i className="fas fa-plus mr-2"></i> 새 이벤트 추가
+                </button>
+            </div>
             <div className="flex items-center space-x-2 border-b border-gray-200 mb-6 overflow-x-auto flex-wrap">
+                {isLoadingDates && (
+                    <div className="flex items-center px-4 py-2 text-gray-500">
+                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900 mr-2"></div>
+                        로딩 중...
+                    </div>
+                )}
                 {Object.keys(schedule).sort().map(dateStr => {
                     const dateObj = new Date(dateStr);
                     const formattedDate = `${dateObj.getMonth() + 1}/${dateObj.getDate()}(${dayNames[dateObj.getDay()]})`;
@@ -84,6 +113,7 @@ const SchedulePage = () => {
                                 onClick={() => setActiveDate(dateStr)}
                                 className={`w-full px-4 py-2 border-b-2 transition-colors duration-200 text-center relative ${dateStr === activeDate ? 'border-gray-800 text-gray-800 font-semibold' : 'border-transparent text-gray-500 hover:border-gray-300'}`}
                                 style={{ paddingRight: '1.2rem' }}
+                                disabled={isLoadingDates}
                             >
                                 <span className="block">{formattedDate}</span>
                                 <span
@@ -97,35 +127,66 @@ const SchedulePage = () => {
                         </div>
                     );
                 })}
-                <button onClick={() => openModal('datePrompt', { onSave: handleAddDate, defaultDate: getNextDefaultDate() })} title="새 날짜 추가" className="px-2 py-1 rounded-full text-gray-500 hover:bg-gray-200 font-bold"><i className="fas fa-plus"></i></button>
+                <button 
+                    onClick={() => openModal('datePrompt', { onSave: handleAddDate, defaultDate: getNextDefaultDate() })} 
+                    title="새 날짜 추가" 
+                    className="px-2 py-1 rounded-full text-gray-500 hover:bg-gray-200 font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={isLoadingDates}
+                >
+                    <i className="fas fa-plus"></i>
+                </button>
             </div>
             <div className="relative overflow-x-auto pl-2">
                 <div className="absolute left-6 top-0 bottom-0 w-0.5 bg-gray-200"></div>
-                <div className="flex flex-col">
-                {(schedule[activeDate] || []).sort((a,b) => a.startTime.localeCompare(b.startTime)).map(event => (
-                    <div key={event.id} className="relative flex items-center mb-8 w-full">
-                        <div className="z-10 shrink-0">
-                            <div className={`w-8 h-8 rounded-full border-4 border-gray-100 timeline-dot timeline-dot-${event.status}`}></div>
-                        </div>
-                        <div className="ml-4 flex-1">
-                            <div className="flex justify-between items-center">
-                                <div>
-                                    <p className="font-bold text-indigo-600">{event.startTime} - {event.endTime}</p>
-                                    <h4 className="text-xl font-bold mt-1">{event.title}</h4>
-                                     <p className="text-gray-500 mt-1"><i className="fas fa-map-marker-alt mr-2"></i>{event.location}</p>
-                                </div>
-                                <div className="space-x-3 shrink-0 flex items-center">
-                                    <button onClick={() => openModal('schedule', { event, onSave: handleSave, activeDate })} className="text-blue-600 hover:text-blue-800 font-bold">수정</button>
-                                    <button onClick={() => handleDelete(event)} className="text-red-600 hover:text-red-800 font-bold">삭제</button>
+                
+                {isLoadingEvents && (
+                    <div className="flex items-center justify-center py-10">
+                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mr-3"></div>
+                        <span className="text-gray-500">일정 로딩 중...</span>
+                    </div>
+                )}
+                
+                {!isLoadingEvents && (
+                    <div className="flex flex-col">
+                    {/* schedule[activeDate]가 undefined이면 아직 로드되지 않은 상태 */}
+                    {schedule[activeDate] && schedule[activeDate].sort((a,b) => a.startTime.localeCompare(b.startTime)).map(event => (
+                        <div key={event.id} className="relative flex items-center mb-8 w-full">
+                            <div className="z-10 shrink-0">
+                                <div className={`w-8 h-8 rounded-full border-4 border-gray-100 timeline-dot timeline-dot-${event.status}`}></div>
+                            </div>
+                            <div className="ml-4 flex-1">
+                                <div className="flex justify-between items-center">
+                                    <div>
+                                        <p className="font-bold text-indigo-600">{event.startTime} - {event.endTime}</p>
+                                        <h4 className="text-xl font-bold mt-1">{event.title}</h4>
+                                         <p className="text-gray-500 mt-1"><i className="fas fa-map-marker-alt mr-2"></i>{event.location}</p>
+                                    </div>
+                                    <div className="space-x-3 shrink-0 flex items-center">
+                                        <button 
+                                            onClick={() => openModal('schedule', { event, onSave: handleSave, activeDate })} 
+                                            className="text-blue-600 hover:text-blue-800 font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+                                            disabled={isLoadingEvents}
+                                        >
+                                            수정
+                                        </button>
+                                        <button 
+                                            onClick={() => handleDelete(event)} 
+                                            className="text-red-600 hover:text-red-800 font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+                                            disabled={isLoadingEvents}
+                                        >
+                                            삭제
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                    ))}
                     </div>
-                ))}
-                </div>
-                 {(!activeDate || schedule[activeDate]?.length === 0) && (
+                )}
+                
+                 {(!activeDate || (!isLoadingEvents && schedule[activeDate] !== undefined && schedule[activeDate]?.length === 0)) && (
                     <div className="text-center py-10 text-gray-500">
-                        날짜를 선택하거나 새 날짜를 추가하여 이벤트를 관리하세요.
+                        {!activeDate ? '날짜를 선택하거나 새 날짜를 추가하여 이벤트를 관리하세요.' : '등록된 이벤트가 없습니다.'}
                     </div>
                 )}
             </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -49,9 +49,9 @@ a.sidebar-link.sub-link.active { background-color: #4f46e5; color: white; font-w
 
 
 /* 타임라인 애니메이션 */
-.timeline-dot-종료 { background-color: #d1d5db; }
-.timeline-dot-예정 { background-color: #22c55e; animation: pulse-green 2s infinite; }
-.timeline-dot-진행중 { background-color: #3b82f6; animation: pulse-blue 2s infinite; }
+.timeline-dot-COMPLETED { background-color: #d1d5db; }
+.timeline-dot-UPCOMING { background-color: #22c55e; animation: pulse-green 2s infinite; }
+.timeline-dot-ONGOING { background-color: #3b82f6; animation: pulse-blue 2s infinite; }
 @keyframes pulse-blue { 0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); } 70% { box-shadow: 0 0 0 10px rgba(59, 130, 246, 0); } 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); } }
 @keyframes pulse-green { 0% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7); } 70% { box-shadow: 0 0 0 10px rgba(34, 197, 94, 0); } 100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); } }
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -18,4 +18,98 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// 축제 날짜 관련 API
+export const scheduleAPI = {
+  // 모든 축제 날짜 조회
+  getEventDates: async () => {
+    try {
+      const response = await api.get('/event-dates');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch event dates:', error);
+      throw new Error('축제 날짜 조회에 실패했습니다.');
+    }
+  },
+
+  // 새 날짜 추가
+  addEventDate: async (date) => {
+    try {
+      await api.post('/event-dates', { date });
+      // 성공 시 2XX 응답, body 없음 - 재조회 필요
+      return await scheduleAPI.getEventDates();
+    } catch (error) {
+      console.error('Failed to add event date:', error);
+      throw new Error('날짜 추가에 실패했습니다.');
+    }
+  },
+
+  // 날짜 수정
+  updateEventDate: async (eventDateId, date) => {
+    try {
+      await api.put(`/event-dates/${eventDateId}`, { date });
+      // 성공 시 2XX 응답, body 없음 - 재조회 필요
+      return await scheduleAPI.getEventDates();
+    } catch (error) {
+      console.error('Failed to update event date:', error);
+      throw new Error('날짜 수정에 실패했습니다.');
+    }
+  },
+
+  // 날짜 삭제
+  deleteEventDate: async (eventDateId) => {
+    try {
+      await api.delete(`/event-dates/${eventDateId}`);
+      // 성공 시 2XX 응답, body 없음 - 재조회 필요
+      return await scheduleAPI.getEventDates();
+    } catch (error) {
+      console.error('Failed to delete event date:', error);
+      throw new Error('날짜 삭제에 실패했습니다.');
+    }
+  },
+
+  // 특정 날짜의 모든 일정 조회
+  getEventsByDateId: async (eventDateId) => {
+    try {
+      const response = await api.get(`/event-dates/${eventDateId}/events`);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch events:', error);
+      throw new Error('일정 조회에 실패했습니다.');
+    }
+  },
+
+  // 일정 추가
+  createEvent: async (eventData) => {
+    try {
+      await api.post('/event-dates/events', eventData);
+      // 성공 시 201 응답, body 없음 - 재조회 필요
+    } catch (error) {
+      console.error('Failed to create event:', error);
+      throw new Error('일정 추가에 실패했습니다.');
+    }
+  },
+
+  // 일정 수정
+  updateEvent: async (eventId, eventData) => {
+    try {
+      await api.patch(`/event-dates/events/${eventId}`, eventData);
+      // 성공 시 204 응답, body 없음 - 재조회 필요
+    } catch (error) {
+      console.error('Failed to update event:', error);
+      throw new Error('일정 수정에 실패했습니다.');
+    }
+  },
+
+  // 일정 삭제
+  deleteEvent: async (eventId) => {
+    try {
+      await api.delete(`/event-dates/events/${eventId}`);
+      // 성공 시 204 응답, body 없음 - 재조회 필요
+    } catch (error) {
+      console.error('Failed to delete event:', error);
+      throw new Error('일정 삭제에 실패했습니다.');
+    }
+  }
+};
+
 export default api;


### PR DESCRIPTION
## #️⃣ 이슈 번호

#186 

<br>

## 🛠️ 작업 내용

- 프론트 엔드 일정 화면 기능을 실제 백엔드 API 엔드포인트와 연결
- DB 데이터 변경 동작 확인

<br>

## 📸 이미지 첨부 (Optional)
잘했죠??

https://github.com/user-attachments/assets/f2f99f12-68c3-407d-bea4-96aa9a88278c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 축제 일정과 이벤트가 서버와 동기화되어 실시간으로 관리됩니다.
  * 일정 및 이벤트 추가, 수정, 삭제 시 서버와 연동되어 데이터가 자동으로 갱신됩니다.
  * 일정과 이벤트 로딩 상태가 UI에 표시되어, 데이터 불러오는 동안 스피너 및 안내 메시지가 나타납니다.

* **버그 수정**
  * 일정 저장 시 모달이 정상적으로 닫히도록 동작이 개선되었습니다.

* **UI/UX 개선**
  * 로딩 중에는 버튼 및 주요 기능이 비활성화되어 중복 동작을 방지합니다.
  * 이벤트가 없거나 날짜가 선택되지 않은 경우, 상황에 맞는 안내 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->