### PR TITLE
[BE] OrganizationResponse 시작일, 종료일을 연관된 EventDate로 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/event/infrastructure/EventDateJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/event/infrastructure/EventDateJpaRepository.java
@@ -9,5 +9,7 @@ public interface EventDateJpaRepository extends JpaRepository<EventDate, Long> {
 
     List<EventDate> findAllByOrganizationId(Long organizationId);
 
+    List<EventDate> findAllByOrganizationIdOrderByDateAsc(Long organizationId);
+
     boolean existsByOrganizationIdAndDate(Long organizationId, LocalDate date);
 }

--- a/backend/src/main/java/com/daedan/festabook/organization/domain/Organization.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/domain/Organization.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -40,12 +39,6 @@ public class Organization {
     private String festivalName;
 
     @Column(nullable = false)
-    private LocalDate startDate;
-
-    @Column(nullable = false)
-    private LocalDate endDate;
-
-    @Column(nullable = false)
     private Integer zoom;
 
     @Embedded
@@ -63,8 +56,6 @@ public class Organization {
             Long id,
             String universityName,
             String festivalName,
-            LocalDate startDate,
-            LocalDate endDate,
             Integer zoom,
             Coordinate centerCoordinate,
             List<Coordinate> polygonHoleBoundary
@@ -77,8 +68,6 @@ public class Organization {
         this.id = id;
         this.universityName = universityName;
         this.festivalName = festivalName;
-        this.startDate = startDate;
-        this.endDate = endDate;
         this.zoom = zoom;
         this.centerCoordinate = centerCoordinate;
         this.polygonHoleBoundary = polygonHoleBoundary;
@@ -87,8 +76,6 @@ public class Organization {
     public Organization(
             String universityName,
             String festivalName,
-            LocalDate startDate,
-            LocalDate endDate,
             Integer zoom,
             Coordinate centerCoordinate,
             List<Coordinate> polygonHoleBoundary
@@ -97,8 +84,6 @@ public class Organization {
                 null,
                 universityName,
                 festivalName,
-                startDate,
-                endDate,
                 zoom,
                 centerCoordinate,
                 polygonHoleBoundary

--- a/backend/src/main/java/com/daedan/festabook/organization/dto/OrganizationResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/dto/OrganizationResponse.java
@@ -1,9 +1,6 @@
 package com.daedan.festabook.organization.dto;
 
-import com.daedan.festabook.organization.domain.FestivalImage;
-import com.daedan.festabook.organization.domain.Organization;
 import java.time.LocalDate;
-import java.util.List;
 
 public record OrganizationResponse(
         Long id,
@@ -13,15 +10,4 @@ public record OrganizationResponse(
         LocalDate startDate,
         LocalDate endDate
 ) {
-
-    public static OrganizationResponse from(Organization organization, List<FestivalImage> festivalImages) {
-        return new OrganizationResponse(
-                organization.getId(),
-                organization.getUniversityName(),
-                FestivalImageResponses.from(festivalImages),
-                organization.getFestivalName(),
-                organization.getStartDate(),
-                organization.getEndDate()
-        );
-    }
 }

--- a/backend/src/main/java/com/daedan/festabook/organization/service/OrganizationService.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/service/OrganizationService.java
@@ -1,8 +1,11 @@
 package com.daedan.festabook.organization.service;
 
+import com.daedan.festabook.event.domain.EventDate;
+import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.organization.domain.FestivalImage;
 import com.daedan.festabook.organization.domain.Organization;
+import com.daedan.festabook.organization.dto.FestivalImageResponses;
 import com.daedan.festabook.organization.dto.OrganizationGeographyResponse;
 import com.daedan.festabook.organization.dto.OrganizationResponse;
 import com.daedan.festabook.organization.infrastructure.FestivalImageJpaRepository;
@@ -18,7 +21,7 @@ public class OrganizationService {
 
     private final OrganizationJpaRepository organizationJpaRepository;
     private final FestivalImageJpaRepository festivalImageJpaRepository;
-
+    private final EventDateJpaRepository eventDateJpaRepository;
 
     public OrganizationGeographyResponse getOrganizationGeographyByOrganizationId(Long organizationId) {
         Organization organization = getOrganizationById(organizationId);
@@ -30,8 +33,16 @@ public class OrganizationService {
         Organization organization = getOrganizationById(organizationId);
         List<FestivalImage> festivalImages =
                 festivalImageJpaRepository.findAllByOrganizationIdOrderBySequenceAsc(organizationId);
+        List<EventDate> eventDates = eventDateJpaRepository.findAllByOrganizationIdOrderByDateAsc(organizationId);
 
-        return OrganizationResponse.from(organization, festivalImages);
+        return new OrganizationResponse(
+                organization.getId(),
+                organization.getUniversityName(),
+                FestivalImageResponses.from(festivalImages),
+                organization.getFestivalName(),
+                eventDates.isEmpty() ? null : eventDates.getFirst().getDate(),
+                eventDates.isEmpty() ? null : eventDates.getLast().getDate()
+        );
     }
 
     private Organization getOrganizationById(Long organizationId) {

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,8 +1,8 @@
 -- ========================
 -- 조직 (Organization)
 -- ========================
-INSERT INTO organization (university_name, festival_name, start_date, end_date, zoom, latitude, longitude)
-VALUES ('서울시립대학교', '2025 시립 Water Festival: AQUA WAVE', '2025-10-15', '2025-10-17', 15, 37.583585, 127.0588862);
+INSERT INTO organization (university_name, festival_name, zoom, latitude, longitude)
+VALUES ('서울시립대학교', '2025 시립 Water Festival: AQUA WAVE', 15, 37.583585, 127.0588862);
 
 -- ========================
 -- 축제 이미지 (FestivalImage)
@@ -14,6 +14,9 @@ VALUES (1, 'https://www.themoviedb.org/t/p/w1280/vpnVM9B6NMmQpWeZvzLvDESb2QY.jpg
        (1, 'https://image.tmdb.org/t/p/original/uxSb5N9S1vtUTeAyQQxiQ6CFGrc.jpg', 4),
        (1, 'https://www.themoviedb.org/t/p/w1280/fwch4T5aUDPuJ6zUzkub8prfhtI.jpg', 5);
 
+-- ========================
+-- 조직 폴리곤 구멍 경계 (OrganizationPolygonHoleBoundary)
+-- ========================
 INSERT INTO organization_polygon_hole_boundary (organization_id, latitude, longitude)
 VALUES (1, 37.5863631, 127.0564018),
        (1, 37.5862823, 127.0562999),
@@ -112,7 +115,6 @@ VALUES (1, '2025-07-31'),
 -- ========================
 -- 타임라인 (Event)
 -- ========================
-
 INSERT INTO event (start_time, end_time, title, location, event_date_id)
 VALUES ('10:00:00', '11:30:00', '개막식', '운동장', 1),
        ('13:00:00', '14:00:00', '한소래', '학생회관 앞 자주터', 1),
@@ -121,10 +123,8 @@ VALUES ('10:00:00', '11:30:00', '개막식', '운동장', 1),
        ('18:00:00', '19:00:00', '새벽을알리는소리', '학생회관 앞 자주터', 1),
        ('19:30:00', '20:30:00', '연예인 공연: 프로미스 나인', '학생회관 앞 자주터', 1),
        ('20:30:00', '21:00:00', '연예인 공연: YB', '학생회관 앞 자주터', 1),
-       ('21:00:00', '22:00:00', '연예인 공연: 잔나비', '학생회관 앞 자주터', 1);
-
-INSERT INTO event (start_time, end_time, title, location, event_date_id)
-VALUES ('10:00:00', '11:00:00', '전체 학생 총회', '중앙무대', 2),
+       ('21:00:00', '22:00:00', '연예인 공연: 잔나비', '학생회관 앞 자주터', 1),
+       ('10:00:00', '11:00:00', '전체 학생 총회', '중앙무대', 2),
        ('11:00:00', '12:00:00', '바운스', '중앙무대', 2),
        ('12:30:00', '13:30:00', '새물결', '중앙무대', 2),
        ('14:00:00', '15:30:00', '제퍼나이어', '중앙무대', 2),
@@ -132,10 +132,8 @@ VALUES ('10:00:00', '11:00:00', '전체 학생 총회', '중앙무대', 2),
        ('17:30:00', '18:30:00', '한소래X새물결', '중앙무대', 2),
        ('19:30:00', '20:30:00', '연예인 공연: 백예린', '중앙무대', 2),
        ('20:30:00', '21:00:00', '연예인 공연: ITZY', '중앙무대', 2),
-       ('21:00:00', '22:00:00', '연예인 공연: 에스파', '중앙무대', 2);
-
-INSERT INTO event (start_time, end_time, title, location, event_date_id)
-VALUES ('09:30:00', '10:30:00', 'Tru-Hz', '운동장', 3),
+       ('21:00:00', '22:00:00', '연예인 공연: 에스파', '중앙무대', 2),
+       ('09:30:00', '10:30:00', 'Tru-Hz', '운동장', 3),
        ('11:00:00', '12:00:00', 'Jane', '운동장', 3),
        ('12:30:00', '13:30:00', '발광', '운동장', 3),
        ('14:00:00', '15:00:00', '발라드림', '운동장', 3),
@@ -254,6 +252,9 @@ VALUES (1, 'BAR', 37.5848056, 127.0600224),
        (1, 'TRASH_CAN', 37.5844988, 127.0612147),
        (1, 'TRASH_CAN', 37.5833199, 127.0595985);
 
+-- ========================
+-- 플레이스 세부 정보 (PlaceDetail)
+-- ========================
 INSERT INTO place_detail (place_id, title, description, location, host, start_time, end_time)
 VALUES (1, '루프탑 칵테일 바', '아름다운 야경과 특별한 칵테일', 'BAR 존 A-1', '스카이 블리스', '18:00:00', '00:00:00'),
        (2, '크래프트 비어 탭룸', '다양한 수제 맥주를 맛볼 수 있는 공간', 'BAR 존 A-2', '홉앤몰트', '17:00:00', '23:00:00'),

--- a/backend/src/test/java/com/daedan/festabook/organization/controller/OrganizationControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/controller/OrganizationControllerTest.java
@@ -120,10 +120,10 @@ class OrganizationControllerTest {
             FestivalImage festivalImage1 = FestivalImageFixture.create(organization, 1);
             festivalImageJpaRepository.saveAll(List.of(festivalImage2, festivalImage1));
 
-            EventDate thirdEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 3));
-            EventDate secondEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 2));
-            EventDate firstEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
-            eventDateJpaRepository.saveAll(List.of(thirdEventDate, secondEventDate, firstEventDate));
+            EventDate eventDate3 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 3));
+            EventDate eventDate2 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 2));
+            EventDate eventDate1 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
+            eventDateJpaRepository.saveAll(List.of(eventDate3, eventDate2, eventDate1));
 
             int festivalImageSize = 2;
             int expectedFieldSize = 6;
@@ -140,8 +140,8 @@ class OrganizationControllerTest {
                     .body("universityName", equalTo(organization.getUniversityName()))
                     .body("festivalImages", hasSize(festivalImageSize))
                     .body("festivalName", equalTo(organization.getFestivalName()))
-                    .body("startDate", equalTo(firstEventDate.getDate().toString()))
-                    .body("endDate", equalTo(thirdEventDate.getDate().toString()))
+                    .body("startDate", equalTo(eventDate1.getDate().toString()))
+                    .body("endDate", equalTo(eventDate3.getDate().toString()))
 
                     .body("festivalImages[0].id", equalTo(festivalImage1.getId().intValue()))
                     .body("festivalImages[0].imageUrl", equalTo(festivalImage1.getImageUrl()))
@@ -158,11 +158,11 @@ class OrganizationControllerTest {
             Organization organization = OrganizationFixture.create();
             organizationJpaRepository.save(organization);
 
-            EventDate firstEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
-            EventDate secondEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
-            EventDate thirdEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
-            EventDate fourthEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
-            eventDateJpaRepository.saveAll(List.of(fourthEventDate, thirdEventDate, secondEventDate, firstEventDate));
+            EventDate eventDate1 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
+            EventDate eventDate2 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
+            EventDate eventDate3 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
+            EventDate eventDate4 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
+            eventDateJpaRepository.saveAll(List.of(eventDate4, eventDate3, eventDate2, eventDate1));
 
             // when & then
             RestAssured
@@ -172,8 +172,8 @@ class OrganizationControllerTest {
                     .get("/organizations")
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("startDate", equalTo(firstEventDate.getDate().toString()))
-                    .body("endDate", equalTo(fourthEventDate.getDate().toString()));
+                    .body("startDate", equalTo(eventDate1.getDate().toString()))
+                    .body("endDate", equalTo(eventDate4.getDate().toString()));
         }
 
         @Test

--- a/backend/src/test/java/com/daedan/festabook/organization/domain/OrganizationFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/domain/OrganizationFixture.java
@@ -1,14 +1,11 @@
 package com.daedan.festabook.organization.domain;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public class OrganizationFixture {
 
     private static final String DEFAULT_UNIVERSITY_NAME = "서울시립대학교";
     private static final String DEFAULT_FESTIVAL_NAME = "2025 시립 Water Festival: AQUA WAVE";
-    private static final LocalDate DEFAULT_START_DATE = LocalDate.of(2025, 10, 15);
-    private static final LocalDate DEFAULT_END_DATE = LocalDate.of(2025, 10, 17);
     private static final Integer DEFAULT_ZOOM = 16;
     private static final Coordinate DEFAULT_CENTER_COORDINATE = CoordinateFixture.create();
     private static final List<Coordinate> DEFAULT_POLYGON_HOLE_BOUNDARY = List.of(
@@ -21,8 +18,6 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
-                DEFAULT_START_DATE,
-                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -35,8 +30,6 @@ public class OrganizationFixture {
         return new Organization(
                 universityName,
                 DEFAULT_FESTIVAL_NAME,
-                DEFAULT_START_DATE,
-                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -49,8 +42,6 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
-                DEFAULT_START_DATE,
-                DEFAULT_END_DATE,
                 zoom,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -63,8 +54,6 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
-                DEFAULT_START_DATE,
-                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 centerCoordinate,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -77,8 +66,6 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
-                DEFAULT_START_DATE,
-                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 polygonHoleBoundary
@@ -92,8 +79,6 @@ public class OrganizationFixture {
                 id,
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
-                DEFAULT_START_DATE,
-                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY

--- a/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.organization.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
 import com.daedan.festabook.event.domain.EventDate;
@@ -104,14 +105,16 @@ class OrganizationServiceTest {
             OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
 
             // then
-            assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
-            assertThat(result.festivalImages().responses().get(0).imageUrl()).isEqualTo(
-                    festivalImages.get(0).getImageUrl());
-            assertThat(result.festivalImages().responses().get(1).imageUrl()).isEqualTo(
-                    festivalImages.get(1).getImageUrl());
-            assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
-            assertThat(result.startDate()).isEqualTo(eventDates.getFirst().getDate());
-            assertThat(result.endDate()).isEqualTo(eventDates.getLast().getDate());
+            assertSoftly(s -> {
+                s.assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
+                s.assertThat(result.festivalImages().responses().get(0).imageUrl())
+                        .isEqualTo(festivalImages.get(0).getImageUrl());
+                s.assertThat(result.festivalImages().responses().get(1).imageUrl())
+                        .isEqualTo(festivalImages.get(1).getImageUrl());
+                s.assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
+                s.assertThat(result.startDate()).isEqualTo(eventDates.getFirst().getDate());
+                s.assertThat(result.endDate()).isEqualTo(eventDates.getLast().getDate());
+            });
         }
 
         @Test
@@ -135,8 +138,10 @@ class OrganizationServiceTest {
             OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
 
             // then
-            assertThat(result.startDate()).isEqualTo(firstEventDate.getDate());
-            assertThat(result.endDate()).isEqualTo(fourthEventDate.getDate());
+            assertSoftly(s -> {
+                s.assertThat(result.startDate()).isEqualTo(firstEventDate.getDate());
+                s.assertThat(result.endDate()).isEqualTo(fourthEventDate.getDate());
+            });
         }
 
         @Test
@@ -152,11 +157,13 @@ class OrganizationServiceTest {
             OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
 
             // then
-            assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
-            assertThat(result.festivalImages().responses()).isEqualTo(List.of());
-            assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
-            assertThat(result.startDate()).isNull();
-            assertThat(result.endDate()).isNull();
+            assertSoftly(s -> {
+                s.assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
+                s.assertThat(result.festivalImages().responses()).isEqualTo(List.of());
+                s.assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
+                s.assertThat(result.startDate()).isNull();
+                s.assertThat(result.endDate()).isNull();
+            });
         }
 
         @Test

--- a/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
@@ -123,11 +123,11 @@ class OrganizationServiceTest {
             Long organizationId = 1L;
             Organization organization = OrganizationFixture.create(organizationId);
 
-            EventDate firstEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
-            EventDate secondEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
-            EventDate thirdEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
-            EventDate fourthEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
-            List<EventDate> eventDates = List.of(firstEventDate, secondEventDate, thirdEventDate, fourthEventDate);
+            EventDate eventDate1 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
+            EventDate eventDate2 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
+            EventDate eventDate3 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
+            EventDate eventDate4 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
+            List<EventDate> eventDates = List.of(eventDate1, eventDate2, eventDate3, eventDate4);
 
             given(organizationJpaRepository.findById(organizationId))
                     .willReturn(Optional.of(organization));
@@ -139,8 +139,8 @@ class OrganizationServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.startDate()).isEqualTo(firstEventDate.getDate());
-                s.assertThat(result.endDate()).isEqualTo(fourthEventDate.getDate());
+                s.assertThat(result.startDate()).isEqualTo(eventDate1.getDate());
+                s.assertThat(result.endDate()).isEqualTo(eventDate4.getDate());
             });
         }
 

--- a/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.daedan.festabook.event.domain.EventDate;
+import com.daedan.festabook.event.domain.EventDateFixture;
+import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.organization.domain.FestivalImage;
 import com.daedan.festabook.organization.domain.FestivalImageFixture;
@@ -13,6 +16,7 @@ import com.daedan.festabook.organization.dto.OrganizationGeographyResponse;
 import com.daedan.festabook.organization.dto.OrganizationResponse;
 import com.daedan.festabook.organization.infrastructure.FestivalImageJpaRepository;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -33,6 +37,9 @@ class OrganizationServiceTest {
 
     @Mock
     private FestivalImageJpaRepository festivalImageJpaRepository;
+
+    @Mock
+    private EventDateJpaRepository eventDateJpaRepository;
 
     @InjectMocks
     private OrganizationService organizationService;
@@ -83,21 +90,73 @@ class OrganizationServiceTest {
             // given
             Long organizationId = 1L;
             Organization organization = OrganizationFixture.create(organizationId);
-
-            List<FestivalImage> festivalImages = FestivalImageFixture.createList(3, organization);
+            List<FestivalImage> festivalImages = FestivalImageFixture.createList(2, organization);
+            List<EventDate> eventDates = EventDateFixture.createList(3, organization);
 
             given(organizationJpaRepository.findById(organizationId))
                     .willReturn(Optional.of(organization));
             given(festivalImageJpaRepository.findAllByOrganizationIdOrderBySequenceAsc(organizationId))
                     .willReturn(festivalImages);
-
-            OrganizationResponse expected = OrganizationResponse.from(organization, festivalImages);
+            given(eventDateJpaRepository.findAllByOrganizationIdOrderByDateAsc(organizationId))
+                    .willReturn(eventDates);
 
             // when
             OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
 
             // then
-            assertThat(result).isEqualTo(expected);
+            assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
+            assertThat(result.festivalImages().responses().get(0).imageUrl()).isEqualTo(
+                    festivalImages.get(0).getImageUrl());
+            assertThat(result.festivalImages().responses().get(1).imageUrl()).isEqualTo(
+                    festivalImages.get(1).getImageUrl());
+            assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
+            assertThat(result.startDate()).isEqualTo(eventDates.getFirst().getDate());
+            assertThat(result.endDate()).isEqualTo(eventDates.getLast().getDate());
+        }
+
+        @Test
+        void 성공_축제_날짜_중_가장_빠른_날짜와_가장_늦은_날짜가_응답됨() {
+            // given
+            Long organizationId = 1L;
+            Organization organization = OrganizationFixture.create(organizationId);
+
+            EventDate firstEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
+            EventDate secondEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
+            EventDate thirdEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
+            EventDate fourthEventDate = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
+            List<EventDate> eventDates = List.of(firstEventDate, secondEventDate, thirdEventDate, fourthEventDate);
+
+            given(organizationJpaRepository.findById(organizationId))
+                    .willReturn(Optional.of(organization));
+            given(eventDateJpaRepository.findAllByOrganizationIdOrderByDateAsc(organizationId))
+                    .willReturn(eventDates);
+
+            // when
+            OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
+
+            // then
+            assertThat(result.startDate()).isEqualTo(firstEventDate.getDate());
+            assertThat(result.endDate()).isEqualTo(fourthEventDate.getDate());
+        }
+
+        @Test
+        void 성공_축제_날짜는_null_가능() {
+            // given
+            Long organizationId = 1L;
+            Organization organization = OrganizationFixture.create(organizationId);
+
+            given(organizationJpaRepository.findById(organizationId))
+                    .willReturn(Optional.of(organization));
+
+            // when
+            OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
+
+            // then
+            assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
+            assertThat(result.festivalImages().responses()).isEqualTo(List.of());
+            assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
+            assertThat(result.startDate()).isNull();
+            assertThat(result.endDate()).isNull();
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 이슈 번호

#282

<br>

## 🛠️ 작업 내용

- Organization에 시작일, 종료일 제거
- OrganizationResponse 시작일, 종료일을 연관된 EventDate로 변경

<br>

## 🙇🏻 중점 리뷰 요청

- Response에 있는 DTO에 EventDate가 들어오게 되면서 비즈니스 로직처럼 느껴져 바깥으로 추출했는데, 혹시 더 나은 방법이 있을까요? LocalDate만 인자로 받게 하는 방법도 있을 것 같아요.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 조직(Organization) 조회 시, 축제 시작일과 종료일이 조직의 이벤트 날짜 중 가장 이른 날짜와 가장 늦은 날짜로 제공됩니다. 이벤트 날짜가 없을 경우 해당 값은 null로 표시됩니다.

* **버그 수정**
  * 조직 정보에서 더 이상 startDate와 endDate 필드를 사용하지 않습니다.

* **테스트**
  * 조직 조회 시 이벤트 날짜 처리에 대한 테스트가 추가 및 개선되었습니다.
  * 이벤트 날짜가 없는 경우와 여러 날짜가 있는 경우의 응답을 검증하는 테스트가 추가되었습니다.

* **데이터**
  * 예시 데이터에서 조직의 날짜 관련 필드가 제거되고, 이벤트 및 장소 상세 정보 데이터가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->