### PR TITLE
[AN] 분실물 화면 구현

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -20,6 +20,7 @@ import com.daedan.festabook.data.repository.BookmarkRepositoryImpl
 import com.daedan.festabook.data.repository.DeviceRepositoryImpl
 import com.daedan.festabook.data.repository.FAQRepositoryImpl
 import com.daedan.festabook.data.repository.FestivalRepositoryImpl
+import com.daedan.festabook.data.repository.LostItemRepositoryImpl
 import com.daedan.festabook.data.repository.NoticeRepositoryImpl
 import com.daedan.festabook.data.repository.PlaceDetailRepositoryImpl
 import com.daedan.festabook.data.repository.PlaceListRepositoryImpl
@@ -35,6 +36,7 @@ import com.daedan.festabook.domain.repository.BookmarkRepository
 import com.daedan.festabook.domain.repository.DeviceRepository
 import com.daedan.festabook.domain.repository.FAQRepository
 import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.domain.repository.LostItemRepository
 import com.daedan.festabook.domain.repository.NoticeRepository
 import com.daedan.festabook.domain.repository.PlaceDetailRepository
 import com.daedan.festabook.domain.repository.PlaceListRepository
@@ -99,6 +101,10 @@ class AppContainer(
     }
     val faqRepository: FAQRepository by lazy {
         FAQRepositoryImpl(faqDataSource)
+    }
+
+    val lostItemRepository: LostItemRepository by lazy {
+        LostItemRepositoryImpl()
     }
 
     init {

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.daedan.festabook.data.repository
+
+import com.daedan.festabook.domain.model.LostItem
+import com.daedan.festabook.domain.repository.LostItemRepository
+
+class LostItemRepositoryImpl : LostItemRepository {
+    override fun getAllLostItems(): List<LostItem> =
+        listOf(
+            LostItem(imageId = 1L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 2L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 3L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 4L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 5L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 6L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 7L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 8L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 9L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(imageId = 10L, imageUrl = "https://picsum.photos/200/300"),
+        )
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
@@ -6,15 +6,55 @@ import com.daedan.festabook.domain.repository.LostItemRepository
 class LostItemRepositoryImpl : LostItemRepository {
     override fun getAllLostItems(): List<LostItem> =
         listOf(
-            LostItem(imageId = 1L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 2L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 3L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 4L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 5L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 6L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 7L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 8L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 9L, imageUrl = "https://picsum.photos/200/300"),
-            LostItem(imageId = 10L, imageUrl = "https://picsum.photos/200/300"),
+            LostItem(
+                imageId = 1L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "도서관",
+            ),
+            LostItem(
+                imageId = 2L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "학생회관",
+            ),
+            LostItem(
+                imageId = 3L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "체육관",
+            ),
+            LostItem(
+                imageId = 4L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "강의동",
+            ),
+            LostItem(
+                imageId = 5L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "기숙사",
+            ),
+            LostItem(
+                imageId = 6L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "편의점",
+            ),
+            LostItem(
+                imageId = 7L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "카페",
+            ),
+            LostItem(
+                imageId = 8L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "주차장",
+            ),
+            LostItem(
+                imageId = 9L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "정문",
+            ),
+            LostItem(
+                imageId = 10L,
+                imageUrl = "https://picsum.photos/200/300",
+                storageLocation = "후문",
+            ),
         )
 }

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.domain.model
+
+data class LostItem(
+    val imageId: Long,
+    val imageUrl: String,
+)

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
@@ -3,4 +3,5 @@ package com.daedan.festabook.domain.model
 data class LostItem(
     val imageId: Long,
     val imageUrl: String,
+    val storageLocation: String,
 )

--- a/android/app/src/main/java/com/daedan/festabook/domain/repository/LostItemRepository.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/repository/LostItemRepository.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.domain.repository
+
+import com.daedan.festabook.domain.model.LostItem
+
+interface LostItemRepository {
+    fun getAllLostItems(): List<LostItem>
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/FragmentUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/FragmentUtil.kt
@@ -19,7 +19,7 @@ import com.daedan.festabook.presentation.placeList.behavior.PlaceListScrollBehav
 import com.google.android.material.snackbar.Snackbar
 
 inline fun <reified T : Parcelable> Bundle.getObject(key: String): T? =
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getParcelable(key, T::class.java)
     } else {
         getParcelable(key)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsFragment.kt
@@ -8,6 +8,7 @@ import com.daedan.festabook.databinding.FragmentNewsBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.news.adapter.NewsPagerAdapter
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
 import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 import com.google.android.material.tabs.TabLayoutMediator
@@ -36,6 +37,10 @@ class NewsFragment :
 
     override fun onFAQClick(faqItem: FAQItemUiModel) {
         viewModel.toggleFAQExpanded(faqItem)
+    }
+
+    override fun onLostItemClick(lostItem: LostItemUiModel) {
+        viewModel.lostItemClick(lostItem)
     }
 
     private fun setupNewsTabLayout() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
@@ -10,10 +10,13 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.daedan.festabook.FestaBookApp
 import com.daedan.festabook.domain.repository.FAQRepository
+import com.daedan.festabook.domain.repository.LostItemRepository
 import com.daedan.festabook.domain.repository.NoticeRepository
 import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 import com.daedan.festabook.presentation.news.faq.model.toUiModel
+import com.daedan.festabook.presentation.news.lost.LostItemUiState
+import com.daedan.festabook.presentation.news.lost.model.toUiModel
 import com.daedan.festabook.presentation.news.notice.NoticeUiState
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 import com.daedan.festabook.presentation.news.notice.model.toUiModel
@@ -22,6 +25,7 @@ import kotlinx.coroutines.launch
 class NewsViewModel(
     private val noticeRepository: NoticeRepository,
     private val faqRepository: FAQRepository,
+    private val lostItemRepository: LostItemRepository,
 ) : ViewModel() {
     private val _noticeUiState: MutableLiveData<NoticeUiState> = MutableLiveData<NoticeUiState>()
     val noticeUiState: LiveData<NoticeUiState> = _noticeUiState
@@ -29,9 +33,13 @@ class NewsViewModel(
     private val _faqUiState: MutableLiveData<FAQUiState> = MutableLiveData()
     val faqUiState: LiveData<FAQUiState> get() = _faqUiState
 
+    private val _lostItemUiState: MutableLiveData<LostItemUiState> = MutableLiveData()
+    val lostItemUiState: LiveData<LostItemUiState> get() = _lostItemUiState
+
     init {
         loadAllNotices(NoticeUiState.InitialLoading)
         loadAllFAQs()
+        loadAllLostItems()
     }
 
     fun loadAllNotices(state: NoticeUiState = NoticeUiState.Loading) {
@@ -70,6 +78,12 @@ class NewsViewModel(
                 }
             }
         }
+    }
+
+    private fun loadAllLostItems(state: NoticeUiState = NoticeUiState.Loading) {
+        val lostItems = lostItemRepository.getAllLostItems()
+
+        _lostItemUiState.value = LostItemUiState.Success(lostItems.map { it.toUiModel() })
     }
 
     private fun loadAllFAQs(state: FAQUiState = FAQUiState.InitialLoading) {
@@ -112,7 +126,8 @@ class NewsViewModel(
                     val noticeRepository =
                         festaBookApp.appContainer.noticeRepository
                     val faqRepository = festaBookApp.appContainer.faqRepository
-                    NewsViewModel(noticeRepository, faqRepository)
+                    val lostItemRepository = festaBookApp.appContainer.lostItemRepository
+                    NewsViewModel(noticeRepository, faqRepository, lostItemRepository)
                 }
             }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
@@ -12,10 +12,12 @@ import com.daedan.festabook.FestaBookApp
 import com.daedan.festabook.domain.repository.FAQRepository
 import com.daedan.festabook.domain.repository.LostItemRepository
 import com.daedan.festabook.domain.repository.NoticeRepository
+import com.daedan.festabook.presentation.common.Event
 import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 import com.daedan.festabook.presentation.news.faq.model.toUiModel
 import com.daedan.festabook.presentation.news.lost.LostItemUiState
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
 import com.daedan.festabook.presentation.news.lost.model.toUiModel
 import com.daedan.festabook.presentation.news.notice.NoticeUiState
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
@@ -35,6 +37,9 @@ class NewsViewModel(
 
     private val _lostItemUiState: MutableLiveData<LostItemUiState> = MutableLiveData()
     val lostItemUiState: LiveData<LostItemUiState> get() = _lostItemUiState
+
+    private val _lostItemClickEvent: MutableLiveData<Event<LostItemUiModel>> = MutableLiveData()
+    val lostItemClickEvent: LiveData<Event<LostItemUiModel>> get() = _lostItemClickEvent
 
     init {
         loadAllNotices(NoticeUiState.InitialLoading)
@@ -78,6 +83,10 @@ class NewsViewModel(
                 }
             }
         }
+    }
+
+    fun lostItemClick(lostItem: LostItemUiModel) {
+        _lostItemClickEvent.value = Event(lostItem)
     }
 
     private fun loadAllLostItems(state: NoticeUiState = NoticeUiState.Loading) {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemDecoration.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemDecoration.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.presentation.news.lost
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class LostItemDecoration(
+    private val spanCount: Int,
+    private val spacing: Int,
+) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State,
+    ) {
+        val position = parent.getChildLayoutPosition(view)
+        val column = position % spanCount
+
+        outRect.left = column * spacing / spanCount
+        outRect.right = spacing - (column + 1) * spacing / spanCount
+
+        if (position >= spanCount) {
+            outRect.top = spacing
+        }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemFragment.kt
@@ -1,55 +1,59 @@
 package com.daedan.festabook.presentation.news.lost
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
 import com.daedan.festabook.R
+import com.daedan.festabook.databinding.FragmentLostItemBinding
+import com.daedan.festabook.presentation.common.BaseFragment
+import com.daedan.festabook.presentation.news.NewsViewModel
+import com.daedan.festabook.presentation.news.lost.adapter.LostItemAdapter
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
+class LostItemFragment : BaseFragment<FragmentLostItemBinding>(R.layout.fragment_lost_item) {
+    private val adapter by lazy {
+        LostItemAdapter()
+    }
 
-/**
- * A simple [Fragment] subclass.
- * Use the [LostItemFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
-class LostItemFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    private val viewModel: NewsViewModel by viewModels({ requireParentFragment() }) {
+        NewsViewModel.Factory
+    }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.rvLostItem.layoutManager = GridLayoutManager(requireContext(), SPAN_COUNT)
+        binding.rvLostItem.adapter = adapter
+
+        val spacingInPx = resources.getDimensionPixelSize(R.dimen.lost_item_spacing_16dp)
+        binding.rvLostItem.addItemDecoration(
+            LostItemDecoration(
+                spanCount = SPAN_COUNT,
+                spacing = spacingInPx,
+            ),
+        )
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.lostItemUiState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is LostItemUiState.InitialLoading -> {}
+                is LostItemUiState.Loading -> {}
+                is LostItemUiState.Success -> {
+                    adapter.submitList(state.lostItems)
+                }
+
+                is LostItemUiState.Error -> {}
+            }
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?,
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_lost_item, container, false)
-    }
-
     companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment LostItemFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
+        private const val SPAN_COUNT: Int = 2
+
         fun newInstance() = LostItemFragment()
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemFragment.kt
@@ -8,11 +8,14 @@ import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentLostItemBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.news.NewsViewModel
+import com.daedan.festabook.presentation.news.lost.LostItemModalDialogFragment.Companion.TAG_MODAL_DIALOG_LOST_ITEM_FRAGMENT
 import com.daedan.festabook.presentation.news.lost.adapter.LostItemAdapter
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 
 class LostItemFragment : BaseFragment<FragmentLostItemBinding>(R.layout.fragment_lost_item) {
     private val adapter by lazy {
-        LostItemAdapter()
+        LostItemAdapter(requireParentFragment() as OnNewsClickListener)
     }
 
     private val viewModel: NewsViewModel by viewModels({ requireParentFragment() }) {
@@ -49,6 +52,18 @@ class LostItemFragment : BaseFragment<FragmentLostItemBinding>(R.layout.fragment
                 is LostItemUiState.Error -> {}
             }
         }
+
+        viewModel.lostItemClickEvent.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { lostItem ->
+                showLostItemModalDialog(lostItem)
+            }
+        }
+    }
+
+    private fun showLostItemModalDialog(lostItem: LostItemUiModel) {
+        LostItemModalDialogFragment
+            .newInstance(lostItem)
+            .show(childFragmentManager, TAG_MODAL_DIALOG_LOST_ITEM_FRAGMENT)
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemModalDialogFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemModalDialogFragment.kt
@@ -1,0 +1,90 @@
+package com.daedan.festabook.presentation.news.lost
+
+import android.app.Dialog
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.graphics.drawable.toDrawable
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import coil3.load
+import com.daedan.festabook.R
+import com.daedan.festabook.databinding.FragmentLostItemModalDialogBinding
+import com.daedan.festabook.presentation.common.getObject
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+
+class LostItemModalDialogFragment : DialogFragment() {
+    private val lostItem: LostItemUiModel by lazy {
+        arguments?.getObject(KEY_LOST_ITEM) ?: LostItemUiModel()
+    }
+
+    private lateinit var binding: FragmentLostItemModalDialogBinding
+
+    @Suppress("ktlint:standard:backing-property-naming")
+    private var _binding: FragmentLostItemModalDialogBinding? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = Dialog(requireContext(), R.style.LostItemModalDialogTheme)
+        dialog.window?.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
+        return dialog
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding =
+            DataBindingUtil.inflate(
+                inflater,
+                R.layout.fragment_lost_item_modal_dialog,
+                container,
+                false,
+            )
+        binding = _binding!!
+
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.ivModalLostItemImage.load(lostItem.imageUrl)
+        binding.tvModalLostItemStorageLocation.text =
+            binding.tvModalLostItemStorageLocation.context.getString(
+                R.string.modal_lost_item,
+                lostItem.storageLocation,
+            )
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        val width = resources.getDimensionPixelSize(R.dimen.lost_item_modal_dialog_width)
+        val height = resources.getDimensionPixelSize(R.dimen.lost_item_modal_dialog_height)
+        dialog?.window?.setLayout(width, height)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG_MODAL_DIALOG_LOST_ITEM_FRAGMENT = "lostItemModalDialogFragment"
+        const val KEY_LOST_ITEM = "lostItem"
+
+        fun newInstance(lostItem: LostItemUiModel) =
+            LostItemModalDialogFragment().apply {
+                arguments =
+                    Bundle().apply {
+                        putParcelable(KEY_LOST_ITEM, lostItem)
+                    }
+            }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemUiState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemUiState.kt
@@ -1,0 +1,17 @@
+package com.daedan.festabook.presentation.news.lost
+
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+
+interface LostItemUiState {
+    data object InitialLoading : LostItemUiState
+
+    data object Loading : LostItemUiState
+
+    data class Success(
+        val lostItems: List<LostItemUiModel>,
+    ) : LostItemUiState
+
+    data class Error(
+        val throwable: Throwable,
+    ) : LostItemUiState
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
@@ -1,0 +1,34 @@
+package com.daedan.festabook.presentation.news.lost.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+
+class LostItemAdapter :
+    ListAdapter<LostItemUiModel, LostItemViewHolder>(
+        object :
+            DiffUtil.ItemCallback<LostItemUiModel>() {
+            override fun areItemsTheSame(
+                oldItem: LostItemUiModel,
+                newItem: LostItemUiModel,
+            ): Boolean = oldItem == newItem
+
+            override fun areContentsTheSame(
+                oldItem: LostItemUiModel,
+                newItem: LostItemUiModel,
+            ): Boolean = oldItem.imageId == newItem.imageId
+        },
+    ) {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): LostItemViewHolder = LostItemViewHolder.from(parent)
+
+    override fun onBindViewHolder(
+        holder: LostItemViewHolder,
+        position: Int,
+    ) {
+        holder.bind(getItem(position))
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
@@ -8,20 +8,7 @@ import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 
 class LostItemAdapter(
     private val onNewsClickListener: OnNewsClickListener,
-) : ListAdapter<LostItemUiModel, LostItemViewHolder>(
-        object :
-            DiffUtil.ItemCallback<LostItemUiModel>() {
-            override fun areItemsTheSame(
-                oldItem: LostItemUiModel,
-                newItem: LostItemUiModel,
-            ): Boolean = oldItem == newItem
-
-            override fun areContentsTheSame(
-                oldItem: LostItemUiModel,
-                newItem: LostItemUiModel,
-            ): Boolean = oldItem.imageId == newItem.imageId
-        },
-    ) {
+) : ListAdapter<LostItemUiModel, LostItemViewHolder>(lostItemDiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -32,5 +19,21 @@ class LostItemAdapter(
         position: Int,
     ) {
         holder.bind(getItem(position))
+    }
+
+    companion object {
+        private val lostItemDiffCallback =
+            object :
+                DiffUtil.ItemCallback<LostItemUiModel>() {
+                override fun areItemsTheSame(
+                    oldItem: LostItemUiModel,
+                    newItem: LostItemUiModel,
+                ): Boolean = oldItem.imageId == newItem.imageId
+
+                override fun areContentsTheSame(
+                    oldItem: LostItemUiModel,
+                    newItem: LostItemUiModel,
+                ): Boolean = oldItem == newItem
+            }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
@@ -4,9 +4,11 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 
-class LostItemAdapter :
-    ListAdapter<LostItemUiModel, LostItemViewHolder>(
+class LostItemAdapter(
+    private val onNewsClickListener: OnNewsClickListener,
+) : ListAdapter<LostItemUiModel, LostItemViewHolder>(
         object :
             DiffUtil.ItemCallback<LostItemUiModel>() {
             override fun areItemsTheSame(
@@ -23,7 +25,7 @@ class LostItemAdapter :
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): LostItemViewHolder = LostItemViewHolder.from(parent)
+    ): LostItemViewHolder = LostItemViewHolder.from(parent, onNewsClickListener)
 
     override fun onBindViewHolder(
         holder: LostItemViewHolder,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemViewHolder.kt
@@ -8,11 +8,16 @@ import coil3.request.transformations
 import coil3.transform.RoundedCornersTransformation
 import com.daedan.festabook.databinding.ItemLostBinding
 import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 
 class LostItemViewHolder(
-    val binding: ItemLostBinding,
+    private val binding: ItemLostBinding,
+    private val onNewsClickListener: OnNewsClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(item: LostItemUiModel) {
+        binding.root.setOnClickListener {
+            onNewsClickListener.onLostItemClick(item)
+        }
         binding.ivLostItem.load(item.imageUrl) {
             transformations(RoundedCornersTransformation(LOST_ITEM_IMAGE_RADIUS))
         }
@@ -21,10 +26,13 @@ class LostItemViewHolder(
     companion object {
         private const val LOST_ITEM_IMAGE_RADIUS = 16f
 
-        fun from(parent: ViewGroup): LostItemViewHolder {
+        fun from(
+            parent: ViewGroup,
+            onNewsClickListener: OnNewsClickListener,
+        ): LostItemViewHolder {
             val inflater = LayoutInflater.from(parent.context)
             val binding = ItemLostBinding.inflate(inflater, parent, false)
-            return LostItemViewHolder(binding)
+            return LostItemViewHolder(binding, onNewsClickListener)
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemViewHolder.kt
@@ -1,0 +1,30 @@
+package com.daedan.festabook.presentation.news.lost.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import coil3.load
+import coil3.request.transformations
+import coil3.transform.RoundedCornersTransformation
+import com.daedan.festabook.databinding.ItemLostBinding
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+
+class LostItemViewHolder(
+    val binding: ItemLostBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(item: LostItemUiModel) {
+        binding.ivLostItem.load(item.imageUrl) {
+            transformations(RoundedCornersTransformation(LOST_ITEM_IMAGE_RADIUS))
+        }
+    }
+
+    companion object {
+        private const val LOST_ITEM_IMAGE_RADIUS = 16f
+
+        fun from(parent: ViewGroup): LostItemViewHolder {
+            val inflater = LayoutInflater.from(parent.context)
+            val binding = ItemLostBinding.inflate(inflater, parent, false)
+            return LostItemViewHolder(binding)
+        }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
@@ -1,0 +1,14 @@
+package com.daedan.festabook.presentation.news.lost.model
+
+import com.daedan.festabook.domain.model.LostItem
+
+data class LostItemUiModel(
+    val imageId: Long,
+    val imageUrl: String,
+)
+
+fun LostItem.toUiModel(): LostItemUiModel =
+    LostItemUiModel(
+        imageId = imageId,
+        imageUrl = imageUrl,
+    )

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
@@ -1,14 +1,19 @@
 package com.daedan.festabook.presentation.news.lost.model
 
+import android.os.Parcelable
 import com.daedan.festabook.domain.model.LostItem
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class LostItemUiModel(
-    val imageId: Long,
-    val imageUrl: String,
-)
+    val imageId: Long = -1L,
+    val imageUrl: String = "",
+    val storageLocation: String = "",
+) : Parcelable
 
 fun LostItem.toUiModel(): LostItemUiModel =
     LostItemUiModel(
         imageId = imageId,
         imageUrl = imageUrl,
+        storageLocation = storageLocation,
     )

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNewsClickListener.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/OnNewsClickListener.kt
@@ -1,10 +1,13 @@
 package com.daedan.festabook.presentation.news.notice.adapter
 
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 
 interface OnNewsClickListener {
     fun onNoticeClick(notice: NoticeUiModel)
 
     fun onFAQClick(faqItem: FAQItemUiModel)
+
+    fun onLostItemClick(lostItem: LostItemUiModel)
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -32,20 +32,20 @@ class PlaceDetailActivity : AppCompatActivity(R.layout.activity_place_detail) {
         PlaceImageViewPagerAdapter()
     }
 
-    private lateinit var binding: ActivityPlaceDetailBinding
+    private val binding: ActivityPlaceDetailBinding by lazy {
+        DataBindingUtil.inflate(
+            layoutInflater,
+            R.layout.activity_place_detail,
+            null,
+            false,
+        )
+    }
     private lateinit var place: PlaceUiModel
 
     private val viewModel by viewModels<PlaceDetailViewModel> { PlaceDetailViewModel.factory(place) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding =
-            DataBindingUtil.inflate<ActivityPlaceDetailBinding>(
-                layoutInflater,
-                R.layout.activity_place_detail,
-                null,
-                false,
-            )
         enableEdgeToEdge()
         setContentView(binding.root)
         ViewCompat.setOnApplyWindowInsetsListener(binding.ncvRoot) { v, insets ->

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -1,7 +1,5 @@
 package com.daedan.festabook.presentation.placeDetail
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -1,5 +1,7 @@
 package com.daedan.festabook.presentation.placeDetail
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView

--- a/android/app/src/main/res/drawable/bg_gray050_radius_10dp.xml
+++ b/android/app/src/main/res/drawable/bg_gray050_radius_10dp.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/gray050" />
+
+    <corners android:radius="10dp" />
+</shape>

--- a/android/app/src/main/res/layout/fragment_lost_item.xml
+++ b/android/app/src/main/res/layout/fragment_lost_item.xml
@@ -1,14 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.news.lost.LostItemFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        tools:context=".presentation.news.lost.LostItemFragment">
 
-</FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_lost_item"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            android:paddingTop="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/fragment_lost_item_modal_dialog.xml
+++ b/android/app/src/main/res/layout/fragment_lost_item_modal_dialog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_gray050_radius_10dp"
+        android:padding="16dp">
+
+        <ImageView
+            android:id="@+id/iv_modal_lost_item_image"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:contentDescription="@string/lost_item"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toTopOf="@id/tv_modal_lost_item_storage_location"
+            app:layout_constraintDimensionRatio="208:247"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_modal_lost_item_storage_location"
+            style="@style/PretendardMedium16"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/lost_item_spacing_16dp"
+            android:textColor="@color/gray500"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_modal_lost_item_image"
+            tools:text="보관 장소: 학생회관 301호" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/fragment_news.xml
+++ b/android/app/src/main/res/layout/fragment_news.xml
@@ -41,6 +41,7 @@
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/gray300"
+            app:layout_constraintBottom_toTopOf="@id/vp_news"
             app:layout_constraintTop_toBottomOf="@id/tl_news" />
 
         <androidx.viewpager2.widget.ViewPager2

--- a/android/app/src/main/res/layout/fragment_news.xml
+++ b/android/app/src/main/res/layout/fragment_news.xml
@@ -28,7 +28,6 @@
             android:id="@+id/tl_news"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:layout_marginHorizontal="16dp"
             android:background="@color/gray050"
             app:layout_constraintBottom_toTopOf="@id/vp_news"
             app:layout_constraintTop_toBottomOf="@id/tv_news_title"

--- a/android/app/src/main/res/layout/fragment_news.xml
+++ b/android/app/src/main/res/layout/fragment_news.xml
@@ -10,7 +10,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginHorizontal="16dp"
         tools:context=".presentation.news.NewsFragment">
 
         <TextView
@@ -18,6 +17,7 @@
             style="@style/PretendardBold24"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
             android:layout_marginTop="40dp"
             android:layout_marginBottom="8dp"
             android:text="@string/news_title"
@@ -28,6 +28,7 @@
             android:id="@+id/tl_news"
             android:layout_width="match_parent"
             android:layout_height="48dp"
+            android:layout_marginHorizontal="16dp"
             android:background="@color/gray050"
             app:layout_constraintBottom_toTopOf="@id/vp_news"
             app:layout_constraintTop_toBottomOf="@id/tv_news_title"
@@ -36,10 +37,18 @@
             app:tabRippleColor="@android:color/transparent"
             app:tabTextColor="@color/selector_news_tab_text_color" />
 
+        <View
+            android:id="@+id/view_news_tab_line"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/gray300"
+            app:layout_constraintTop_toBottomOf="@id/tl_news" />
+
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/vp_news"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:layout_marginHorizontal="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tl_news"
             tools:layout_editor_absoluteX="0dp" />

--- a/android/app/src/main/res/layout/item_lost.xml
+++ b/android/app/src/main/res/layout/item_lost.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/iv_lostItem"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:contentDescription="@string/lost_item"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_lost.xml
+++ b/android/app/src/main/res/layout/item_lost.xml
@@ -7,7 +7,7 @@
         android:layout_height="wrap_content">
 
         <ImageView
-            android:id="@+id/iv_lostItem"
+            android:id="@+id/iv_lost_item"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:contentDescription="@string/lost_item"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -2,5 +2,6 @@
 <resources>
     <dimen name="schedule_tab_item_end_margin">12dp</dimen>
     <dimen name="poster_item_width">300dp</dimen>
+    <dimen name="lost_item_spacing_16dp">16dp</dimen>
 
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -3,5 +3,6 @@
     <dimen name="schedule_tab_item_end_margin">12dp</dimen>
     <dimen name="poster_item_width">300dp</dimen>
     <dimen name="lost_item_spacing_16dp">16dp</dimen>
-
+    <dimen name="lost_item_modal_dialog_width">360dp</dimen>
+    <dimen name="lost_item_modal_dialog_height">452dp</dimen>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="refresh">새로고침</string>
     <string name="content_description_floating_action_button">플로팅 지도 버튼</string>
     <string name="move">이동</string>
+    <string name="lost_item">분실물 이미지</string>
 
     <!--실패 시 출력 -->
     <string name="fail_snackbar_confirm">확인</string>
@@ -85,5 +86,6 @@
     <string name="error_unknown_exception">알 수 없는 에러가 발생했습니다 잠시 후 다시 시도해주세요</string>
     <string name="error_fail_to_load_place_info">정보를 불러오는데 실패했습니다</string>
     <string name="faq_expand">답변 펼치기</string>
+
 
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="tab_faq">Q&amp;A</string>
     <string name="tab_lost_item">분실물</string>
     <string name="tab_faq_question">Q. %1$s</string>
+    <string name="modal_lost_item">보관 장소 : %1$s</string>
 
     <!--    설정 화면-->
     <string name="setting_title">설정</string>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -62,4 +62,10 @@
         <item name="android:background">@android:color/transparent</item>
     </style>
 
+    <style name="LostItemModalDialogTheme" parent="Theme.AppCompat.Dialog">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+    s
+
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -66,6 +66,5 @@
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowNoTitle">true</item>
     </style>
-    s
-
+    
 </resources>


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/239

<br>

## 🛠️ 작업 내용

- 분실물 화면 UI 구현
- 특정 아이템 클릭 시 모달창 구현
- 탭 하단 분리선 추가

<br>

## 🙇🏻 중점 리뷰 요청

- API가 아직 안나와서 더미데이터로 구현했습니다!
- 피그마 보다 모달창을 일부러 크게 했습니당.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/5747d702-979e-4022-82ab-ad1f68cfe895


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 분실물 목록을 보여주는 화면이 추가되었습니다.
  * 분실물 이미지를 그리드 형태로 확인할 수 있습니다.
  * 분실물 이미지를 클릭하면 보관 장소 정보가 포함된 모달 다이얼로그가 표시됩니다.

* **UI/스타일**
  * 분실물 목록 및 상세 모달 다이얼로그를 위한 새로운 레이아웃과 스타일이 적용되었습니다.
  * 분실물 이미지에 라운드 처리와 그리드 간격이 적용되었습니다.

* **문서화 및 리소스**
  * 분실물 관련 문자열, 색상, 크기, 배경 등 리소스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->