### PR TITLE
[FE] Q&A 페이지 구현

### DIFF
--- a/frontend/src/components/common/ConfirmModal.jsx
+++ b/frontend/src/components/common/ConfirmModal.jsx
@@ -1,7 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Modal from './Modal';
 
-const ConfirmModal = ({ title, message, onConfirm, onCancel }) => (
+const ConfirmModal = ({ title, message, onConfirm, onCancel }) => {
+    useEffect(() => {
+        const handleKeyPress = (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                onConfirm();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                onCancel();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyPress);
+        return () => {
+            document.removeEventListener('keydown', handleKeyPress);
+        };
+    }, [onConfirm, onCancel]);
+
+    return (
     <Modal isOpen={true} onClose={onCancel} maxWidth="max-w-sm">
         <h3 className="text-lg font-bold mb-4">{title}</h3><p>{message}</p>
         <div className="mt-6 flex justify-end space-x-3">
@@ -9,6 +27,7 @@ const ConfirmModal = ({ title, message, onConfirm, onCancel }) => (
             <button onClick={onConfirm} className="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg">삭제</button>
         </div>
     </Modal>
-);
+    );
+};
 
 export default ConfirmModal;

--- a/frontend/src/components/modals/QnaModal.jsx
+++ b/frontend/src/components/modals/QnaModal.jsx
@@ -9,6 +9,13 @@ const QnaModal = ({ qna, onSave, onClose }) => {
         setAnswer(qna?.answer || '');
     }, [qna]);
     const handleSave = () => { onSave({ question, answer }); onClose(); };
