### PR TITLE
[BE, CICD] 개발 서버 RDB의 JPA-DDL create-drop 동작 중 테이블 삭제 실패 문제 해결 

### DIFF
--- a/.github/workflows/ci-cd-backend.yml
+++ b/.github/workflows/ci-cd-backend.yml
@@ -59,9 +59,9 @@ jobs:
         echo "JAR_FILE_PATH=${JAR_FILE}" >> $GITHUB_OUTPUT
         echo "JAR_FILE_NAME=$(basename ${JAR_FILE})" >> $GITHUB_OUTPUT
 
-    # 서버의 예전 jar 서버 종료 및 jar 파일 삭제
-    - name: Ubuntu close old server and delete old Jar
-      uses: appleboy/ssh-action@master # SSH를 통해 원격 서버에 명령 실행 및 파일 전송
+    # Spring WAS 종료 및 jar 파일 삭제
+    - name: Ubuntu close Spring WAS and delete old Jar file
+      uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.SSH_HOST }}
         port: ${{ secrets.SSH_PORT }}
@@ -69,30 +69,40 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         passphrase: ${{ secrets.SSH_PASSPHRASE }}
         script: |
-          # 서버에 배포될 경로 설정
+          # Ubuntu Jar 파일 경로 설정 및 생성
           REMOTE_APP_DIR="/home/${{ secrets.SSH_USERNAME }}/${{ github.event.repository.name }}/backend"
+          mkdir -p "${REMOTE_APP_DIR}"
           REMOTE_JAR_PATH="${REMOTE_APP_DIR}/${{ steps.get_jar_name.outputs.JAR_FILE_NAME }}"
-          
           echo "Deploying to ${REMOTE_JAR_PATH}"
           
-          # 원격 디렉토리 생성 (없을 경우)
-          mkdir -p "${REMOTE_APP_DIR}"
-          
-          # 8080 포트를 사용하는 프로세스 종료
-          # lsof 명령어를 사용하여 8080 포트를 점유하고 있는 프로세스의 PID를 찾습니다.
+          # Spring WAS (:8080) 종료
           PID=$(lsof -t -i:8080 || true)
           if [ -n "$PID" ]; then
-            echo "Killing process with PID: $PID that is using port 8080"
-            kill -9 $PID
-            sleep 5 # 프로세스 종료 대기
+            echo "Found running process with PID: $PID. Sending SIGTERM for graceful shutdown."
+            kill -SIGTERM $PID
+            
+            # 프로세스 종료 대기
+            for i in $(seq 1 20); do
+              if ! kill -0 $PID 2>/dev/null; then # `kill -0 $PID` 프로세스 살아있으면 true 응답. !가 존재하니 프로세스가 살아있으면 false가 됨.
+                echo "Process $PID has terminated."
+                break
+              fi
+              echo "Waiting for process $PID to terminate... ($i/20)"
+              sleep 1
+            done
+
+            # SIGTERM 종료 명령 후 프로세스 생존시 강제 종료
+            if kill -0 $PID 2>/dev/null; then
+              echo "Process $PID did not terminate gracefully. Forcing shutdown with SIGKILL."
+              kill -9 $PID
+            fi
           else
             echo "No process found using port 8080."
           fi
           
-          # 이전 JAR 파일 삭제 (선택 사항이지만 권장)
+          # Old JAR 파일 삭제
           rm -f "${REMOTE_APP_DIR}/*.jar"
-
-          echo "Preparation on remote server complete."
+          echo "Old server stopped and old JAR files deleted from ${REMOTE_APP_DIR}."
 
     # scp-action 실행 전, 전송할 파일의 경로와 대상 경로 확인
     - name: Debug print file transfer path info

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  # Graceful Shutdown 활성화
+  shutdown: graceful
+
 spring:
   application:
     name: festabook
@@ -8,6 +12,9 @@ spring:
     defer-datasource-initialization: true
   profiles:
     include: secret
+  lifecycle:
+    # WAS 종료 대기 시간 15초로 설정
+    timeout-per-shutdown-phase: 15s 
 
 # Swagger
 springdoc:


### PR DESCRIPTION
## #️⃣ 이슈 번호

#344 

<br>

## 🛠️ 작업 내용

- Application.yml, CI/CD 스크립트 수정: WAS 종료 로직을 Graceful Shutdown 방식으로 변경함.

- kill -9 대신 SIGTERM 신호 전송: 기존 kill -9 명령어를 kill -SIGTERM으로 수정하여 애플리케이션이 정리 작업을 할 시간을 부여함.

- 종료 대기 및 강제 종료 로직 추가: WAS가 즉시 종료되지 않을 경우, 일정 시간(20초) 동안 대기 후에도 프로세스가 남아있으면 kill -9를 사용하여 강제 종료하도록 스크립트를 개선함.

- application.yml에 Graceful Shutdown 설정 추가: 개발 환경의 안정적인 배포를 위해 Spring Boot의 Graceful Shutdown 기능을 활성화하고, 종료 대기 시간을 15초로 설정함.

<br>

## 🙇🏻 중점 리뷰 요청
- 변경된 종료 로직의 적절성: Graceful Shutdown을 위한 대기 시간(20초) 및 강제 종료 로직이 현재 개발 환경에 적합한지 확인 부탁함.

- 스크립트의 안정성: 셸 스크립트의 문법적, 논리적 오류가 없는지 검토해주면 감사하겠음.

- 설정 파일 변경: application.yml에 추가된 Graceful Shutdown 설정이 다른 부분에 영향을 미치는지 확인이 필요함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 서버 종료 시 최대 15초 동안 정상 종료를 시도하도록 설정이 추가되었습니다.
  * 배포 시 기존 서버 종료 및 JAR 파일 정리 과정이 개선되어, 서버가 정상적으로 종료되지 않을 경우 강제 종료가 이루어집니다.  
  * 배포 디렉토리 생성 단계가 앞당겨져 오류 가능성이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->