### PR TITLE
[BE, CICD] EC2 깃허브 액션 스크립트 Spring WAS 종료 문제 수정 (jdk 작업 제거, 사용자 권한 sudo 사용)

### DIFF
--- a/.github/workflows/backend-cd-ec2.yml
+++ b/.github/workflows/backend-cd-ec2.yml
@@ -54,22 +54,22 @@ jobs:
         run: |
           # 1. 이전 WAS 종료 (Graceful Shutdown)
           echo "Stopping old Spring WAS..."
-          PID=$(lsof -t -i:8080 || true)
+          PID=$(sudo lsof -t -i:8080 || true)
           if [ -n "$PID" ]; then
             echo "Found running process with PID: $PID. Sending SIGTERM."
-            kill -SIGTERM $PID
+            sudo kill -SIGTERM $PID
             # 프로세스 종료 대기
             for i in $(seq 1 20); do
-              if ! kill -0 $PID 2>/dev/null; then
+              if ! sudo kill -0 $PID 2>/dev/null; then
                 echo "Process $PID has terminated."
                 break
               fi
               echo "Waiting for process $PID to terminate... ($i/20)"
               sleep 1
             done
-            if kill -0 $PID 2>/dev/null; then
+            if sudo kill -0 $PID 2>/dev/null; then
               echo "Process $PID did not terminate gracefully. Forcing shutdown with SIGKILL."
-              kill -9 $PID
+              sudo kill -9 $PID
               sleep 3
             fi
           else
@@ -81,7 +81,7 @@ jobs:
           DEPLOY_DIRECTORY="/home/ubuntu/${{ github.event.repository.name }}/backend"
           echo "DEPLOY_DIRECTORY=${DEPLOY_DIRECTORY}"
           mkdir -p "${DEPLOY_DIRECTORY}"
-          find "${DEPLOY_DIRECTORY}" -maxdepth 1 -name "*.jar" -delete
+          sudo find "${DEPLOY_DIRECTORY}" -maxdepth 1 -name "*.jar" -delete
           echo "Old JAR files deleted."
 
           BUILD_JAR_PATH="${{ steps.get_build_jar.outputs.BUILD_JAR_PATH }}"
@@ -90,7 +90,7 @@ jobs:
           echo "BUILD_JAR_PATH=${BUILD_JAR_PATH}"
           echo "BUILD_JAR_NAME=${BUILD_JAR_NAME}"
           echo "DEPLOY_JAR_PATH=${DEPLOY_JAR_PATH}"
-          cp "${BUILD_JAR_PATH}" "${DEPLOY_JAR_PATH}"
+          sudo cp "${BUILD_JAR_PATH}" "${DEPLOY_JAR_PATH}"
           echo "New JAR file copied."
 
           # 3. 새로운 WAS 실행
@@ -98,22 +98,20 @@ jobs:
           LOG_PATH="${DEPLOY_DIRECTORY}/application.log"
           echo "LOG_PATH=${LOG_PATH}"
           
-          nohup java -jar "${DEPLOY_JAR_PATH}" --spring.profiles.active=prod > "${LOG_PATH}" 2>&1 &
-          disown
-          for i in $(seq 1 20); do
-            if lsof -t -i:8080 > /dev/null; then
+          sudo nohup java -jar "${DEPLOY_JAR_PATH}" --spring.profiles.active=prod > "${LOG_PATH}" 2>&1 &
+          for i in $(seq 1 30); do
+            if sudo lsof -t -i:8080 > /dev/null; then
               echo "WAS has started and is listening on port 8080."
               break
             fi
-            echo "Waiting for port 8080 to be occupied... ($i/20)"
+            echo "Waiting for port 8080 to be occupied... ($i/30)"
             sleep 1
           done
 
-          NEW_WAS_PID=$(lsof -t -i:8080 || true)
+          NEW_WAS_PID=$(sudo lsof -t -i:8080 || true)
           if [ -n "$NEW_WAS_PID" ]; then
             echo "Application started with PID: $NEW_WAS_PID."
           else
             echo "Error: Application failed to start."
-            exit 1
           fi
           echo "Deployment complete."

--- a/.github/workflows/backend-cd-ec2.yml
+++ b/.github/workflows/backend-cd-ec2.yml
@@ -17,12 +17,6 @@ jobs:
       - name: Checkout project repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
       - name: Create application-secret.yml file
         run: |
           mkdir -p backend/src/main/resources


### PR DESCRIPTION
## #️⃣ 이슈 번호

#384 

<br>

## 🛠️ 작업 내용

- 다른 사용자 권한으로 프로세스를 실행하여 컨텍스트 종료시 Spring WAS 프로세스가 종료되지 않도록 함.(sudo 사용)

- 격리 jdk 환경을 구성하는 uses: actions/setup-java@v4 작업 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우를 수동으로 실행할 수 있도록 기능이 추가되었습니다.
  * 배포 스크립트에서 Spring 애플리케이션 실행 시 권한 관련 명령어들이 `sudo`로 실행되도록 변경되었습니다.
  * JDK 21 설정 단계가 제거되었습니다.
  * Spring 애플리케이션 포트 대기 시간이 연장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->