+    
+    const handleKeyPress = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSave();
+        }
+    };
 
     return (
         <Modal isOpen={true} onClose={onClose}>
@@ -16,11 +23,25 @@ const QnaModal = ({ qna, onSave, onClose }) => {
             <div className="space-y-4">
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">질문</label>
-                    <input type="text" value={question} onChange={e => setQuestion(e.target.value)} placeholder="[20자 이내로 작성해주세요]" className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
+                    <input 
+                        type="text" 
+                        value={question} 
+                        onChange={e => setQuestion(e.target.value)} 
+                        onKeyPress={handleKeyPress}
+                        placeholder="[20자 이내로 작성해주세요]" 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    />
                 </div>
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">답변</label>
-                    <textarea value={answer} onChange={e => setAnswer(e.target.value)} rows="4" placeholder="사용자가 이해하기 쉽게 친절한 답변을 작성해주세요." className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" />
+                    <textarea 
+                        value={answer} 
+                        onChange={e => setAnswer(e.target.value)} 
+                        onKeyPress={handleKeyPress}
+                        rows="4" 
+                        placeholder="사용자가 이해하기 쉽게 친절한 답변을 작성해주세요." 
+                        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
+                    />
                 </div>
             </div>
             <div className="mt-6 flex justify-between w-full">

--- a/frontend/src/components/modals/QnaModal.jsx
+++ b/frontend/src/components/modals/QnaModal.jsx
@@ -10,12 +10,22 @@ const QnaModal = ({ qna, onSave, onClose }) => {
     }, [qna]);
     const handleSave = () => { onSave({ question, answer }); onClose(); };
     
-    const handleKeyPress = (e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            handleSave();
-        }
-    };
+    useEffect(() => {
+        const handleKeyPress = (e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleSave();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyPress);
+        return () => {
+            document.removeEventListener('keydown', handleKeyPress);
+        };
+    }, [question, answer, onClose]);
 
     return (
         <Modal isOpen={true} onClose={onClose}>
@@ -27,8 +37,7 @@ const QnaModal = ({ qna, onSave, onClose }) => {
                         type="text" 
                         value={question} 
                         onChange={e => setQuestion(e.target.value)} 
-                        onKeyPress={handleKeyPress}
-                        placeholder="[20자 이내로 작성해주세요]" 
+                        placeholder="질문을 작성해 주세요" 
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
                     />
                 </div>
@@ -37,9 +46,8 @@ const QnaModal = ({ qna, onSave, onClose }) => {
                     <textarea 
                         value={answer} 
                         onChange={e => setAnswer(e.target.value)} 
-                        onKeyPress={handleKeyPress}
                         rows="4" 
-                        placeholder="사용자가 이해하기 쉽게 친절한 답변을 작성해주세요." 
+                        placeholder="답변을 작성해 주세요" 
                         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500" 
                     />
                 </div>

--- a/frontend/src/data/initialData.js
+++ b/frontend/src/data/initialData.js
@@ -8,15 +8,6 @@ export const initialData = {
         { id: 1, name: '검정색 카드지갑', location: '대운동장 스탠드', date: '2025-07-18', photo: 'https://placehold.co/100x100/e0e0e0/757575?text=Photo', status: '보관중' },
         { id: 2, name: '에어팟 프로', location: '본관 화장실', date: '2025-07-17', photo: 'https://placehold.co/100x100/e2e8f0/4a5568?text=Photo', status: '인계완료' },
     ],
-    qnaItems: [
-        { id: 1, question: '초청가수 공연은 몇시부터 하나요?', answer: '안녕하세요! 초청가수 공연은 금일 21시부터 대운동장에서 시작될 예정입니다. 많은 관심 부탁드립니다.' },
-        { id: 2, question: '흡연구역은 어디에 있나요?', answer: '흡연구역은 학생회관 뒤편과 공대 3호관 옆에 마련되어 있습니다. 지정된 장소에서만 흡연 부탁드립니다.' },
-        { id: 3, question: '주점은 외부인도 이용 가능한가요?', answer: '네, 가능합니다. 다만, 주류 구매 시에는 신분증 확인이 필요할 수 있습니다.' },
-        { id: 4, question: '축제 기간 동안 도서관은 운영하나요?', answer: '축제 기간 동안 도서관은 단축 운영됩니다. 자세한 시간은 도서관 홈페이지 공지를 확인해주세요.' },
-        { id: 5, question: '주차는 어디에 할 수 있나요?', answer: '방문객 주차는 정문 지하주차장을 이용해주시기 바랍니다. 주차 공간이 협소하니 가급적 대중교통 이용을 부탁드립니다.' },
-        { id: 6, question: '응급 의료 지원 부스는 어디에 있나요?', answer: '의료 지원 부스는 학생회관 1층 로비에 마련되어 있습니다.' },
-        { id: 7, question: '화장실은 어디에 있나요?', answer: '각 건물 1층 및 축제 행사장 곳곳에 이동식 화장실이 비치되어 있습니다.' },
-    ],
     schedule: {
         "2025-07-18": [
             { id: 1, startTime: "14:00", endTime: "16:00", title: "동아리 연합 공연", location: "소극장", status: '종료' },
@@ -28,12 +19,4 @@ export const initialData = {
             { id: 5, startTime: "13:00", endTime: "17:00", title: "플리마켓 & 체험부스", location: "학생회관 앞", status: '예정' },
         ]
     },
-    booths: [
-        { id: 1, editKey: 'key123', title: '컴퓨터공학과 주점', category: 'BAR', description: '시원한 맥주와 맛있는 파전!', images: ['https://placehold.co/400x300/e2e8f0/4a5568?text=Image+1'], mainImageIndex: 0, location: '학생회관 앞', host: '컴퓨터공학과 학생회', startTime: '18:00', endTime: '23:00', notices: [{id: 1, text: '오늘의 추천 메뉴: 해물파전!'}], coords: null },
-        { id: 2, editKey: 'key456', title: '타코야끼 푸드트럭', category: 'FOOD_TRUCK', description: '오사카 정통 타코야끼', images: ['https://placehold.co/400x300/e2e8f0/4a5568?text=Image+1', 'https://placehold.co/400x300/e2e8f0/4a5568?text=Image+2', 'https://placehold.co/400x300/e2e8f0/4a5568?text=Image+3'], mainImageIndex: 1, location: '농구장 옆', host: '타코야끼 사장님', startTime: '12:00', endTime: '22:00', notices: [], coords: null },
-        { id: 3, editKey: 'key789', title: '중앙 흡연구역', category: 'SMOKING', description: '학생회관 뒤편에 위치해있습니다.', images: ['https://placehold.co/400x300/cbd5e1/475569?text=Image+1'], mainImageIndex: 0, location: '학생회관 뒤편', host: '총학생회', startTime: '00:00', endTime: '23:59', notices: [], coords: null },
-        { id: 4, editKey: 'key101', title: '페이스페인팅 부스', category: 'BOOTH', description: '무료로 예쁜 그림을 그려드려요!', images: [], mainImageIndex: -1, location: '도서관 앞', host: '미술 동아리', startTime: '13:00', endTime: '17:00', notices: [{id: 1, text: '재료 소진 시 조기 마감될 수 있습니다.'}], coords: null },
-        { id: 5, editKey: 'key112', title: '경영학과 주점', category: 'BAR', description: '칵테일과 함께하는 즐거운 밤!', images: ['https://placehold.co/400x300/fecaca/991b1b?text=Image+1', 'https://placehold.co/400x300/fecaca/991b1b?text=Image+2'], mainImageIndex: 0, location: '중앙 광장', host: '경영학과 학생회', startTime: '18:00', endTime: '00:00', notices: [{id: 1, text: '신분증 미지참 시 주류 구매가 불가합니다.'}, {id: 2, text: '외부 음식 반입 금지'}], coords: null },
-        { id: 6, editKey: 'key131', title: '분리수거 쓰레기통', category: 'TRASH_CAN', description: '깨끗한 축제를 위해 분리수거에 동참해주세요.', images: [], mainImageIndex: -1, location: '각 건물 입구', host: '총학생회', startTime: '00:00', endTime: '23:59', notices: [], coords: null },
-    ],
 };

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -112,4 +112,62 @@ export const scheduleAPI = {
   }
 };
 
+// QnA 관련 API
+export const qnaAPI = {
+  // 모든 QnA 조회
+  getQuestions: async () => {
+    try {
+      const response = await api.get('/questions');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch questions:', error);
+      throw new Error('QnA 조회에 실패했습니다.');
+    }
+  },
+
+  // 새 QnA 추가
+  createQuestion: async (questionData) => {
+    try {
+      const response = await api.post('/questions', questionData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to create question:', error);
+      throw new Error('QnA 추가에 실패했습니다.');
+    }
+  },
+
+  // QnA 수정
+  updateQuestion: async (questionId, questionData) => {
+    try {
+      const response = await api.patch(`/questions/${questionId}`, questionData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to update question:', error);
+      throw new Error('QnA 수정에 실패했습니다.');
+    }
+  },
+
+  // QnA 삭제
+  deleteQuestion: async (questionId) => {
+    try {
+      await api.delete(`/questions/${questionId}`);
+      // 성공 시 204 응답, body 없음
+    } catch (error) {
+      console.error('Failed to delete question:', error);
+      throw new Error('QnA 삭제에 실패했습니다.');
+    }
+  },
+
+  // QnA 순서 변경
+  updateQuestionSequences: async (sequences) => {
+    try {
+      const response = await api.patch('/questions/sequences', sequences);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to update question sequences:', error);
+      throw new Error('QnA 순서 변경에 실패했습니다.');
+    }
+  }
+};
+
 export default api;


### PR DESCRIPTION
## #️⃣ 이슈 번호

ex) #312 

<br>

## 🛠️ 작업 내용

- Q&A API 연결
- 모달 ESC, ENTER 반영

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * QnA(질문과 답변) 관리가 서버와 동기화되어 실시간으로 반영됩니다.
  * QnA 항목 추가, 수정, 삭제, 순서 변경 시 성공/실패 알림이 표시됩니다.
  * QnA 페이지에서 데이터가 비동기로 로딩되고, 오류 발생 시 안내 메시지가 표시됩니다.

* **개선 및 변경**
  * QnA 입력창의 안내 문구가 더 직관적으로 변경되었습니다.
  * QnA 항목의 고유 식별자가 일관되게 적용되었습니다.
  * QnA 및 부스 관련 초기 데이터가 제거되었습니다.

* **버그 수정**
  * 모달 창에서 Enter 및 Escape 키로 확인/취소가 정상 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->