### PR TITLE
[AN] 바텀 네비게이션 지도 버튼 누르면 바텀시트가 내려가고 지도가 보이게 변경

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -212,6 +212,8 @@ class MainActivity : AppCompatActivity() {
         }
         binding.fabMap.setOnClickListener {
             binding.bnvMenu.selectedItemId = R.id.item_menu_map
+            val fragment = supportFragmentManager.findFragmentByTag(TAG_PLACE_LIST_FRAGMENT)
+            if (fragment is OnMenuItemReClickListener) fragment.onMenuItemReClick()
             switchFragment(placeListFragment, TAG_PLACE_LIST_FRAGMENT)
         }
     }
@@ -224,7 +226,6 @@ class MainActivity : AppCompatActivity() {
                     val fragment = supportFragmentManager.findFragmentByTag(TAG_SCHEDULE_FRAGMENT)
                     if (fragment is OnMenuItemReClickListener) fragment.onMenuItemReClick()
                 }
-
                 R.id.item_menu_news -> Unit
                 R.id.item_menu_setting -> Unit
             }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListFragment.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.presentation.placeList
 
 import android.os.Bundle
 import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -9,6 +10,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceListBinding
 import com.daedan.festabook.presentation.common.BaseFragment
+import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.initialPadding
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailActivity
@@ -19,6 +21,7 @@ import com.daedan.festabook.presentation.placeList.model.PlaceListUiState
 import com.daedan.festabook.presentation.placeList.model.PlaceUiModel
 import com.daedan.festabook.presentation.placeList.placeMap.MapManager
 import com.daedan.festabook.presentation.placeList.placeMap.getMap
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.chip.Chip
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
@@ -30,7 +33,8 @@ class PlaceListFragment :
     BaseFragment<FragmentPlaceListBinding>(
         R.layout.fragment_place_list,
     ),
-    PlaceClickListener {
+    PlaceClickListener,
+    OnMenuItemReClickListener {
     private val viewModel by viewModels<PlaceListViewModel> { PlaceListViewModel.Factory }
 
     private val placeAdapter by lazy {
@@ -60,6 +64,12 @@ class PlaceListFragment :
 
     override fun onPlaceClicked(place: PlaceUiModel) {
         startPlaceDetailActivity(place)
+    }
+
+    override fun onMenuItemReClick() {
+        val layoutParams = binding.layoutPlaceList.layoutParams as? CoordinatorLayout.LayoutParams
+        val behavior = layoutParams?.behavior as? BottomSheetBehavior
+        behavior?.state = BottomSheetBehavior.STATE_HALF_EXPANDED
     }
 
     private fun setUpBinding() {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/353바텀 네비게이션 지도 버튼 누르면 바텀시트가 내려가고 지도가 보이게 변경

<br>

## 🛠️ 작업 내용

- 바텀 네비게이션 지도 버튼 누르면 바텀시트가 내려가고 지도가 보이게 변경

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/a573975d-db09-4071-ba9a-6d081be8dc14




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지도 화면의 플로팅 액션 버튼 클릭 시, 장소 목록 하단 시트가 반쯤 확장된 상태로 전환됩니다.  
  * 메뉴 항목을 다시 클릭하면 장소 목록 하단 시트가 반쯤 확장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->