### PR TITLE
[AN] BottomNavigationView 중앙 맞지 않는 버그 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -185,6 +185,7 @@ class MainActivity : AppCompatActivity() {
             binding.fcvFragmentContainer.updatePadding(
                 bottom = binding.babMenu.height + binding.babMenu.marginBottom,
             )
+            binding.bnvMenu.x = binding.bnvMenu.x / 2
         }
         binding.babMenu.setOnApplyWindowInsetsListener(null)
         binding.babMenu.setPadding(0, 0, 0, 0)


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/320

<br>

## 🛠️ 작업 내용

- 중앙이 맞지 않는 버그 해결하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

# 꼭 에뮬레이터 실행 후 버그 리포트 부탁드립니다

- 저번에도 그렇고 xml상에서는 크게 문제가 없고, preview에서는 문제없이 동작합니다. 
그런데 막상 실기기에서 실행하니 알 수 없는 값들로 미세하게 조정하니 이걸 직접 코드로 정상화 하고 있습니다 
하면 할수록 제가 바보가 되는것 같네요. 이 부분에 대해 의견 나누고 싶어요

<br>

## 📸 이미지 첨부 (Optional)

<img src="https://github.com/user-attachments/assets/057ff3dd-e378-4ea0-af31-3e6ef700ff5c" width="50%" height="50%"/>
