### PR TITLE
[AN, CI/CD] android ci Gradle 캐싱 처리

### DIFF
--- a/.github/workflows/android-ci-pr-test.yml
+++ b/.github/workflows/android-ci-pr-test.yml
@@ -1,4 +1,4 @@
-name: Android CI
+name: Android CI Pull-Request Gradle Test
 
 on:
   push:
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - 'android'
-
 
 jobs:
   build:

--- a/.github/workflows/android-ci-pr-test.yml
+++ b/.github/workflows/android-ci-pr-test.yml
@@ -1,30 +1,38 @@
 name: Android CI Pull-Request Gradle Test
 
 on:
-  push:
-    branches:
-      - 'android'
   pull_request:
     branches:
-      - 'android'
+      - main
+      - android
 
 jobs:
-  build:
-
+  Run-PR-Test:
     runs-on: ubuntu-latest
-
     defaults:
       run:
         working-directory: android
 
     steps:
-      - uses: actions/checkout@v4
-      - name: set up JDK 17
+      - name: Repository Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/build.gradle.kts', 'android/**/settings.gradle.kts', 'android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Create local.properties with BASE_URL
         run: |
@@ -37,12 +45,6 @@ jobs:
           DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: echo "$DATA" > app/google-services.json
 
-      - name: Check local.properties content
-        run:  cat local.properties
-
-      - name: Echo env var
-        run: echo "${{ secrets.BASE_URL }}"
-
       - name: Clean Project
         run: ./gradlew clean
 
@@ -51,6 +53,3 @@ jobs:
         
       - name: Run Unit Test
         run: ./gradlew test
-
-      - name: Build with Gradle
-        run: ./gradlew build

--- a/.github/workflows/android-ci-pr-test.yml
+++ b/.github/workflows/android-ci-pr-test.yml
@@ -30,7 +30,7 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.android/build-cache
-          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/build.gradle.kts', 'android/**/settings.gradle.kts', 'android/**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/build.gradle.kts', 'android/**/settings.gradle.kts', 'android/**/gradle-wrapper.properties', 'android/gradle/libs.versions.toml', 'android/**/gradle.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#364 

<br>

## 🛠️ 작업 내용


- 안드로이드 CI/CD 워크플로우 신규 추가:
  - Pull-Request 시 안드로이드 프로젝트의 ktlint 및 Unit Test를 실행하는 워크플로우를 추가함.
  - Gradle 캐싱을 적용하여 안드로이드 프로젝트 빌드 시간을 최적화함.
  - 필요없는 build 과정 삭제 (apk 생성)
  - GitHub Secrets를 이용해 local.properties 및 google-services.json 파일을 안전하게 생성하도록 구성함.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Android CI 워크플로우가 "Android CI Pull-Request Gradle Test"로 이름이 변경되었습니다.
  * 워크플로우가 이제 `main` 및 `android` 브랜치로의 풀 리퀘스트에서만 실행됩니다.
  * Gradle 및 Android 빌드 캐시가 추가되어 빌드 효율성이 향상되었습니다.
  * 불필요한 디버그 및 빌드 단계가 정리되어 테스트 작업만 실행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 이미지 및 정리
### 기존 최악의 경우 9분 10초 (550s)
<img width="1305" height="92" alt="image" src="https://github.com/user-attachments/assets/f7223636-50e9-4460-b1b4-04f0f27b7103" />

### Gradle 캐시 도입 이후 1분 46초(106s)
<img width="1300" height="96" alt="image" src="https://github.com/user-attachments/assets/a4b3ba7c-96ad-4ff7-b87b-c4a980004ece" />

CI Gradle Test 과정 5.18배 속도 개선
- name: Gradle cache 섹션 코드 분석 후 레쥬메에 넣어도 될 듯.

안드로이드 의존 파일을 매번 다운로드 받는 과정에서 네트워크 상황에 따라 속도 차이가 크게 났음.
이 의존 파일을 캐싱하여 다운로드 속도에 들이는 시간을 줄임.