### PR TITLE
[AN] 일정 화면 업데이트 기능 수정

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/data/service/api/FestaBookAuthInterceptor.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/api/FestaBookAuthInterceptor.kt
@@ -11,7 +11,7 @@ class FestaBookAuthInterceptor(
         val requestWithHeader =
             originalRequest
                 .newBuilder()
-                .addHeader("organization", organizationId)
+                .addHeader("festival", organizationId)
                 .build()
 
         return chain.proceed(requestWithHeader)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -32,7 +32,9 @@ import com.google.firebase.messaging.FirebaseMessaging
 import timber.log.Timber
 
 class MainActivity : AppCompatActivity() {
-    private lateinit var binding: ActivityMainBinding
+    private val binding: ActivityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
     private val viewModel: MainViewModel by viewModels { MainViewModel.Factory }
 
     private val placeListFragment by lazy {
@@ -52,7 +54,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private val settingFragment by lazy {
-        SettingFragment.newInstance()
+        SettingFragment().newInstance()
     }
 
     private val requestPermissionLauncher =
@@ -128,8 +130,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setupBinding() {
-        binding = ActivityMainBinding.inflate(layoutInflater)
-
         setContentView(binding.root)
         ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -184,7 +184,7 @@ class MainActivity : AppCompatActivity() {
             binding.fcvFragmentContainer.updatePadding(
                 bottom = binding.babMenu.height + binding.babMenu.marginBottom,
             )
-            binding.bnvMenu.x = binding.bnvMenu.x / 2
+            binding.bnvMenu.x /= 2
         }
         binding.babMenu.setOnApplyWindowInsetsListener(null)
         binding.babMenu.setPadding(0, 0, 0, 0)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
@@ -34,13 +34,8 @@ class ScheduleFragment :
     }
 
     override fun onMenuItemReClick() {
-        val currentScheduleTabPageFragmentPosition = binding.vpSchedule.currentItem
-        val tag = getTagByFragmentPosition(currentScheduleTabPageFragmentPosition)
-        val scheduleTabPageFragment = childFragmentManager.findFragmentByTag(tag)
-
-        if (scheduleTabPageFragment is ScheduleTabPageUpdater) {
-            scheduleTabPageFragment.updateScheduleTabPage()
-        }
+        viewModel.loadAllDates()
+        viewModel.loadScheduleByDate()
     }
 
     @SuppressLint("WrongConstant")
@@ -89,7 +84,7 @@ class ScheduleFragment :
 
                 is ScheduleDatesUiState.Error -> {
                     showSkeleton(isLoading = false)
-                    Timber.tag("TAG").d("setupDate: ${scheduleDatesUiState.throwable.message}")
+                    Timber.d("setupDate: ${scheduleDatesUiState.throwable.message}")
                     showErrorSnackBar(scheduleDatesUiState.throwable)
                 }
             }
@@ -112,7 +107,5 @@ class ScheduleFragment :
     companion object {
         private const val PRELOAD_PAGE_COUNT: Int = 2
         private const val EMPTY_DATE_TEXT: String = ""
-
-        private fun getTagByFragmentPosition(position: Int): String = "f$position"
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -13,9 +13,7 @@ import com.daedan.festabook.presentation.schedule.ScheduleViewModel.Companion.IN
 import com.daedan.festabook.presentation.schedule.adapter.ScheduleAdapter
 import timber.log.Timber
 
-class ScheduleTabPageFragment :
-    BaseFragment<FragmentScheduleTabPageBinding>(R.layout.fragment_schedule_tab_page),
-    ScheduleTabPageUpdater {
+class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.layout.fragment_schedule_tab_page) {
     private val viewModel: ScheduleViewModel by viewModels {
         val dateId: Long = arguments?.getLong(KEY_DATE_ID, INVALID_ID) ?: INVALID_ID
         ScheduleViewModel.factory(dateId)
@@ -36,10 +34,6 @@ class ScheduleTabPageFragment :
 
         binding.lifecycleOwner = viewLifecycleOwner
         onSwipeRefreshScheduleByDateListener()
-    }
-
-    override fun updateScheduleTabPage() {
-        viewModel.loadScheduleByDate()
     }
 
     private fun setupScheduleEventRecyclerView() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageUpdater.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageUpdater.kt
@@ -1,5 +1,0 @@
-package com.daedan.festabook.presentation.schedule
-
-fun interface ScheduleTabPageUpdater {
-    fun updateScheduleTabPage()
-}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -14,6 +14,7 @@ import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiStatus
 import com.daedan.festabook.presentation.schedule.model.toUiModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.time.LocalDate
 
 class ScheduleViewModel(
@@ -56,7 +57,7 @@ class ScheduleViewModel(
                     val scheduleEventUiModels = scheduleEvents.map { it.toUiModel() }
                     val currentEventPosition =
                         scheduleEventUiModels
-                            .indexOfFirst { scheduleEvent -> scheduleEvent.status == ScheduleEventUiStatus.ONGOING }
+                            .indexOfFirst { scheduleEvent -> scheduleEvent.status != ScheduleEventUiStatus.COMPLETED }
                             .let { currentIndex -> if (currentIndex == INVALID_INDEX) FIRST_INDEX else currentIndex }
 
                     _scheduleEventsUiState.value =
@@ -68,7 +69,7 @@ class ScheduleViewModel(
         }
     }
 
-    private fun loadAllDates() {
+    fun loadAllDates() {
         viewModelScope.launch {
             _scheduleDatesUiState.value = ScheduleDatesUiState.Loading
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -14,7 +14,6 @@ import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiStatus
 import com.daedan.festabook.presentation.schedule.model.toUiModel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.time.LocalDate
 
 class ScheduleViewModel(

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -13,8 +13,4 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
     ) {
         super.onViewCreated(view, savedInstanceState)
     }
-
-    companion object {
-        fun newInstance() = SettingFragment()
-    }
 }

--- a/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page_skeleton.xml
@@ -14,10 +14,12 @@
         android:id="@+id/cl_schedule_event_card_skeleton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
         android:background="@drawable/bg_gray300_radius_10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/iv_schedule_event_time_line_circle_skeleton"
-        app:layout_constraintTop_toBottomOf="@id/view_space">
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/tv_schedule_event_title_skeleton"
@@ -107,8 +109,8 @@
 
     <ImageView
         android:id="@+id/iv_schedule_event_time_line_circle_skeleton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
         android:layout_marginEnd="16dp"
         android:contentDescription="@string/schedule_circle"
         android:elevation="11dp"


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/370

<br>

## 🛠️ 작업 내용

- 일정 화면 메뉴 재선택 시 현재 날짜에 해당하는 일정으로 로딩
- 진행중인 일정이 없을 시 진행 예정인 일정으로 로딩
- 스켈레톤 UI 사이즈 변경

<br>

## 🙇🏻 중점 리뷰 요청


<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/e5af2236-dd00-410f-8d0b-3454ef9a03f3



