### PR TITLE
[AN] fragment 동작 firebase analytics 연결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
+++ b/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import com.daedan.festabook.logging.FirebaseAnalyticsTree
 import com.daedan.festabook.service.NotificationHelper
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.naver.maps.map.NaverMapSdk
@@ -38,7 +39,7 @@ class FestaBookApp : Application() {
     }
 
     private fun setupTimber() {
-        if (BuildConfig.DEBUG) plantDebugTimberTree()
+        if (BuildConfig.DEBUG) plantDebugTimberTree() else plantInfoTimberTree()
     }
 
     private fun plantDebugTimberTree() {
@@ -48,6 +49,10 @@ class FestaBookApp : Application() {
                     "${super.createStackElementTag(element)}:${element.lineNumber}"
             },
         )
+    }
+
+    private fun plantInfoTimberTree() {
+        Timber.plant(FirebaseAnalyticsTree(fireBaseAnalytics))
     }
 
     private fun setupNaverSdk() {

--- a/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
+++ b/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
@@ -9,23 +9,20 @@ import com.naver.maps.map.NaverMapSdk
 import timber.log.Timber
 
 class FestaBookApp : Application() {
-    lateinit var appContainer: AppContainer
-        private set
+    val appContainer: AppContainer by lazy {
+        AppContainer(this)
+    }
 
-    private lateinit var fireBaseAnalytics: FirebaseAnalytics
+    private val fireBaseAnalytics: FirebaseAnalytics by lazy {
+        FirebaseAnalytics.getInstance(this)
+    }
 
     override fun onCreate() {
         super.onCreate()
-        setupFirebaseAnalytics()
         setupTimber()
         setupNaverSdk()
         setupNotificationChannel()
-        appContainer = AppContainer(this)
         setLightTheme()
-    }
-
-    private fun setupFirebaseAnalytics() {
-        fireBaseAnalytics = FirebaseAnalytics.getInstance(this)
     }
 
     private fun setupNotificationChannel() {

--- a/android/app/src/main/java/com/daedan/festabook/logging/FirebaseAnalyticsTree.kt
+++ b/android/app/src/main/java/com/daedan/festabook/logging/FirebaseAnalyticsTree.kt
@@ -1,0 +1,59 @@
+package com.daedan.festabook.logging
+
+import android.os.Bundle
+import android.util.Log
+import com.google.firebase.analytics.FirebaseAnalytics
+import timber.log.Timber
+
+class FirebaseAnalyticsTree(
+    private val analytics: FirebaseAnalytics,
+) : Timber.Tree() {
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ) {
+        if (priority != Log.INFO) return
+
+        if (message.startsWith("screen_stay:")) {
+            setupFragmentStayLog(message)
+            return
+        }
+
+        val bundle =
+            Bundle().apply {
+                putString("tag", tag ?: "NoTag")
+                putString("message", message.take(MAX_MESSAGE_LENGTH))
+                t?.let {
+                    putString("exception", it.toString())
+                }
+            }
+        analytics.logEvent("timber_info_log", bundle)
+    }
+
+    private fun setupFragmentStayLog(message: String) {
+        val data =
+            message
+                .removePrefix("screen_stay:")
+                .split(",")
+                .associate {
+                    val (key, value) = it.split("=")
+                    key to value
+                }
+
+        val screen = data["screen"] ?: return
+        val duration = data["duration_ms"]?.toLong() ?: return
+
+        val bundle =
+            Bundle().apply {
+                putString("screen", screen)
+                putLong("duration_ms", duration)
+            }
+        analytics.logEvent("screen_stay_time", bundle)
+    }
+
+    companion object {
+        private const val MAX_MESSAGE_LENGTH = 100
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/logging/FirebaseAnalyticsTree.kt
+++ b/android/app/src/main/java/com/daedan/festabook/logging/FirebaseAnalyticsTree.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import com.google.firebase.analytics.FirebaseAnalytics
 import timber.log.Timber
+import java.util.Locale
 
 class FirebaseAnalyticsTree(
     private val analytics: FirebaseAnalytics,
@@ -43,17 +44,21 @@ class FirebaseAnalyticsTree(
                 }
 
         val screen = data["screen"] ?: return
-        val duration = data["duration_ms"]?.toLong() ?: return
+        val durationMs = data["duration_ms"]?.toLong() ?: return
+        val durationSec = (durationMs / 1000).toInt()
+        val formattedDurationSec = durationSec.formatDurationSec()
 
         val bundle =
             Bundle().apply {
                 putString("screen", screen)
-                putLong("duration_ms", duration)
+                putString("duration_sec", formattedDurationSec)
             }
         analytics.logEvent("screen_stay_time", bundle)
     }
 
     companion object {
         private const val MAX_MESSAGE_LENGTH = 100
+
+        private fun Int.formatDurationSec(): String = String.format(Locale.US, "%d:%02d", this / 60, this % 60)
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/BaseFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/BaseFragment.kt
@@ -7,12 +7,18 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
+import timber.log.Timber
 
 abstract class BaseFragment<T : ViewBinding>(
     private val layoutId: Int,
 ) : Fragment() {
+    //    lateinit var screenName: String
     protected lateinit var binding: T
+
+    @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: T? = null
+
+    private var enterTime: Long = 0L
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,6 +28,20 @@ abstract class BaseFragment<T : ViewBinding>(
         _binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
         binding = _binding!!
         return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        enterTime = System.currentTimeMillis()
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        val stayDuration = System.currentTimeMillis() - enterTime
+        val screenName = this::class.simpleName ?: "UKnown Class"
+
+        Timber.i("screen_stay:screen=$screenName,duration_ms=$stayDuration")
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/BaseFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/BaseFragment.kt
@@ -12,13 +12,14 @@ import timber.log.Timber
 abstract class BaseFragment<T : ViewBinding>(
     private val layoutId: Int,
 ) : Fragment() {
-    //    lateinit var screenName: String
     protected lateinit var binding: T
 
     @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: T? = null
 
+    private val screenName: String = this::class.simpleName ?: "Unknown Class"
     private var enterTime: Long = 0L
+    private val stayDuration get() = System.currentTimeMillis() - enterTime
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -35,17 +36,29 @@ abstract class BaseFragment<T : ViewBinding>(
         enterTime = System.currentTimeMillis()
     }
 
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        if (!hidden) {
+            enterTime = System.currentTimeMillis()
+        } else {
+            Timber.i(formatStayLog(screenName, stayDuration))
+        }
+    }
+
     override fun onPause() {
         super.onPause()
-
-        val stayDuration = System.currentTimeMillis() - enterTime
-        val screenName = this::class.simpleName ?: "UKnown Class"
-
-        Timber.i("screen_stay:screen=$screenName,duration_ms=$stayDuration")
+        Timber.i(formatStayLog(screenName, stayDuration))
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private fun formatStayLog(
+            screenName: String,
+            stayDuration: Long,
+        ): String = "screen_stay:screen=$screenName,duration_ms=$stayDuration"
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

https://github.com/woowacourse-teams/2025-festabook/issues/382

<br>

## 🛠️ 작업 내용

- fragment 동작 firebase analytics 연결
- 현재화면에 대한 체류 시간 표시
- 에뮬레이터와 firebase analytics 연결하는 명령어
```bash
adb shell setprop debug.firebase.analytics.app com.daedan.festabook.debug
```
<br>

## 🙇🏻 중점 리뷰 요청
- debug모드일 때 Timber.i가 firebase에 안보이게 했습니다!!



<br>

## 📸 이미지 첨부 (Optional)
<img width="3420" height="2224" alt="image" src="https://github.com/user-attachments/assets/4a905497-e3f7-421b-b613-912ffa544cef" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 화면(Fragment)별로 사용자가 머문 시간을 자동으로 기록하고, 해당 정보를 로그로 남깁니다.
  * Firebase Analytics와 연동된 로그 시스템이 도입되어, 주요 정보성 로그 및 화면 체류 시간이 분석에 활용됩니다.

* **버그 수정**
  * 앱 실행 환경에 따라 로그 트리 설정이 자동으로 최적화됩니다. (디버그/릴리즈 구분)

* **리팩터링**
  * 앱 초기화 및 로그 시스템 구조가 개선되어 안정성과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->