### PR TITLE
[AN] ci 스크립트에 테스트 실패 시 스택 트레이스 뜨도록 변경

### DIFF
--- a/.github/workflows/android-ci-pr-test.yml
+++ b/.github/workflows/android-ci-pr-test.yml
@@ -53,3 +53,12 @@ jobs:
         
       - name: Run Unit Test
         run: ./gradlew test
+
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: android/app/build/test-results/**/TEST-*.xml
+          check_name: '테스트 결과 🛠️'
+          check_run_annotations: 'none'
+          comment_mode: 'off'


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/388

<br>

## 🛠️ 작업 내용

- ci 스크립트 작성
<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Android CI에서 유닛 테스트 결과를 자동으로 게시하는 단계가 추가되었습니다.  
  * 테스트 결과는 PR에서 "테스트 결과 🛠️"로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->