### PR TITLE
[BE] Organization 시작일, 종료일 EventDate와 분리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/event/infrastructure/EventDateJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/event/infrastructure/EventDateJpaRepository.java
@@ -9,7 +9,5 @@ public interface EventDateJpaRepository extends JpaRepository<EventDate, Long> {
 
     List<EventDate> findAllByOrganizationId(Long organizationId);
 
-    List<EventDate> findAllByOrganizationIdOrderByDateAsc(Long organizationId);
-
     boolean existsByOrganizationIdAndDate(Long organizationId, LocalDate date);
 }

--- a/backend/src/main/java/com/daedan/festabook/organization/domain/Organization.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/domain/Organization.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -39,6 +40,12 @@ public class Organization {
     private String festivalName;
 
     @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
     private Integer zoom;
 
     @Embedded
@@ -56,6 +63,8 @@ public class Organization {
             Long id,
             String universityName,
             String festivalName,
+            LocalDate startDate,
+            LocalDate endDate,
             Integer zoom,
             Coordinate centerCoordinate,
             List<Coordinate> polygonHoleBoundary
@@ -68,6 +77,8 @@ public class Organization {
         this.id = id;
         this.universityName = universityName;
         this.festivalName = festivalName;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.zoom = zoom;
         this.centerCoordinate = centerCoordinate;
         this.polygonHoleBoundary = polygonHoleBoundary;
@@ -76,6 +87,8 @@ public class Organization {
     public Organization(
             String universityName,
             String festivalName,
+            LocalDate startDate,
+            LocalDate endDate,
             Integer zoom,
             Coordinate centerCoordinate,
             List<Coordinate> polygonHoleBoundary
@@ -84,6 +97,8 @@ public class Organization {
                 null,
                 universityName,
                 festivalName,
+                startDate,
+                endDate,
                 zoom,
                 centerCoordinate,
                 polygonHoleBoundary

--- a/backend/src/main/java/com/daedan/festabook/organization/dto/OrganizationResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/dto/OrganizationResponse.java
@@ -1,6 +1,9 @@
 package com.daedan.festabook.organization.dto;
 
+import com.daedan.festabook.organization.domain.FestivalImage;
+import com.daedan.festabook.organization.domain.Organization;
 import java.time.LocalDate;
+import java.util.List;
 
 public record OrganizationResponse(
         Long id,
@@ -10,4 +13,15 @@ public record OrganizationResponse(
         LocalDate startDate,
         LocalDate endDate
 ) {
+
+    public static OrganizationResponse from(Organization organization, List<FestivalImage> festivalImages) {
+        return new OrganizationResponse(
+                organization.getId(),
+                organization.getUniversityName(),
+                FestivalImageResponses.from(festivalImages),
+                organization.getFestivalName(),
+                organization.getStartDate(),
+                organization.getEndDate()
+        );
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/organization/service/OrganizationService.java
+++ b/backend/src/main/java/com/daedan/festabook/organization/service/OrganizationService.java
@@ -1,11 +1,8 @@
 package com.daedan.festabook.organization.service;
 
-import com.daedan.festabook.event.domain.EventDate;
-import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.organization.domain.FestivalImage;
 import com.daedan.festabook.organization.domain.Organization;
-import com.daedan.festabook.organization.dto.FestivalImageResponses;
 import com.daedan.festabook.organization.dto.OrganizationGeographyResponse;
 import com.daedan.festabook.organization.dto.OrganizationResponse;
 import com.daedan.festabook.organization.infrastructure.FestivalImageJpaRepository;
@@ -21,7 +18,6 @@ public class OrganizationService {
 
     private final OrganizationJpaRepository organizationJpaRepository;
     private final FestivalImageJpaRepository festivalImageJpaRepository;
-    private final EventDateJpaRepository eventDateJpaRepository;
 
     public OrganizationGeographyResponse getOrganizationGeographyByOrganizationId(Long organizationId) {
         Organization organization = getOrganizationById(organizationId);
@@ -33,16 +29,8 @@ public class OrganizationService {
         Organization organization = getOrganizationById(organizationId);
         List<FestivalImage> festivalImages =
                 festivalImageJpaRepository.findAllByOrganizationIdOrderBySequenceAsc(organizationId);
-        List<EventDate> eventDates = eventDateJpaRepository.findAllByOrganizationIdOrderByDateAsc(organizationId);
 
-        return new OrganizationResponse(
-                organization.getId(),
-                organization.getUniversityName(),
-                FestivalImageResponses.from(festivalImages),
-                organization.getFestivalName(),
-                eventDates.isEmpty() ? null : eventDates.getFirst().getDate(),
-                eventDates.isEmpty() ? null : eventDates.getLast().getDate()
-        );
+        return OrganizationResponse.from(organization, festivalImages);
     }
 
     private Organization getOrganizationById(Long organizationId) {

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,8 +1,8 @@
 -- ========================
 -- 조직 (Organization)
 -- ========================
-INSERT INTO organization (university_name, festival_name, zoom, latitude, longitude)
-VALUES ('서울시립대학교', '2025 시립 Water Festival: AQUA WAVE', 15, 37.583585, 127.0588862);
+INSERT INTO organization (university_name, festival_name, start_date, end_date, zoom, latitude, longitude)
+VALUES ('서울시립대학교', '2025 시립 Water Festival: AQUA WAVE', '2025-08-04', '2025-08-06', 15, 37.583585, 127.0588862);
 
 -- ========================
 -- 축제 이미지 (FestivalImage)
@@ -105,9 +105,9 @@ VALUES (1, 37.5863631, 127.0564018),
 -- 일정 날짜 (EventDate)
 -- ========================
 INSERT INTO event_date (organization_id, date)
-VALUES (1, '2025-07-31'),
-       (1, '2025-08-01'),
-       (1, '2025-08-02');
+VALUES (1, '2025-08-04'),
+       (1, '2025-08-05'),
+       (1, '2025-08-06');
 -- VALUES (1, ADDDATE(CURDATE(), -1)),
 --        (1, CURDATE()),
 --        (1, ADDDATE(CURDATE(), 1));

--- a/backend/src/test/java/com/daedan/festabook/organization/controller/OrganizationControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/controller/OrganizationControllerTest.java
@@ -2,11 +2,7 @@ package com.daedan.festabook.organization.controller;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
 
-import com.daedan.festabook.event.domain.EventDate;
-import com.daedan.festabook.event.domain.EventDateFixture;
-import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.organization.domain.FestivalImage;
 import com.daedan.festabook.organization.domain.FestivalImageFixture;
 import com.daedan.festabook.organization.domain.Organization;
@@ -17,7 +13,6 @@ import io.restassured.RestAssured;
 import io.restassured.config.JsonConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.config.JsonPathConfig;
-import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,9 +38,6 @@ class OrganizationControllerTest {
 
     @Autowired
     private FestivalImageJpaRepository festivalImageJpaRepository;
-
-    @Autowired
-    private EventDateJpaRepository eventDateJpaRepository;
 
     @LocalServerPort
     private int port;
@@ -120,11 +112,6 @@ class OrganizationControllerTest {
             FestivalImage festivalImage1 = FestivalImageFixture.create(organization, 1);
             festivalImageJpaRepository.saveAll(List.of(festivalImage2, festivalImage1));
 
-            EventDate eventDate3 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 3));
-            EventDate eventDate2 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 2));
-            EventDate eventDate1 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
-            eventDateJpaRepository.saveAll(List.of(eventDate3, eventDate2, eventDate1));
-
             int festivalImageSize = 2;
             int expectedFieldSize = 6;
 
@@ -140,8 +127,8 @@ class OrganizationControllerTest {
                     .body("universityName", equalTo(organization.getUniversityName()))
                     .body("festivalImages", hasSize(festivalImageSize))
                     .body("festivalName", equalTo(organization.getFestivalName()))
-                    .body("startDate", equalTo(eventDate1.getDate().toString()))
-                    .body("endDate", equalTo(eventDate3.getDate().toString()))
+                    .body("startDate", equalTo(organization.getStartDate().toString()))
+                    .body("endDate", equalTo(organization.getEndDate().toString()))
 
                     .body("festivalImages[0].id", equalTo(festivalImage1.getId().intValue()))
                     .body("festivalImages[0].imageUrl", equalTo(festivalImage1.getImageUrl()))
@@ -150,51 +137,6 @@ class OrganizationControllerTest {
                     .body("festivalImages[1].id", equalTo(festivalImage2.getId().intValue()))
                     .body("festivalImages[1].imageUrl", equalTo(festivalImage2.getImageUrl()))
                     .body("festivalImages[1].sequence", equalTo(festivalImage2.getSequence()));
-        }
-
-        @Test
-        void 성공_축제_날짜_중_가장_빠른_날짜와_가장_늦은_날짜가_응답됨() {
-            // given
-            Organization organization = OrganizationFixture.create();
-            organizationJpaRepository.save(organization);
-
-            EventDate eventDate1 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
-            EventDate eventDate2 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
-            EventDate eventDate3 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
-            EventDate eventDate4 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
-            eventDateJpaRepository.saveAll(List.of(eventDate4, eventDate3, eventDate2, eventDate1));
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(ORGANIZATION_HEADER_NAME, organization.getId())
-                    .when()
-                    .get("/organizations")
-                    .then()
-                    .statusCode(HttpStatus.OK.value())
-                    .body("startDate", equalTo(eventDate1.getDate().toString()))
-                    .body("endDate", equalTo(eventDate4.getDate().toString()));
-        }
-
-        @Test
-        void 성공_축제_날짜는_null_가능() {
-            // given
-            Organization organization = OrganizationFixture.create();
-            organizationJpaRepository.save(organization);
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(ORGANIZATION_HEADER_NAME, organization.getId())
-                    .when()
-                    .get("/organizations")
-                    .then()
-                    .statusCode(HttpStatus.OK.value())
-                    .body("universityName", equalTo(organization.getUniversityName()))
-                    .body("festivalImages", hasSize(0))
-                    .body("festivalName", equalTo(organization.getFestivalName()))
-                    .body("startDate", nullValue())
-                    .body("endDate", nullValue());
         }
 
         @Test

--- a/backend/src/test/java/com/daedan/festabook/organization/domain/OrganizationFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/domain/OrganizationFixture.java
@@ -1,11 +1,14 @@
 package com.daedan.festabook.organization.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class OrganizationFixture {
 
     private static final String DEFAULT_UNIVERSITY_NAME = "서울시립대학교";
     private static final String DEFAULT_FESTIVAL_NAME = "2025 시립 Water Festival: AQUA WAVE";
+    private static final LocalDate DEFAULT_START_DATE = LocalDate.of(2025, 10, 15);
+    private static final LocalDate DEFAULT_END_DATE = LocalDate.of(2025, 10, 17);
     private static final Integer DEFAULT_ZOOM = 16;
     private static final Coordinate DEFAULT_CENTER_COORDINATE = CoordinateFixture.create();
     private static final List<Coordinate> DEFAULT_POLYGON_HOLE_BOUNDARY = List.of(
@@ -18,6 +21,8 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -30,6 +35,8 @@ public class OrganizationFixture {
         return new Organization(
                 universityName,
                 DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -42,6 +49,8 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
                 zoom,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -54,6 +63,8 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 centerCoordinate,
                 DEFAULT_POLYGON_HOLE_BOUNDARY
@@ -66,6 +77,8 @@ public class OrganizationFixture {
         return new Organization(
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 polygonHoleBoundary
@@ -79,6 +92,8 @@ public class OrganizationFixture {
                 id,
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
                 DEFAULT_POLYGON_HOLE_BOUNDARY

--- a/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/organization/service/OrganizationServiceTest.java
@@ -5,9 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
-import com.daedan.festabook.event.domain.EventDate;
-import com.daedan.festabook.event.domain.EventDateFixture;
-import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.organization.domain.FestivalImage;
 import com.daedan.festabook.organization.domain.FestivalImageFixture;
@@ -17,7 +14,6 @@ import com.daedan.festabook.organization.dto.OrganizationGeographyResponse;
 import com.daedan.festabook.organization.dto.OrganizationResponse;
 import com.daedan.festabook.organization.infrastructure.FestivalImageJpaRepository;
 import com.daedan.festabook.organization.infrastructure.OrganizationJpaRepository;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -38,9 +34,6 @@ class OrganizationServiceTest {
 
     @Mock
     private FestivalImageJpaRepository festivalImageJpaRepository;
-
-    @Mock
-    private EventDateJpaRepository eventDateJpaRepository;
 
     @InjectMocks
     private OrganizationService organizationService;
@@ -92,14 +85,11 @@ class OrganizationServiceTest {
             Long organizationId = 1L;
             Organization organization = OrganizationFixture.create(organizationId);
             List<FestivalImage> festivalImages = FestivalImageFixture.createList(2, organization);
-            List<EventDate> eventDates = EventDateFixture.createList(3, organization);
 
             given(organizationJpaRepository.findById(organizationId))
                     .willReturn(Optional.of(organization));
             given(festivalImageJpaRepository.findAllByOrganizationIdOrderBySequenceAsc(organizationId))
                     .willReturn(festivalImages);
-            given(eventDateJpaRepository.findAllByOrganizationIdOrderByDateAsc(organizationId))
-                    .willReturn(eventDates);
 
             // when
             OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
@@ -112,57 +102,8 @@ class OrganizationServiceTest {
                 s.assertThat(result.festivalImages().responses().get(1).imageUrl())
                         .isEqualTo(festivalImages.get(1).getImageUrl());
                 s.assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
-                s.assertThat(result.startDate()).isEqualTo(eventDates.getFirst().getDate());
-                s.assertThat(result.endDate()).isEqualTo(eventDates.getLast().getDate());
-            });
-        }
-
-        @Test
-        void 성공_축제_날짜_중_가장_빠른_날짜와_가장_늦은_날짜가_응답됨() {
-            // given
-            Long organizationId = 1L;
-            Organization organization = OrganizationFixture.create(organizationId);
-
-            EventDate eventDate1 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 1));
-            EventDate eventDate2 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 4));
-            EventDate eventDate3 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 5));
-            EventDate eventDate4 = EventDateFixture.create(organization, LocalDate.of(2025, 8, 6));
-            List<EventDate> eventDates = List.of(eventDate1, eventDate2, eventDate3, eventDate4);
-
-            given(organizationJpaRepository.findById(organizationId))
-                    .willReturn(Optional.of(organization));
-            given(eventDateJpaRepository.findAllByOrganizationIdOrderByDateAsc(organizationId))
-                    .willReturn(eventDates);
-
-            // when
-            OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
-
-            // then
-            assertSoftly(s -> {
-                s.assertThat(result.startDate()).isEqualTo(eventDate1.getDate());
-                s.assertThat(result.endDate()).isEqualTo(eventDate4.getDate());
-            });
-        }
-
-        @Test
-        void 성공_축제_날짜는_null_가능() {
-            // given
-            Long organizationId = 1L;
-            Organization organization = OrganizationFixture.create(organizationId);
-
-            given(organizationJpaRepository.findById(organizationId))
-                    .willReturn(Optional.of(organization));
-
-            // when
-            OrganizationResponse result = organizationService.getOrganizationByOrganizationId(organizationId);
-
-            // then
-            assertSoftly(s -> {
-                s.assertThat(result.universityName()).isEqualTo(organization.getUniversityName());
-                s.assertThat(result.festivalImages().responses()).isEqualTo(List.of());
-                s.assertThat(result.festivalName()).isEqualTo(organization.getFestivalName());
-                s.assertThat(result.startDate()).isNull();
-                s.assertThat(result.endDate()).isNull();
+                s.assertThat(result.startDate()).isEqualTo(organization.getStartDate());
+                s.assertThat(result.endDate()).isEqualTo(organization.getEndDate());
             });
         }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#265 

<br>

## 🛠️ 작업 내용

- Organization 시작일, 종료일 EventDate와 분리

<br>

## 🙇🏻 중점 리뷰 요청

- 슬랙으로 논의한 부분 그냥 단순 롤백입니다.
- 조직 CUD API 구현을 하기 위한 사전 작업이어서 빠르게 PR 올립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 조직(Organization)에 축제 시작일(startDate)과 종료일(endDate) 정보가 추가되어, 조직 정보에서 축제 기간을 직접 확인할 수 있습니다.

* **버그 수정**
  * 조직 정보 조회 시 축제 날짜가 올바르게 반영되지 않던 문제를 개선하였습니다.

* **테스트**
  * 조직 및 축제 날짜 관련 테스트 코드가 조직의 날짜 필드를 기준으로 단순화 및 정비되었습니다.

* **데이터**
  * 샘플 데이터에 조직의 시작일과 종료일이 추가되고, 축제 날짜가 새로운 기간으로 갱신되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->