### PR TITLE
[AN] 홈 화면 서버 연결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -8,8 +8,8 @@ import com.daedan.festabook.data.datasource.remote.NoticeDataSource
 import com.daedan.festabook.data.datasource.remote.NoticeDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.OrganizationBookmarkDataSource
 import com.daedan.festabook.data.datasource.remote.OrganizationBookmarkDataSourceImpl
-import com.daedan.festabook.data.datasource.remote.OrganizationDataSource
-import com.daedan.festabook.data.datasource.remote.OrganizationDataSourceImpl
+import com.daedan.festabook.data.datasource.remote.organization.OrganizationDataSource
+import com.daedan.festabook.data.datasource.remote.organization.OrganizationDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.place.PlaceDataSource
 import com.daedan.festabook.data.datasource.remote.place.PlaceDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.schedule.ScheduleDataSource

--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -8,12 +8,15 @@ import com.daedan.festabook.data.datasource.remote.NoticeDataSource
 import com.daedan.festabook.data.datasource.remote.NoticeDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.OrganizationBookmarkDataSource
 import com.daedan.festabook.data.datasource.remote.OrganizationBookmarkDataSourceImpl
+import com.daedan.festabook.data.datasource.remote.OrganizationDataSource
+import com.daedan.festabook.data.datasource.remote.OrganizationDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.place.PlaceDataSource
 import com.daedan.festabook.data.datasource.remote.place.PlaceDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.schedule.ScheduleDataSource
 import com.daedan.festabook.data.datasource.remote.schedule.ScheduleDataSourceImpl
 import com.daedan.festabook.data.repository.BookmarkRepositoryImpl
 import com.daedan.festabook.data.repository.DeviceRepositoryImpl
+import com.daedan.festabook.data.repository.FestivalRepositoryImpl
 import com.daedan.festabook.data.repository.NoticeRepositoryImpl
 import com.daedan.festabook.data.repository.PlaceDetailRepositoryImpl
 import com.daedan.festabook.data.repository.PlaceListRepositoryImpl
@@ -26,6 +29,7 @@ import com.daedan.festabook.data.service.api.ApiClient.placeService
 import com.daedan.festabook.data.service.api.ApiClient.scheduleService
 import com.daedan.festabook.domain.repository.BookmarkRepository
 import com.daedan.festabook.domain.repository.DeviceRepository
+import com.daedan.festabook.domain.repository.FestivalRepository
 import com.daedan.festabook.domain.repository.NoticeRepository
 import com.daedan.festabook.domain.repository.PlaceDetailRepository
 import com.daedan.festabook.domain.repository.PlaceListRepository
@@ -58,6 +62,10 @@ class AppContainer(
         PlaceDataSourceImpl(placeService, organizationService)
     }
 
+    private val organizationDataSource: OrganizationDataSource by lazy {
+        OrganizationDataSourceImpl(organizationService)
+    }
+
     val placeDetailRepository: PlaceDetailRepository by lazy {
         PlaceDetailRepositoryImpl(placeDetailDataSource)
     }
