### PR TITLE
[FE] 학생회 홈 페이지 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import BoothModal from './components/modals/BoothModal';
 import CopyLinkModal from './components/modals/CopyLinkModal';
 import FestivalInfoModal from './components/modals/FestivalInfoModal';
 import FestivalImagesModal from './components/modals/FestivalImagesModal';
+import AddImageModal from './components/modals/AddImageModal';
 import ConfirmModal from './components/common/ConfirmModal';
 import Modal from './components/common/Modal';
 import { NoticeDetailModal } from './components/modals/NoticeModal';
@@ -66,7 +67,7 @@ function App() {
 
     const renderModal = () => {
         const { type, props } = modalState;
-        const allProps = { ...props, onClose: closeModal, showToast };
+        const allProps = { ...props, onClose: closeModal, showToast, openModal };
         switch (type) {
             case 'notice': return <NoticeModal {...allProps} />;
             case 'notice-detail': return <NoticeDetailModal {...allProps} />;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import Sidebar from './components/layout/Sidebar';
 
 // Pages
 
-import GenericPage from './pages/GenericPage';
+import HomePage from './pages/HomePage';
 import SchedulePage from './pages/SchedulePage';
 import BoothsPage from './pages/BoothsPage';
 import MapSettingsPage from './pages/MapSettingsPage';
@@ -26,6 +26,8 @@ import ScheduleModal from './components/modals/ScheduleModal';
 import DatePromptModal from './components/modals/DatePromptModal';
 import BoothModal from './components/modals/BoothModal';
 import CopyLinkModal from './components/modals/CopyLinkModal';
+import FestivalInfoModal from './components/modals/FestivalInfoModal';
+import FestivalImagesModal from './components/modals/FestivalImagesModal';
 import ConfirmModal from './components/common/ConfirmModal';
 import Modal from './components/common/Modal';
 import { NoticeDetailModal } from './components/modals/NoticeModal';
@@ -51,14 +53,14 @@ function App() {
     const renderPage = () => {
         switch (page) {
 
-            case 'home': return <GenericPage title="홈" />;
+            case 'home': return <HomePage />;
             case 'schedule': return <SchedulePage />;
             case 'booths': return <BoothsPage />;
             case 'map-settings': return <MapSettingsPage />;
             case 'notices': return <NoticesPage />;
             case 'lost-found': return <LostFoundPage />;
             case 'qna': return <QnaPage />;
-            default: return <GenericPage title="홈" />;
+            default: return <HomePage />;
         }
     };
 
@@ -74,6 +76,8 @@ function App() {
             case 'datePrompt': return <DatePromptModal {...allProps} />;
             case 'booth': return <BoothModal {...allProps} />;
             case 'copyLink': return <CopyLinkModal {...allProps} />;
+            case 'festival-info': return <FestivalInfoModal isOpen={true} {...allProps} />;
+            case 'festival-images': return <FestivalImagesModal isOpen={true} {...allProps} />;
             case 'confirm': return <ConfirmModal {...allProps} onConfirm={() => { props.onConfirm(); closeModal(); }} onCancel={closeModal} />;
             case 'image': return <Modal isOpen={true} onClose={closeModal} maxWidth="max-w-4xl"><div className="relative"><img src={props.src} className="max-w-full max-h-[80vh] rounded-lg mx-auto" alt="상세 이미지" /><button onClick={closeModal} className="absolute top-2 right-2 text-white text-3xl bg-black bg-opacity-50 rounded-full w-8 h-8 flex items-center justify-center">&times;</button></div></Modal>;
             case 'organization':

--- a/frontend/src/components/modals/AddImageModal.jsx
+++ b/frontend/src/components/modals/AddImageModal.jsx
@@ -1,0 +1,216 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Modal from '../common/Modal';
+
+const AddImageModal = ({ isOpen, onClose, showToast }) => {
+    const [selectedFile, setSelectedFile] = useState(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // ESC 키 이벤트 리스너
+    useEffect(() => {
+        const handleEscKey = (event) => {
+            if (event.key === 'Escape' && isOpen && !isUploading) {
+                event.preventDefault();
+                event.stopPropagation();
+                onClose();
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('keydown', handleEscKey, true);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleEscKey, true);
+        };
+    }, [isOpen, isUploading, onClose]);
+
+    // 모달이 닫힐 때 상태 초기화
+    useEffect(() => {
+        if (!isOpen) {
+            setSelectedFile(null);
+            setIsDragging(false);
+            setIsUploading(false);
+        }
+    }, [isOpen]);
+
+    const handleClose = () => {
+        if (!isUploading) {
+            onClose();
+        }
+    };
+
+    const validateFile = (file) => {
+        const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
+        const maxSize = 5 * 1024 * 1024; // 5MB
+
+        if (!allowedTypes.includes(file.type)) {
+            showToast('PNG, JPG, JPEG 파일만 업로드 가능합니다.');
+            return false;
+        }
+
+        if (file.size > maxSize) {
+            showToast('파일 크기는 5MB 이하여야 합니다.');
+            return false;
+        }
+
+        return true;
+    };
+
+    const handleFileSelect = (file) => {
+        if (validateFile(file)) {
+            setSelectedFile(file);
+        }
+    };
+
+    const handleFileInputChange = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+            handleFileSelect(file);
+        }
+    };
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+    };
+
+    const handleDrop = (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+        
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            handleFileSelect(files[0]);
+        }
+    };
+
+    const handleUploadClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleUpload = async () => {
+        if (!selectedFile) {
+            showToast('업로드할 이미지를 선택해주세요.');
+            return;
+        }
+
+        setIsUploading(true);
+        
+        try {
+            // TODO: API 호출로 이미지 업로드
+            // const formData = new FormData();
+            // formData.append('image', selectedFile);
+            // const response = await api.post('/organizations/images', formData);
+            
+            // 임시 지연 (실제 API 호출 시 제거)
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            
+            showToast('이미지가 성공적으로 업로드되었습니다.');
+            onClose();
+        } catch (error) {
+            showToast('이미지 업로드에 실패했습니다.');
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose} maxWidth="max-w-md">
+            <div className="p-6">
+                <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">새 이미지 추가</h2>
+                
+                {/* 이미지 선택 영역 */}
+                <div className="mb-6">
+                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                        이미지 선택
+                    </label>
+                    <div
+                        className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                            isDragging 
+                                ? 'border-blue-500 bg-blue-50' 
+                                : selectedFile 
+                                    ? 'border-green-500 bg-green-50' 
+                                    : 'border-gray-300 hover:border-gray-400'
+                        }`}
+                        onClick={handleUploadClick}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onDrop={handleDrop}
+                    >
+                        {selectedFile ? (
+                            <div>
+                                <div className="w-16 h-16 mx-auto mb-4 bg-green-100 rounded-full flex items-center justify-center">
+                                    <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                    </svg>
+                                </div>
+                                <p className="text-green-700 font-medium mb-1">{selectedFile.name}</p>
+                                <p className="text-green-600 text-sm">
+                                    {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                                </p>
+                                <p className="text-gray-500 text-xs mt-2">클릭하여 다른 파일 선택</p>
+                            </div>
+                        ) : (
+                            <div>
+                                <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
+                                    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                                    </svg>
+                                </div>
+                                <p className="text-gray-700 font-medium mb-1">클릭하여 이미지 선택</p>
+                                <p className="text-gray-500 text-sm">PNG, JPG, JPEG (최대 5MB)</p>
+                                <p className="text-gray-400 text-xs mt-2">또는 파일을 여기에 드래그하세요</p>
+                            </div>
+                        )}
+                    </div>
+                    
+                    {/* 숨겨진 파일 입력 */}
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/png,image/jpeg,image/jpg"
+                        onChange={handleFileInputChange}
+                        className="hidden"
+                    />
+                </div>
+
+                {/* 액션 버튼 */}
+                <div className="flex justify-end space-x-3">
+                    <button
+                        onClick={handleClose}
+                        disabled={isUploading}
+                        className="px-4 py-2 text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        취소
+                    </button>
+                    <button
+                        onClick={handleUpload}
+                        disabled={!selectedFile || isUploading}
+                        className="px-4 py-2 text-white bg-gray-600 rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+                    >
+                        {isUploading ? (
+                            <>
+                                <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                업로드 중...
+                            </>
+                        ) : (
+                            '업로드'
+                        )}
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default AddImageModal; 

--- a/frontend/src/components/modals/FestivalImagesModal.jsx
+++ b/frontend/src/components/modals/FestivalImagesModal.jsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import Modal from '../common/Modal';
+
+const FestivalImagesModal = ({ isOpen, onClose, organization, showToast }) => {
+    const [selectedImage, setSelectedImage] = useState(null);
+
+    // ESC 키 이벤트 리스너
+    useEffect(() => {
+        const handleEscKey = (event) => {
+            if (event.key === 'Escape' && selectedImage) {
+                handleCloseDetail();
+            }
+        };
+
+        if (selectedImage) {
+            document.addEventListener('keydown', handleEscKey);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleEscKey);
+        };
+    }, [selectedImage]);
+
+    const handleImageClick = (image) => {
+        setSelectedImage(image);
+    };
+
+    const handleCloseDetail = () => {
+        setSelectedImage(null);
+    };
+
+    const handleDeleteImage = (imageId) => {
+        // TODO: API 호출로 이미지 삭제
+        showToast('이미지 삭제 기능은 준비 중입니다.');
+    };
+
+    const handleEditImage = (imageId) => {
+        // TODO: 이미지 수정 모달 열기
+        showToast('이미지 수정 기능은 준비 중입니다.');
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} maxWidth="max-w-7xl">
+            <div className="p-6">
+                <div className="flex justify-between items-center mb-6">
+                    <h2 className="text-2xl font-bold text-gray-900">축제 이미지 관리</h2>
+                    <button 
+                        onClick={() => showToast('이미지 업로드 기능은 준비 중입니다.')}
+                        className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                    >
+                        새 이미지 추가
+                    </button>
+                </div>
+
+                {organization?.festivalImages && organization.festivalImages.length > 0 ? (
+                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-[600px] overflow-y-auto">
+                        {organization.festivalImages.map((image, index) => (
+                            <div
+                                key={image.id}
+                                className="relative group cursor-pointer"
+                                onClick={() => handleImageClick(image)}
+                            >
+                            <div className="aspect-[3/4]
+                                            bg-gray-200 rounded-lg overflow-hidden
+                                            transition-colors">
+                                    <img
+                                        src={image.imageUrl}
+                                        alt={`축제 이미지 ${index + 1}`}
+                                        className="w-full h-full object-cover"
+                                    />
+                                </div>
+                                <div className="absolute top-2 right-2 bg-black bg-opacity-75 text-white text-xs px-2 py-1 rounded">
+                                    {index + 1}
+                                </div>
+                                <div className="absolute inset-0
+                                                    bg-black/0
+                                                    group-hover:bg-black/50
+                                                    transition-all duration-200
+                                                    rounded-lg
+                                                    pointer-events-none">
+                                    <div className="absolute inset-0 flex items-center justify-center
+                                                    opacity-0 group-hover:opacity-100
+                                                    transition-opacity duration-200
+                                                    pointer-events-auto">
+                                        <span className="text-white text-sm font-medium">클릭하여 상세보기</span>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="text-center py-12">
+                        <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        <p className="text-gray-500 mb-4">축제 이미지가 없습니다</p>
+                        <button 
+                            onClick={() => showToast('이미지 업로드 기능은 준비 중입니다.')}
+                            className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                        >
+                            첫 번째 이미지 추가
+                        </button>
+                    </div>
+                )}
+
+                {/* 이미지 상세 보기 오버레이 */}
+                {selectedImage && (
+                    <div 
+                        className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+                        onClick={handleCloseDetail}
+                    >
+                        <div 
+                            className="relative"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <img
+                                src={selectedImage.imageUrl}
+                                alt="상세 이미지"
+                                className="rounded-lg shadow-2xl"
+                                style={{
+                                    maxWidth: '100vw',
+                                    maxHeight: '95vh',
+                                    width: 'auto',
+                                    height: 'auto',
+                                    display: 'block'
+                                }}
+                            />
+                            {/* 닫기 버튼 */}
+                            <button 
+                                onClick={handleCloseDetail}
+                                className="absolute top-4 right-4 bg-black bg-opacity-60 text-white p-2 rounded-full hover:bg-opacity-80 transition-colors"
+                            >
+                                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                <div className="flex justify-end mt-6">
+                    <button
+                        onClick={onClose}
+                        className="bg-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-400 transition-colors"
+                    >
+                        닫기
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default FestivalImagesModal; 

--- a/frontend/src/components/modals/FestivalImagesModal.jsx
+++ b/frontend/src/components/modals/FestivalImagesModal.jsx
@@ -257,7 +257,7 @@ const FestivalImagesModal = ({ isOpen, onClose, organization, showToast, openMod
                         </svg>
                         <p className="text-gray-500 mb-4">축제 이미지가 없습니다</p>
                         <button 
-                            onClick={() => showToast('이미지 업로드 기능은 준비 중입니다.')}
+                            onClick={handleAddImageClick}
                             className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
                         >
                             첫 번째 이미지 추가

--- a/frontend/src/components/modals/FestivalImagesModal.jsx
+++ b/frontend/src/components/modals/FestivalImagesModal.jsx
@@ -1,42 +1,148 @@
 import React, { useState, useEffect } from 'react';
 import Modal from '../common/Modal';
+import AddImageModal from './AddImageModal';
 
-const FestivalImagesModal = ({ isOpen, onClose, organization, showToast }) => {
+const FestivalImagesModal = ({ isOpen, onClose, organization, showToast, openModal }) => {
     const [selectedImage, setSelectedImage] = useState(null);
+    const [isReorderMode, setIsReorderMode] = useState(false);
+    const [isDeleteMode, setIsDeleteMode] = useState(false);
+    const [images, setImages] = useState([]);
+    const [draggedItem, setDraggedItem] = useState(null);
+    const [imagesToDelete, setImagesToDelete] = useState([]);
+    const [showAddImageModal, setShowAddImageModal] = useState(false);
 
     // ESC 키 이벤트 리스너
     useEffect(() => {
         const handleEscKey = (event) => {
-            if (event.key === 'Escape' && selectedImage) {
-                handleCloseDetail();
+            if (event.key === 'Escape' && isOpen) {
+                if (selectedImage) {
+                    handleCloseDetail();
+                } else if (isReorderMode || isDeleteMode) {
+                    handleCancelMode();
+                } else {
+                    onClose();
+                }
             }
         };
 
-        if (selectedImage) {
+        if (isOpen) {
             document.addEventListener('keydown', handleEscKey);
         }
 
         return () => {
             document.removeEventListener('keydown', handleEscKey);
         };
-    }, [selectedImage]);
+    }, [selectedImage, isReorderMode, isDeleteMode, onClose, isOpen]);
+
+    // 이미지 데이터 초기화 및 모달 상태 관리
+    useEffect(() => {
+        if (isOpen) {
+            if (organization?.festivalImages) {
+                setImages([...organization.festivalImages]);
+            }
+        } else {
+            // 모달이 닫힐 때 모든 상태 초기화
+            setSelectedImage(null);
+            setIsReorderMode(false);
+            setIsDeleteMode(false);
+            setDraggedItem(null);
+            setImagesToDelete([]);
+            setShowAddImageModal(false);
+        }
+    }, [organization, isOpen]);
 
     const handleImageClick = (image) => {
-        setSelectedImage(image);
+        if (!isReorderMode && !isDeleteMode) {
+            setSelectedImage(image);
+        }
     };
 
     const handleCloseDetail = () => {
         setSelectedImage(null);
     };
 
-    const handleDeleteImage = (imageId) => {
-        // TODO: API 호출로 이미지 삭제
-        showToast('이미지 삭제 기능은 준비 중입니다.');
+    // 드래그 앤 드롭 함수들
+    const handleDragStart = (e, image) => {
+        if (isReorderMode) {
+            setDraggedItem(image);
+            e.dataTransfer.effectAllowed = 'move';
+        }
     };
 
-    const handleEditImage = (imageId) => {
-        // TODO: 이미지 수정 모달 열기
-        showToast('이미지 수정 기능은 준비 중입니다.');
+    const handleDragOver = (e) => {
+        if (isReorderMode) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+        }
+    };
+
+    const handleDrop = (e, targetImage) => {
+        if (isReorderMode && draggedItem && draggedItem.id !== targetImage.id) {
+            e.preventDefault();
+            
+            const draggedIndex = images.findIndex(img => img.id === draggedItem.id);
+            const targetIndex = images.findIndex(img => img.id === targetImage.id);
+            
+            const newImages = [...images];
+            const [removed] = newImages.splice(draggedIndex, 1);
+            newImages.splice(targetIndex, 0, removed);
+            
+            setImages(newImages);
+            setDraggedItem(null);
+        }
+    };
+
+    const handleDragEnd = () => {
+        setDraggedItem(null);
+    };
+
+    // 삭제 모드 함수들
+    const handleDeleteToggle = (imageId) => {
+        if (isDeleteMode) {
+            setImagesToDelete(prev => 
+                prev.includes(imageId) 
+                    ? prev.filter(id => id !== imageId)
+                    : [...prev, imageId]
+            );
+        }
+    };
+
+    const handleSaveOrder = async () => {
+        try {
+            // TODO: API 호출로 순서 저장
+            showToast('이미지 순서가 저장되었습니다.');
+            setIsReorderMode(false);
+        } catch (error) {
+            showToast('순서 저장에 실패했습니다.');
+        }
+    };
+
+    const handleSaveDeletions = async () => {
+        try {
+            // TODO: API 호출로 삭제된 이미지들 처리
+            const newImages = images.filter(img => !imagesToDelete.includes(img.id));
+            setImages(newImages);
+            setImagesToDelete([]);
+            setIsDeleteMode(false);
+            showToast('선택된 이미지들이 삭제되었습니다.');
+        } catch (error) {
+            showToast('삭제에 실패했습니다.');
+        }
+    };
+
+    const handleCancelMode = () => {
+        setIsReorderMode(false);
+        setIsDeleteMode(false);
+        setDraggedItem(null);
+        setImagesToDelete([]);
+        // 원본 데이터로 복원
+        if (organization?.festivalImages) {
+            setImages([...organization.festivalImages]);
+        }
+    };
+
+    const handleAddImageClick = () => {
+        setShowAddImageModal(true);
     };
 
     return (
@@ -44,47 +150,103 @@ const FestivalImagesModal = ({ isOpen, onClose, organization, showToast }) => {
             <div className="p-6">
                 <div className="flex justify-between items-center mb-6">
                     <h2 className="text-2xl font-bold text-gray-900">축제 이미지 관리</h2>
-                    <button 
-                        onClick={() => showToast('이미지 업로드 기능은 준비 중입니다.')}
-                        className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
-                    >
-                        새 이미지 추가
-                    </button>
+                    <div className="flex space-x-2">
+                        {!isReorderMode && !isDeleteMode && (
+                            <>
+                                <button 
+                                    onClick={() => setIsReorderMode(true)}
+                                    className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+                                >
+                                    순서 변경
+                                </button>
+                                <button 
+                                    onClick={() => setIsDeleteMode(true)}
+                                    className="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition-colors"
+                                >
+                                    삭제
+                                </button>
+                                <button 
+                                    onClick={handleAddImageClick}
+                                    className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                                >
+                                    새 이미지 추가
+                                </button>
+                            </>
+                        )}
+                        {(isReorderMode || isDeleteMode) && (
+                            <>
+                                <button 
+                                    onClick={isReorderMode ? handleSaveOrder : handleSaveDeletions}
+                                    className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
+                                >
+                                    {isReorderMode ? '순서 저장' : '삭제 완료'}
+                                </button>
+                                <button 
+                                    onClick={handleCancelMode}
+                                    className="bg-gray-500 text-white px-4 py-2 rounded-lg hover:bg-gray-600 transition-colors"
+                                >
+                                    취소
+                                </button>
+                            </>
+                        )}
+                    </div>
                 </div>
 
-                {organization?.festivalImages && organization.festivalImages.length > 0 ? (
+                {(isReorderMode || isDeleteMode) && (
+                    <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+                        <p className="text-yellow-800 text-sm">
+                            {isReorderMode 
+                                ? '드래그하여 이미지 순서를 변경하세요. 변경사항을 저장하려면 "순서 저장" 버튼을 클릭하세요.'
+                                : '삭제할 이미지들을 선택하세요. 선택 완료 후 "삭제 완료" 버튼을 클릭하세요.'
+                            }
+                        </p>
+                    </div>
+                )}
+
+                {images && images.length > 0 ? (
                     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-[600px] overflow-y-auto">
-                        {organization.festivalImages.map((image, index) => (
+                        {images.map((image, index) => (
                             <div
                                 key={image.id}
-                                className="relative group cursor-pointer"
-                                onClick={() => handleImageClick(image)}
+                                className={`relative group cursor-pointer ${
+                                    isReorderMode ? 'cursor-move' : ''
+                                } ${
+                                    draggedItem?.id === image.id ? 'opacity-50' : ''
+                                }`}
+                                onClick={() => isDeleteMode ? handleDeleteToggle(image.id) : handleImageClick(image)}
+                                draggable={isReorderMode}
+                                onDragStart={(e) => handleDragStart(e, image)}
+                                onDragOver={(e) => handleDragOver(e)}
+                                onDrop={(e) => handleDrop(e, image)}
+                                onDragEnd={handleDragEnd}
                             >
-                            <div className="aspect-[3/4]
-                                            bg-gray-200 rounded-lg overflow-hidden
-                                            transition-colors">
+                                <div className="aspect-[3/4] bg-gray-200 rounded-lg overflow-hidden transition-colors">
                                     <img
                                         src={image.imageUrl}
                                         alt={`축제 이미지 ${index + 1}`}
-                                        className="w-full h-full object-cover"
+                                        className="w-full h-full object-cover pointer-events-none"
                                     />
+                                    {isDeleteMode && imagesToDelete.includes(image.id) && (
+                                        <div className="absolute inset-0 border-4 border-red-500 rounded-lg pointer-events-none"></div>
+                                    )}
                                 </div>
                                 <div className="absolute top-2 right-2 bg-black bg-opacity-75 text-white text-xs px-2 py-1 rounded">
                                     {index + 1}
                                 </div>
-                                <div className="absolute inset-0
-                                                    bg-black/0
-                                                    group-hover:bg-black/50
-                                                    transition-all duration-200
-                                                    rounded-lg
-                                                    pointer-events-none">
-                                    <div className="absolute inset-0 flex items-center justify-center
-                                                    opacity-0 group-hover:opacity-100
-                                                    transition-opacity duration-200
-                                                    pointer-events-auto">
-                                        <span className="text-white text-sm font-medium">클릭하여 상세보기</span>
+                                {isDeleteMode && imagesToDelete.includes(image.id) && (
+                                    <div className="absolute top-2 left-2 bg-red-500 text-white p-1 rounded-full">
+                                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                                        </svg>
                                     </div>
-                                </div>
+                                )}
+                                {!isReorderMode && !isDeleteMode && (
+                                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/50 transition-all duration-200 rounded-lg pointer-events-none">
+                                        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-auto">
+                                            <span className="text-white text-sm font-medium">클릭하여 상세보기</span>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         ))}
                     </div>
@@ -147,6 +309,25 @@ const FestivalImagesModal = ({ isOpen, onClose, organization, showToast }) => {
                     </button>
                 </div>
             </div>
+
+            {/* 새 이미지 추가 모달 (중첩) */}
+            {showAddImageModal && (
+            <AddImageModal
+                key="add-image-modal"
+                isOpen={true}
+                onClose={() => {
+                    setShowAddImageModal(false);
+                    // 상태 초기화
+                    setSelectedImage(null);
+                    setIsReorderMode(false);
+                    setIsDeleteMode(false);
+                    setDraggedItem(null);
+                    setImagesToDelete([]);
+                }}
+                showToast={showToast}
+            />
+            )}
+
         </Modal>
     );
 };

--- a/frontend/src/components/modals/FestivalInfoModal.jsx
+++ b/frontend/src/components/modals/FestivalInfoModal.jsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import Modal from '../common/Modal';
+
+const FestivalInfoModal = ({ isOpen, onClose, organization, showToast }) => {
+    const [formData, setFormData] = useState({
+        festivalName: organization?.festivalName || '',
+        startDate: organization?.startDate ? organization.startDate.split('T')[0] : '',
+        endDate: organization?.endDate ? organization.endDate.split('T')[0] : '',
+        isActive: true // 기본값은 활성화
+    });
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        
+        try {
+            // TODO: API 호출로 축제 정보 업데이트
+            // const response = await api.put('/organizations', formData);
+            
+            showToast('축제 정보가 성공적으로 수정되었습니다.');
+            onClose();
+        } catch (error) {
+            showToast('축제 정보 수정에 실패했습니다.');
+        }
+    };
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({
+            ...prev,
+            [name]: value
+        }));
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} maxWidth="max-w-md">
+            <form onSubmit={handleSubmit}>
+                <h2 className="text-2xl font-bold mb-6 text-center">축제 정보 수정</h2>
+                
+                <div className="space-y-4">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            축제명
+                        </label>
+                        <input
+                            type="text"
+                            name="festivalName"
+                            value={formData.festivalName}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            placeholder="축제명을 입력하세요"
+                            required
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            시작일
+                        </label>
+                        <input
+                            type="date"
+                            name="startDate"
+                            value={formData.startDate}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            required
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            종료일
+                        </label>
+                        <input
+                            type="date"
+                            name="endDate"
+                            value={formData.endDate}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            required
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            축제 상태
+                        </label>
+                        <div className="flex items-center space-x-4">
+                            <label className="flex items-center">
+                                <input
+                                    type="radio"
+                                    name="isActive"
+                                    value="true"
+                                    checked={formData.isActive === true}
+                                    onChange={(e) => setFormData(prev => ({ ...prev, isActive: e.target.value === 'true' }))}
+                                    className="mr-2 text-black focus:ring-black"
+                                />
+                                <span className="text-sm text-gray-700">활성화</span>
+                            </label>
+                            <label className="flex items-center">
+                                <input
+                                    type="radio"
+                                    name="isActive"
+                                    value="false"
+                                    checked={formData.isActive === false}
+                                    onChange={(e) => setFormData(prev => ({ ...prev, isActive: e.target.value === 'true' }))}
+                                    className="mr-2 text-black focus:ring-black"
+                                />
+                                <span className="text-sm text-gray-700">비활성화</span>
+                            </label>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                            비활성화 시 학생 앱에서 축제 정보가 숨겨집니다
+                        </p>
+                    </div>
+                </div>
+                
+                <div className="flex space-x-3 mt-6">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="flex-1 bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-400 transition-colors duration-200"
+                    >
+                        취소
+                    </button>
+                    <button
+                        type="submit"
+                        className="flex-1 bg-black text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-800 transition-colors duration-200"
+                    >
+                        수정
+                    </button>
+                </div>
+            </form>
+        </Modal>
+    );
+};
+
+export default FestivalInfoModal; 

--- a/frontend/src/components/modals/FestivalInfoModal.jsx
+++ b/frontend/src/components/modals/FestivalInfoModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Modal from '../common/Modal';
 
 const FestivalInfoModal = ({ isOpen, onClose, organization, showToast }) => {
@@ -31,6 +31,21 @@ const FestivalInfoModal = ({ isOpen, onClose, organization, showToast }) => {
         }));
     };
 
+    // ESC 키 이벤트 리스너
+    useEffect(() => {
+        const handleEscKey = (event) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleEscKey);
+
+        return () => {
+            document.removeEventListener('keydown', handleEscKey);
+        };
+    }, [onClose]);
+
     return (
         <Modal isOpen={isOpen} onClose={onClose} maxWidth="max-w-md">
             <form onSubmit={handleSubmit}>
@@ -41,12 +56,17 @@ const FestivalInfoModal = ({ isOpen, onClose, organization, showToast }) => {
                         <label className="block text-sm font-medium text-gray-700 mb-2">
                             축제명
                         </label>
-                        <input
-                            type="text"
+                        <textarea
                             name="festivalName"
                             value={formData.festivalName}
                             onChange={handleChange}
-                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' && !e.shiftKey) {
+                                    e.preventDefault();
+                                    handleSubmit(e);
+                                }
+                            }}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black resize-none"
                             placeholder="축제명을 입력하세요"
                             required
                         />

--- a/frontend/src/pages/GenericPage.jsx
+++ b/frontend/src/pages/GenericPage.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const GenericPage = ({ title }) => (
-    <div><h2 className="text-3xl font-bold mb-6">{title}</h2><div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"><p className="text-gray-500">{title} 페이지 콘텐츠가 여기에 표시됩니다.</p></div></div>
-);
-
-export default GenericPage;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -121,7 +121,7 @@ const HomePage = () => {
             {/* 축제 기본 정보 */}
             <div className="bg-white rounded-xl shadow-lg p-6 mb-8">
                 <div className="flex justify-between items-start mb-4">
-                    <h3 className="text-lg font-semibold text-gray-900">축제 정보 설정</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">축제 정보</h3>
                     <button 
                         onClick={() => openModal('festival-info', { organization })}
                         className="text-black hover:text-gray-700 text-sm font-medium"

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -23,22 +23,9 @@ const HomePage = () => {
                 showToast('Organization ID가 설정되지 않았습니다.');
                 return;
             }
-
-            console.log('API 호출 시작:', `/organizations`, 'Organization ID:', orgId);
-            
             const response = await api.get('/organizations');
-            console.log('API 응답:', response.data);
-            
             setOrganization(response.data);
         } catch (error) {
-            console.error('Organization 데이터 로딩 실패:', error);
-            console.error('에러 상세:', {
-                message: error.message,
-                status: error.response?.status,
-                statusText: error.response?.statusText,
-                data: error.response?.data
-            });
-            
             if (error.response?.status === 404) {
                 showToast('조직 정보를 찾을 수 없습니다. Organization ID를 확인해주세요.');
             } else if (error.response?.status === 401) {
@@ -182,7 +169,6 @@ const HomePage = () => {
                                         src={image.imageUrl}
                                         alt={`축제 이미지 ${index + 1}`}
                                         className="w-full h-full object-cover block pointer-events-none"
-                                        onError={() => console.error(`이미지 로딩 실패: ${image.imageUrl}`)}
                                     />
                                     <div className="absolute top-2 right-2 bg-black bg-opacity-75 text-white text-xs px-2 py-1 rounded">
                                         {index + 1}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useModal } from '../hooks/useModal';
+import api from '../utils/api';
+
+const HomePage = () => {
+    const { openModal, showToast } = useModal();
+    const [organization, setOrganization] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [isDragging, setIsDragging] = useState(false);
+    const scrollContainerRef = useRef(null);
+    const dragStartRef = useRef(null);
+    const scrollLeftRef = useRef(null);
+
+    useEffect(() => {
+        fetchOrganizationData();
+    }, []);
+
+    const fetchOrganizationData = async () => {
+        try {
+            setLoading(true);
+            const orgId = localStorage.getItem('organization');
+            if (!orgId) {
+                showToast('Organization ID가 설정되지 않았습니다.');
+                return;
+            }
+
+            console.log('API 호출 시작:', `/organizations`, 'Organization ID:', orgId);
+            
+            const response = await api.get('/organizations');
+            console.log('API 응답:', response.data);
+            
+            setOrganization(response.data);
+        } catch (error) {
+            console.error('Organization 데이터 로딩 실패:', error);
+            console.error('에러 상세:', {
+                message: error.message,
+                status: error.response?.status,
+                statusText: error.response?.statusText,
+                data: error.response?.data
+            });
+            
+            if (error.response?.status === 404) {
+                showToast('조직 정보를 찾을 수 없습니다. Organization ID를 확인해주세요.');
+            } else if (error.response?.status === 401) {
+                showToast('인증에 실패했습니다. Organization ID를 다시 설정해주세요.');
+            } else if (error.code === 'NETWORK_ERROR') {
+                showToast('네트워크 연결을 확인해주세요.');
+            } else {
+                showToast(`데이터를 불러오는데 실패했습니다. (${error.response?.status || '알 수 없는 오류'})`);
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}년 ${month}월 ${day}일`;
+    };
+
+    const handleMouseDown = (e) => {
+        setIsDragging(true);
+        dragStartRef.current = e.pageX - scrollContainerRef.current.offsetLeft;
+        scrollLeftRef.current = scrollContainerRef.current.scrollLeft;
+    };
+
+    const handleMouseMove = (e) => {
+        if (!isDragging) return;
+        e.preventDefault();
+        const x = e.pageX - scrollContainerRef.current.offsetLeft;
+        const walk = (x - dragStartRef.current) * 2;
+        scrollContainerRef.current.scrollLeft = scrollLeftRef.current - walk;
+    };
+
+    const handleMouseUp = () => {
+        setIsDragging(false);
+    };
+
+    const handleMouseLeave = () => {
+        setIsDragging(false);
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-64">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-black"></div>
+            </div>
+        );
+    }
+
+    if (!organization) {
+        return (
+            <div className="text-center py-12">
+                <p className="text-gray-600 mb-4">조직 정보를 불러올 수 없습니다.</p>
+                <button 
+                    onClick={fetchOrganizationData}
+                    className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                >
+                    다시 시도
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-full">
+            {/* 헤더 섹션 */}
+            <div className="mb-8">
+                <div className="flex justify-between items-start">
+                    <div>
+                        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+                            {organization.universityName} 관리
+                        </h1>
+                    </div>
+                </div>
+            </div>
+
+            {/* 축제 기본 정보 */}
+            <div className="bg-white rounded-xl shadow-lg p-6 mb-8">
+                <div className="flex justify-between items-start mb-4">
+                    <h3 className="text-lg font-semibold text-gray-900">축제 정보 설정</h3>
+                    <button 
+                        onClick={() => openModal('festival-info', { organization })}
+                        className="text-black hover:text-gray-700 text-sm font-medium"
+                    >
+                        수정
+                    </button>
+                </div>
+                <div className="space-y-4">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">축제명</label>
+                        <p className="text-lg font-semibold text-gray-900">{organization.festivalName}</p>
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">기간</label>
+                        <p className="text-gray-900">{formatDate(organization.startDate)} - {formatDate(organization.endDate)}</p>
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">상태</label>
+                        <span className={`inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium ${
+                            organization.isActive !== false 
+                                ? 'bg-black text-white' 
+                                : 'bg-gray-300 text-gray-700'
+                        }`}>
+                            {organization.isActive !== false ? '활성' : '비활성'}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            {/* 축제 이미지 갤러리 */}
+            <div className="bg-white rounded-xl shadow-lg p-6 mb-8">
+                <div className="flex justify-between items-center mb-6">
+                    <h3 className="text-lg font-semibold text-gray-900">축제 이미지</h3>
+                    <button 
+                        onClick={() => openModal('festival-images', { organization })}
+                        className="text-black hover:text-gray-700 text-sm font-medium"
+                    >
+                        수정
+                    </button>
+                </div>
+                
+                {organization.festivalImages && organization.festivalImages.length > 0 ? (
+                    <div 
+                        ref={scrollContainerRef}
+                        className={`overflow-x-auto ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+                        onMouseDown={handleMouseDown}
+                        onMouseMove={handleMouseMove}
+                        onMouseUp={handleMouseUp}
+                        onMouseLeave={handleMouseLeave}
+                    >
+                        <div className="flex space-x-4 w-max select-none">
+                            {organization.festivalImages.map((image, index) => (
+                                <div
+                                    key={image.id}
+                                    className="relative group flex-shrink-0 w-[300px] h-[400px] bg-gray-200 rounded-lg overflow-hidden"
+                                >
+                                    <img
+                                        src={image.imageUrl}
+                                        alt={`축제 이미지 ${index + 1}`}
+                                        className="w-full h-full object-cover block pointer-events-none"
+                                        onError={() => console.error(`이미지 로딩 실패: ${image.imageUrl}`)}
+                                    />
+                                    <div className="absolute top-2 right-2 bg-black bg-opacity-75 text-white text-xs px-2 py-1 rounded">
+                                        {index + 1}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="text-center py-12">
+                        <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                        </svg>
+                        <p className="text-gray-500 mb-4">축제 이미지가 없습니다</p>
+                        <button
+                            onClick={() => showToast('이미지 업로드 기능은 준비 중입니다.')}
+                            className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                        >
+                            첫 번째 이미지 추가
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default HomePage; 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#327

<br>

## 🛠️ 작업 내용

- 학생회 홈 페이지 구현

<br>

## 📸 이미지 첨부 (Optional)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b90056f7-3165-4949-9fce-30ddb7ed11bc" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a4b12248-d767-4f6f-b1f2-e3cfd56eea70" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/72e0bba8-9a88-42ed-b91a-ebc8f289992d" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7b701f28-cd3c-4cb9-9674-263ac86894e7" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/859d325a-1ec0-418a-bd46-0e9dd7a9842c" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3c332f3a-ee4a-4783-98b6-39329b6ec020" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5e3a6e93-aa19-4174-a371-12e6b50e0e92" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 축제 정보 편집, 이미지 관리, 이미지 업로드를 위한 새로운 모달(축제 정보, 축제 이미지, 이미지 추가) 기능이 추가되었습니다.
  * 홈 페이지가 새롭게 도입되어 조직 및 축제 데이터를 시각적으로 관리할 수 있습니다.
  * 축제 이미지 갤러리에서 이미지를 드래그하여 순서 변경, 다중 선택 삭제, 이미지 상세 보기 및 업로드가 가능합니다.

* **버그 수정**
  * 없음

* **기타**
  * 기존 GenericPage가 삭제되고 HomePage로 대체되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->