### PR TITLE
[BE, CICD] EC2 깃허브 액션 스크립트 Spring WAS 종료 문제 수정

### DIFF
--- a/.github/workflows/backend-cd-ec2.yml
+++ b/.github/workflows/backend-cd-ec2.yml
@@ -104,6 +104,7 @@ jobs:
           echo "LOG_PATH=${LOG_PATH}"
           
           nohup java -jar "${DEPLOY_JAR_PATH}" --spring.profiles.active=prod > "${LOG_PATH}" 2>&1 &
+          disown
           for i in $(seq 1 20); do
             if lsof -t -i:8080 > /dev/null; then
               echo "WAS has started and is listening on port 8080."

--- a/.github/workflows/backend-cd-ec2.yml
+++ b/.github/workflows/backend-cd-ec2.yml
@@ -7,6 +7,7 @@ on:
       - backend
     paths:
       - 'backend/**'
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## #️⃣ 이슈 번호

#384 

<br>

## 🛠️ 작업 내용

- workflow_dispatch 이벤트 추가 및 disown 명령어 적용

- disown 명령어 추가:
  - 문제: 기존 배포 스크립트에서 Spring WAS가 GitHub Actions 러너 프로세스와 함께 종료되는 문제 발생.
  - 해결: nohup으로 백그라운드에서 실행한 후, disown 명령어를 추가해서 WAS 프로세스를 러너 프로세스의 관리 목록에서 완전히 분리함.
    이제 러너가 종료돼도 WAS는 독립적으로 계속 실행될 것을 예상함.

- workflow_dispatch 이벤트 추가:
  - 기능: 코드 푸시 없이도 GitHub Actions 페이지에서 수동으로 워크플로우를 실행할 수 있도록 workflow_dispatch 이벤트를 추가.
  - 활용: 이를 통해 긴급하게 재배포가 필요하거나 특정 브랜치를 수동으로 배포하고 싶을 때 버튼으로 액션 실행 가능.

<br>

## 🙇🏻 중점 리뷰 요청

- 워크플로 제안 환영