@@ -77,6 +85,9 @@ class AppContainer(
     }
     val bookmarkRepository: BookmarkRepository by lazy {
         BookmarkRepositoryImpl(organizationBookmarkDataSource)
+    }
+    val festivalRepository: FestivalRepository by lazy {
+        FestivalRepositoryImpl(organizationDataSource)
     }
 
     init {

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/OrganizationDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/OrganizationDataSource.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.data.datasource.remote
+
+import com.daedan.festabook.data.model.response.OrganizationResponse
+
+interface OrganizationDataSource {
+    suspend fun fetchOrganization(): ApiResult<OrganizationResponse>
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/OrganizationDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/OrganizationDataSourceImpl.kt
@@ -1,0 +1,13 @@
+package com.daedan.festabook.data.datasource.remote
+
+import com.daedan.festabook.data.model.response.OrganizationResponse
+import com.daedan.festabook.data.service.OrganizationService
+
+class OrganizationDataSourceImpl(
+    private val organizationService: OrganizationService,
+) : OrganizationDataSource {
+    override suspend fun fetchOrganization(): ApiResult<OrganizationResponse> =
+        ApiResult.toApiResult {
+            organizationService.fetchOrganization()
+        }
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/organization/OrganizationDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/organization/OrganizationDataSource.kt
@@ -1,5 +1,6 @@
-package com.daedan.festabook.data.datasource.remote
+package com.daedan.festabook.data.datasource.remote.organization
 
+import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.response.OrganizationResponse
 
 interface OrganizationDataSource {

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/organization/OrganizationDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/organization/OrganizationDataSourceImpl.kt
@@ -1,5 +1,6 @@
-package com.daedan.festabook.data.datasource.remote
+package com.daedan.festabook.data.datasource.remote.organization
 
+import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.response.OrganizationResponse
 import com.daedan.festabook.data.service.OrganizationService
 

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/OrganizationResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/OrganizationResponse.kt
@@ -1,5 +1,6 @@
 package com.daedan.festabook.data.model.response
 
+import com.daedan.festabook.domain.model.Festival
 import com.daedan.festabook.domain.model.Organization
 import com.daedan.festabook.domain.model.Poster
 import kotlinx.serialization.SerialName
@@ -35,10 +36,13 @@ fun OrganizationResponse.toDomain() =
     Organization(
         id = id,
         universityName = universityName,
-        festivalImages = festivalImages.map { it.toDomain() },
-        festivalName = festivalName,
-        startDate = startDate,
-        endDate = endDate,
+        festival =
+            Festival(
+                festivalImages = festivalImages.map { it.toDomain() },
+                festivalName = festivalName,
+                startDate = startDate,
+                endDate = endDate,
+            ),
     )
 
 fun OrganizationResponse.FestivalImage.toDomain() =

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/OrganizationResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/OrganizationResponse.kt
@@ -3,6 +3,7 @@ package com.daedan.festabook.data.model.response
 import com.daedan.festabook.domain.model.Festival
 import com.daedan.festabook.domain.model.Organization
 import com.daedan.festabook.domain.model.Poster
+import com.daedan.festabook.domain.model.toLocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -40,8 +41,8 @@ fun OrganizationResponse.toDomain() =
             Festival(
                 festivalImages = festivalImages.map { it.toDomain() },
                 festivalName = festivalName,
-                startDate = startDate,
-                endDate = endDate,
+                startDate = startDate.toLocalDate(),
+                endDate = endDate.toLocalDate(),
             ),
     )
 

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/OrganizationResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/OrganizationResponse.kt
@@ -1,0 +1,49 @@
+package com.daedan.festabook.data.model.response
+
+import com.daedan.festabook.domain.model.Organization
+import com.daedan.festabook.domain.model.Poster
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrganizationResponse(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("universityName")
+    val universityName: String,
+    @SerialName("festivalImages")
+    val festivalImages: List<FestivalImage>,
+    @SerialName("festivalName")
+    val festivalName: String,
+    @SerialName("startDate")
+    val startDate: String,
+    @SerialName("endDate")
+    val endDate: String,
+) {
+    @Serializable
+    data class FestivalImage(
+        @SerialName("id")
+        val id: Long,
+        @SerialName("imageUrl")
+        val imageUrl: String,
+        @SerialName("sequence")
+        val sequence: Int,
+    )
+}
+
+fun OrganizationResponse.toDomain() =
+    Organization(
+        id = id,
+        universityName = universityName,
+        festivalImages = festivalImages.map { it.toDomain() },
+        festivalName = festivalName,
+        startDate = startDate,
+        endDate = endDate,
+    )
+
+fun OrganizationResponse.FestivalImage.toDomain() =
+    Poster(
+        id = id,
+        imageUrl = imageUrl,
+        sequence = sequence,
+    )

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.daedan.festabook.data.repository
 
-import com.daedan.festabook.data.datasource.remote.OrganizationDataSource
+import com.daedan.festabook.data.datasource.remote.organization.OrganizationDataSource
 import com.daedan.festabook.data.model.response.toDomain
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.model.Organization

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.daedan.festabook.data.repository
+
+import com.daedan.festabook.data.datasource.remote.OrganizationDataSource
+import com.daedan.festabook.data.model.response.toDomain
+import com.daedan.festabook.data.util.toResult
+import com.daedan.festabook.domain.model.Organization
+import com.daedan.festabook.domain.repository.FestivalRepository
+
+class FestivalRepositoryImpl(
+    private val organizationDataSource: OrganizationDataSource,
+) : FestivalRepository {
+    override suspend fun getFestivalInfo(): Result<Organization> {
+        val response = organizationDataSource.fetchOrganization().toResult()
+        return response.mapCatching { it.toDomain() }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/service/OrganizationService.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/OrganizationService.kt
@@ -1,10 +1,14 @@
 package com.daedan.festabook.data.service
 
 import com.daedan.festabook.data.model.response.OrganizationGeographyResponse
+import com.daedan.festabook.data.model.response.OrganizationResponse
 import retrofit2.Response
 import retrofit2.http.GET
 
 interface OrganizationService {
+    @GET("organizations")
+    suspend fun fetchOrganization(): Response<OrganizationResponse>
+
     @GET("organizations/geography")
     suspend fun fetchOrganizationGeography(): Response<OrganizationGeographyResponse>
 }

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/Festival.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/Festival.kt
@@ -1,0 +1,8 @@
+package com.daedan.festabook.domain.model
+
+data class Festival(
+    val festivalName: String,
+    val festivalImages: List<Poster>,
+    val startDate: String,
+    val endDate: String,
+)

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/Festival.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/Festival.kt
@@ -1,8 +1,10 @@
 package com.daedan.festabook.domain.model
 
+import java.time.LocalDate
+
 data class Festival(
     val festivalName: String,
     val festivalImages: List<Poster>,
-    val startDate: String,
-    val endDate: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
 )

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/Organization.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/Organization.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.domain.model
+
+data class Organization(
+    val id: Long,
+    val universityName: String,
+    val festivalImages: List<Poster>,
+    val festivalName: String,
+    val startDate: String,
+    val endDate: String,
+)

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/Organization.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/Organization.kt
@@ -3,8 +3,5 @@ package com.daedan.festabook.domain.model
 data class Organization(
     val id: Long,
     val universityName: String,
-    val festivalImages: List<Poster>,
-    val festivalName: String,
-    val startDate: String,
-    val endDate: String,
+    val festival: Festival,
 )

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/Poster.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/Poster.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.domain.model
+
+data class Poster(
+    val id: Long,
+    val imageUrl: String,
+    val sequence: Int,
+)

--- a/android/app/src/main/java/com/daedan/festabook/domain/repository/FestivalRepository.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/repository/FestivalRepository.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.domain.repository
+
+import com.daedan.festabook.domain.model.Organization
+
+interface FestivalRepository {
+    suspend fun getFestivalInfo(): Result<Organization>
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/TextUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/TextUtil.kt
@@ -1,0 +1,21 @@
+package com.daedan.festabook.presentation.common
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+fun formatFestivalPeriod(
+    start: String,
+    end: String,
+): String {
+    val inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    val startDate = LocalDate.parse(start, inputFormatter)
+    val endDate = LocalDate.parse(end, inputFormatter)
+
+    return if (startDate.year == endDate.year) {
+        "${startDate.year}년 ${startDate.monthValue}월 ${startDate.dayOfMonth}일 - " +
+            "${endDate.monthValue}월 ${endDate.dayOfMonth}일"
+    } else {
+        "${startDate.year}년 ${startDate.monthValue}월 ${startDate.dayOfMonth}일 - " +
+            "${endDate.year}년 ${endDate.monthValue}월 ${endDate.dayOfMonth}일"
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/TextUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/TextUtil.kt
@@ -1,21 +1,15 @@
 package com.daedan.festabook.presentation.common
 
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 fun formatFestivalPeriod(
-    start: String,
-    end: String,
-): String {
-    val inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-    val startDate = LocalDate.parse(start, inputFormatter)
-    val endDate = LocalDate.parse(end, inputFormatter)
-
-    return if (startDate.year == endDate.year) {
-        "${startDate.year}년 ${startDate.monthValue}월 ${startDate.dayOfMonth}일 - " +
-            "${endDate.monthValue}월 ${endDate.dayOfMonth}일"
+    start: LocalDate,
+    end: LocalDate,
+): String =
+    if (start.year == end.year) {
+        "${start.year}. ${start.monthValue}. ${start.dayOfMonth} - " +
+            "${end.monthValue}. ${end.dayOfMonth}"
     } else {
-        "${startDate.year}년 ${startDate.monthValue}월 ${startDate.dayOfMonth}일 - " +
-            "${endDate.year}년 ${endDate.monthValue}월 ${endDate.dayOfMonth}일"
+        "${start.year}. ${start.monthValue}. ${start.dayOfMonth} - " +
+            "${end.year}. ${end.monthValue}. ${end.dayOfMonth}"
     }
-}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -3,6 +3,7 @@ package com.daedan.festabook.presentation.home
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.PagerSnapHelper
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentHomeBinding
@@ -14,6 +15,7 @@ import com.daedan.festabook.presentation.home.adapter.PosterAdapter
 
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private val viewModel: HomeViewModel by viewModels { HomeViewModel.Factory }
+    private val centerItemMotionEnlarger = CenterItemMotionEnlarger()
 
     private lateinit var adapter: PosterAdapter
 
@@ -72,11 +74,20 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         val safeMaxValue = Int.MAX_VALUE / INFINITE_SCROLL_SAFETY_FACTOR
         val initialPosition = safeMaxValue - (safeMaxValue % size)
 
-        binding.rvHomePoster.scrollToPosition(initialPosition)
+        val layoutManager = binding.rvHomePoster.layoutManager as? LinearLayoutManager ?: return
+
+        val itemWidth = resources.getDimensionPixelSize(R.dimen.poster_item_width)
+        val offset = (binding.rvHomePoster.width / 2) - (itemWidth / 2)
+
+        layoutManager.scrollToPositionWithOffset(initialPosition, offset)
+
+        binding.rvHomePoster.post {
+            centerItemMotionEnlarger.expandCenterItem(binding.rvHomePoster)
+        }
     }
 
     private fun addScrollEffectListener() {
-        binding.rvHomePoster.addOnScrollListener(CenterItemMotionEnlarger())
+        binding.rvHomePoster.addOnScrollListener(centerItemMotionEnlarger)
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -25,8 +25,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     ) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
-        viewModel.loadFestival()
-
         setupObservers()
     }
 
@@ -34,27 +32,28 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         viewModel.festivalUiState.observe(viewLifecycleOwner) { festivalUiState ->
             when (festivalUiState) {
                 is FestivalUiState.Loading -> {}
-                is FestivalUiState.Success -> {
-                    binding.tvHomeOrganizationTitle.text =
-                        festivalUiState.organization.universityName
-                    binding.tvHomeFestivalTitle.text =
-                        festivalUiState.organization.festival.festivalName
-                    binding.tvHomeFestivalDate.text =
-                        formatFestivalPeriod(
-                            festivalUiState.organization.festival.startDate,
-                            festivalUiState.organization.festival.endDate,
-                        )
-
-                    val posterUrls =
-                        festivalUiState.organization.festival.festivalImages
-                            .sortedBy { it.sequence }
-                            .map { it.imageUrl }
-                    setupAdapter(posterUrls)
-                }
-
+                is FestivalUiState.Success -> handleSuccessState(festivalUiState)
                 is FestivalUiState.Error -> {}
             }
         }
+    }
+
+    private fun handleSuccessState(festivalUiState: FestivalUiState.Success) {
+        binding.tvHomeOrganizationTitle.text =
+            festivalUiState.organization.universityName
+        binding.tvHomeFestivalTitle.text =
+            festivalUiState.organization.festival.festivalName
+        binding.tvHomeFestivalDate.text =
+            formatFestivalPeriod(
+                festivalUiState.organization.festival.startDate,
+                festivalUiState.organization.festival.endDate,
+            )
+
+        val posterUrls =
+            festivalUiState.organization.festival.festivalImages
+                .sortedBy { it.sequence }
+                .map { it.imageUrl }
+        setupAdapter(posterUrls)
     }
 
     private fun setupAdapter(posters: List<String> = emptyList()) {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -2,51 +2,75 @@ package com.daedan.festabook.presentation.home
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.PagerSnapHelper
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentHomeBinding
 import com.daedan.festabook.presentation.common.BaseFragment
+import com.daedan.festabook.presentation.common.formatFestivalPeriod
 import com.daedan.festabook.presentation.home.adapter.CenterItemMotionEnlarger
+import com.daedan.festabook.presentation.home.adapter.FestivalUiState
 import com.daedan.festabook.presentation.home.adapter.PosterAdapter
 
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
+    private val viewModel: HomeViewModel by viewModels { HomeViewModel.Factory }
+
     private lateinit var adapter: PosterAdapter
-    private val posters =
-        listOf(
-            R.drawable.sample_poster,
-            R.drawable.sample_poster2,
-            R.drawable.sample_poster3,
-            R.drawable.sample_poster4,
-        )
 
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        viewModel.loadFestival()
 
-        setupPosterRecyclerView()
+        setupObservers()
     }
 
-    private fun setupPosterRecyclerView() {
-        setupAdapter()
-        attachSnapHelper()
-        scrollToInitialPosition()
-        addScrollEffectListener()
+    private fun setupObservers() {
+        viewModel.festivalUiState.observe(viewLifecycleOwner) { festivalUiState ->
+            when (festivalUiState) {
+                is FestivalUiState.Loading -> {}
+                is FestivalUiState.Success -> {
+                    binding.tvHomeOrganizationTitle.text =
+                        festivalUiState.organization.universityName
+                    binding.tvHomeFestivalTitle.text =
+                        festivalUiState.organization.festival.festivalName
+                    binding.tvHomeFestivalDate.text =
+                        formatFestivalPeriod(
+                            festivalUiState.organization.festival.startDate,
+                            festivalUiState.organization.festival.endDate,
+                        )
+
+                    val posterUrls =
+                        festivalUiState.organization.festival.festivalImages
+                            .sortedBy { it.sequence }
+                            .map { it.imageUrl }
+                    setupAdapter(posterUrls)
+                }
+
+                is FestivalUiState.Error -> {}
+            }
+        }
     }
 
-    private fun setupAdapter() {
+    private fun setupAdapter(posters: List<String> = emptyList()) {
         adapter = PosterAdapter(posters)
         binding.rvHomePoster.adapter = adapter
+
+        attachSnapHelper()
+        scrollToInitialPosition(posters.size)
+        addScrollEffectListener()
     }
 
     private fun attachSnapHelper() {
         PagerSnapHelper().attachToRecyclerView(binding.rvHomePoster)
     }
 
-    private fun scrollToInitialPosition() {
+    private fun scrollToInitialPosition(size: Int) {
         val safeMaxValue = Int.MAX_VALUE / INFINITE_SCROLL_SAFETY_FACTOR
-        val initialPosition = safeMaxValue - (safeMaxValue % posters.size)
+        val initialPosition = safeMaxValue - (safeMaxValue % size)
 
         binding.rvHomePoster.scrollToPosition(initialPosition)
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
@@ -1,0 +1,44 @@
+package com.daedan.festabook.presentation.home
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.daedan.festabook.FestaBookApp
+import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.presentation.home.adapter.FestivalUiState
+import kotlinx.coroutines.launch
+
+class HomeViewModel(
+    private val festivalRepository: FestivalRepository,
+) : ViewModel() {
+    private val _festivalUiState = MutableLiveData<FestivalUiState>()
+    val festivalUiState: MutableLiveData<FestivalUiState> get() = _festivalUiState
+
+    fun loadFestival() {
+        viewModelScope.launch {
+            _festivalUiState.value = FestivalUiState.Loading
+
+            val result = festivalRepository.getFestivalInfo()
+            result
+                .onSuccess { festival ->
+                    _festivalUiState.value = FestivalUiState.Success(festival)
+                }.onFailure {
+                    _festivalUiState.value = FestivalUiState.Error(it)
+                }
+        }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    val festivalRepository =
+                        (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as FestaBookApp).appContainer.festivalRepository
+                    HomeViewModel(festivalRepository)
+                }
+            }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.daedan.festabook.presentation.home
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -15,7 +16,11 @@ class HomeViewModel(
     private val festivalRepository: FestivalRepository,
 ) : ViewModel() {
     private val _festivalUiState = MutableLiveData<FestivalUiState>()
-    val festivalUiState: MutableLiveData<FestivalUiState> get() = _festivalUiState
+    val festivalUiState: LiveData<FestivalUiState> get() = _festivalUiState
+
+    init {
+        loadFestival()
+    }
 
     fun loadFestival() {
         viewModelScope.launch {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/CenterItemMotionEnlarger.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/CenterItemMotionEnlarger.kt
@@ -11,18 +11,28 @@ class CenterItemMotionEnlarger(
         dx: Int,
         dy: Int,
     ) {
-        val centerThresholdPx =
-            (centerThresholdDp * rv.context.resources.displayMetrics.density).toInt()
-        val center = rv.width / 2
+        val thresholdPx = (centerThresholdDp * rv.context.resources.displayMetrics.density).toInt()
+        updateChildAnimations(rv, thresholdPx)
+    }
 
-        for (i in 0 until rv.childCount) {
-            val child = rv.getChildAt(i)
-            val holder = rv.getChildViewHolder(child) as? PosterItemViewHolder ?: continue
+    fun expandCenterItem(recyclerView: RecyclerView) {
+        val thresholdPx = (centerThresholdDp * recyclerView.context.resources.displayMetrics.density).toInt()
+        updateChildAnimations(recyclerView, thresholdPx)
+    }
+
+    private fun updateChildAnimations(
+        recyclerView: RecyclerView,
+        thresholdPx: Int,
+    ) {
+        val center = recyclerView.width / 2
+        for (i in 0 until recyclerView.childCount) {
+            val child = recyclerView.getChildAt(i)
+            val holder = recyclerView.getChildViewHolder(child) as? PosterItemViewHolder ?: continue
 
             val childCenter = (child.left + child.right) / 2
             val distanceFromCenter = abs(center - childCenter)
 
-            if (distanceFromCenter < centerThresholdPx) {
+            if (distanceFromCenter < thresholdPx) {
                 holder.transitionToExpanded()
             } else {
                 holder.transitionToCollapsed()

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/FestivalUiState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/FestivalUiState.kt
@@ -1,0 +1,15 @@
+package com.daedan.festabook.presentation.home.adapter
+
+import com.daedan.festabook.domain.model.Organization
+
+sealed interface FestivalUiState {
+    data object Loading : FestivalUiState
+
+    data class Success(
+        val organization: Organization,
+    ) : FestivalUiState
+
+    data class Error(
+        val throwable: Throwable,
+    ) : FestivalUiState
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterAdapter.kt
@@ -4,7 +4,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 
 class PosterAdapter(
-    private val posters: List<Int>,
+    private val posters: List<String>,
 ) : RecyclerView.Adapter<PosterItemViewHolder>() {
     override fun onCreateViewHolder(
         parent: ViewGroup,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
@@ -3,14 +3,15 @@ package com.daedan.festabook.presentation.home.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import coil3.load
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ItemHomePosterBinding
 
 class PosterItemViewHolder(
     val binding: ItemHomePosterBinding,
 ) : RecyclerView.ViewHolder(binding.root) {
-    fun bind(poster: Int) {
-        binding.ivHomePoster.setImageResource(poster)
+    fun bind(url: String) {
+        binding.ivHomePoster.load(url)
         binding.motionLayout.progress = 0f
         binding.motionLayout.transitionToState(R.id.collapsed)
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
@@ -1,9 +1,16 @@
 package com.daedan.festabook.presentation.home.adapter
 
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.graphics.drawable.toDrawable
 import androidx.recyclerview.widget.RecyclerView
 import coil3.load
+import coil3.request.CachePolicy
+import coil3.request.crossfade
+import coil3.request.placeholder
+import coil3.request.transformations
+import coil3.transform.RoundedCornersTransformation
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ItemHomePosterBinding
 
@@ -11,7 +18,12 @@ class PosterItemViewHolder(
     val binding: ItemHomePosterBinding,
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(url: String) {
-        binding.ivHomePoster.load(url)
+        binding.ivHomePoster.load(url) {
+            crossfade(true)
+            placeholder(Color.LTGRAY.toDrawable())
+            transformations(RoundedCornersTransformation(20f))
+            memoryCachePolicy(CachePolicy.ENABLED)
+        }
         binding.motionLayout.progress = 0f
         binding.motionLayout.transitionToState(R.id.collapsed)
     }

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -19,9 +19,9 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="40dp"
-            android:text="가천대학교"
             android:textColor="@color/gray900"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="가천대학교" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_home_poster"
@@ -42,10 +42,10 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="16dp"
-            android:text="2025 가천 Water Festival\n: AQUA WAVE"
             android:textColor="@color/gray900"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/rv_home_poster" />
+            app:layout_constraintTop_toBottomOf="@id/rv_home_poster"
+            tools:text="2025 가천 Water Festival\n: AQUA WAVE" />
 
         <TextView
             android:id="@+id/tv_home_festival_date"
@@ -54,9 +54,9 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="8dp"
-            android:text="2025년 10월 15일 - 10월 17일"
             android:textColor="@color/gray500"
-            app:layout_constraintTop_toBottomOf="@id/tv_home_festival_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_home_festival_title"
+            tools:text="2025년 10월 15일 - 10월 17일" />
 
         <com.google.android.material.divider.MaterialDivider
             android:id="@+id/view_divider"

--- a/android/app/src/main/res/layout/item_home_poster.xml
+++ b/android/app/src/main/res/layout/item_home_poster.xml
@@ -21,6 +21,9 @@
             android:scaleType="centerCrop"
             android:src="@drawable/sample_poster"
             app:layout_constraintDimensionRatio="3:4"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
     </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="schedule_tab_item_end_margin">12dp</dimen>
+    <dimen name="poster_item_width">300dp</dimen>
+
 </resources>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #287 

<br>

## 🛠️ 작업 내용

- 홈 화면 서버 연결
- 홈 화면 초기 실행 시에 가운데로 포스터가 로딩 되도록 수정

<br>

## 🙇🏻 중점 리뷰 요청

- 안드로이드 내부 코드에서는 도메인을 Organization > Festival 로 설정했습니다.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/a261d68c-4faf-4d6e-b225-5160e6c11e0d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 축제 및 조직 정보를 위한 새로운 데이터 모델과 API 연동이 추가되었습니다.
  * 축제 정보를 비동기적으로 불러오는 기능이 홈 화면에 적용되었습니다.
  * 축제 기간을 보기 좋게 포매팅하는 유틸리티 함수가 추가되었습니다.

* **UI 개선**
  * 홈 화면이 MVVM 패턴으로 리팩토링되어, 축제 정보 및 포스터가 실시간으로 갱신됩니다.
  * 포스터 이미지가 동적으로 로드되며, 중앙 포스터 확대 애니메이션이 개선되었습니다.
  * 포스터 아이템의 레이아웃 및 크기 제약이 명확해졌습니다.

* **기타**
  * 축제 및 조직 관련 도메인/데이터/리포지토리 구조가 추가되어 유지보수가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->