### PR TITLE
[COMMON] GitHub Noti 커스터마이징

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,143 @@
+name: Slack Review Notification
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  # 최초 리뷰 요청 알림
+  notify-initial-review-request:
+    if: github.event.action == 'opened' || github.event.action == 'ready_for_review'
+    runs-on: ubuntu-latest
+    steps:
+      # JSON 파싱 도구
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Notify Initial Reviewers
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          REVIEWERS_JSON='${{ toJson(github.event.pull_request.requested_reviewers) }}'
+
+          declare -A GITHUB_TO_SLACK
+          GITHUB_TO_SLACK["soeun2537"]="U09A0LM0CRW"
+          GITHUB_TO_SLACK["taek2222"]="U099ARRH3D3"
+          GITHUB_TO_SLACK["changuii"]="U099BR9RNE6"
+          GITHUB_TO_SLACK["eoehd1ek"]="U0995NANDML"
+          GITHUB_TO_SLACK["oungsi2000"]="U098U2R57NK"
+          GITHUB_TO_SLACK["parkjiminnnn"]="U098U8SLXHD"
+          GITHUB_TO_SLACK["etama123"]="U0995MPSZ62"
+
+          SLACK_AUTHOR_ID=${GITHUB_TO_SLACK[$PR_AUTHOR]:-"$PR_AUTHOR"}
+          SLACK_AUTHOR_MENTION="<@$SLACK_AUTHOR_ID>"
+
+          REVIEWER_MENTIONS=""
+          for reviewer in $(echo "$REVIEWERS_JSON" | jq -r '.[].login'); do
+            slack_id=${GITHUB_TO_SLACK[$reviewer]:-"$reviewer"}
+            REVIEWER_MENTIONS+="<@$slack_id> "
+          done
+
+          if [ -z "$REVIEWER_MENTIONS" ]; then
+            echo "리뷰어가 없으므로 알림 생략"
+            exit 0
+          fi
+
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"🔥 *리뷰 요청 알림*\n*PR 제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${SLACK_AUTHOR_MENTION}\n*리뷰어:* ${REVIEWER_MENTIONS}\n*링크:* ${PR_URL}\"}" \
+            $SLACK_WEBHOOK_URL
+
+  # 재리뷰 요청 알림
+  notify-review-re-request:
+    if: github.event.action == 'review_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Re-review Requested
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_REVIEWER="${{ github.event.requested_reviewer.login }}"
+          REPOSITORY="${{ github.repository }}"
+
+          declare -A GITHUB_TO_SLACK
+          GITHUB_TO_SLACK["soeun2537"]="U09A0LM0CRW"
+          GITHUB_TO_SLACK["taek2222"]="U099ARRH3D3"
+          GITHUB_TO_SLACK["changuii"]="U099BR9RNE6"
+          GITHUB_TO_SLACK["eoehd1ek"]="U0995NANDML"
+          GITHUB_TO_SLACK["oungsi2000"]="U098U2R57NK"
+          GITHUB_TO_SLACK["parkjiminnnn"]="U098U8SLXHD"
+          GITHUB_TO_SLACK["etama123"]="U0995MPSZ62"
+
+          SLACK_AUTHOR_ID=${GITHUB_TO_SLACK[$PR_AUTHOR]:-"$PR_AUTHOR"}
+          SLACK_AUTHOR_MENTION="<@$SLACK_AUTHOR_ID>"
+
+          slack_id=${GITHUB_TO_SLACK[$PR_REVIEWER]:-"$PR_REVIEWER"}
+          SLACK_REVIEWER_MENTION="<@$slack_id>"
+
+          REVIEW_API_URL="https://api.github.com/repos/$REPOSITORY/pulls/$PR_NUMBER/reviews"
+          REVIEW_COUNT=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$REVIEW_API_URL" \
+            | jq -r --arg reviewer "$PR_REVIEWER" '[.[] | select(.user.login == $reviewer)] | length')
+
+          if [ "$REVIEW_COUNT" -eq 0 ]; then
+            echo "최초 리뷰 요청으로 간주되어 알림 생략"
+            exit 0
+          fi
+
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"🏸 *재리뷰 요청 알림*\n*PR 제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${SLACK_AUTHOR_MENTION}\n*리뷰어:* ${SLACK_REVIEWER_MENTION}\n*링크:* ${PR_URL}\"}" \
+            $SLACK_WEBHOOK_URL
+
+  # 리뷰 완료 알림
+  notify-review-submitted:
+    if: github.event.review.state == 'approved' || github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Review Submitted
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          REVIEW_STATE="${{ github.event.review.state }}"
+          REVIEWER="${{ github.event.review.user.login }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          REPOSITORY="${{ github.repository }}"
+          
+          if [[ "$REVIEW_STATE" == "commented" ]]; then
+            echo "단순 코멘트 리뷰는 알림 생략"
+            exit 0
+          fi
+
+          declare -A GITHUB_TO_SLACK
+          GITHUB_TO_SLACK["soeun2537"]="U09A0LM0CRW"
+          GITHUB_TO_SLACK["taek2222"]="U099ARRH3D3"
+          GITHUB_TO_SLACK["changuii"]="U099BR9RNE6"
+          GITHUB_TO_SLACK["eoehd1ek"]="U0995NANDML"
+          GITHUB_TO_SLACK["oungsi2000"]="U098U2R57NK"
+          GITHUB_TO_SLACK["parkjiminnnn"]="U098U8SLXHD"
+          GITHUB_TO_SLACK["etama123"]="U0995MPSZ62"
+
+          SLACK_REVIEWER_ID=${GITHUB_TO_SLACK[$REVIEWER]:-"$REVIEWER"}
+          SLACK_AUTHOR_ID=${GITHUB_TO_SLACK[$PR_AUTHOR]:-"$PR_AUTHOR"}
+
+          SLACK_REVIEWER_MENTION="<@$SLACK_REVIEWER_ID>"
+          SLACK_AUTHOR_MENTION="<@$SLACK_AUTHOR_ID>"
+
+          ICON=""
+          case "$REVIEW_STATE" in
+            approved) ICON="✅" ;;
+            changes_requested) ICON="🔴" ;;
+          esac
+
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"${ICON} *리뷰 완료 알림*\n*PR 제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${SLACK_AUTHOR_MENTION}\n*리뷰어:* ${SLACK_REVIEWER_MENTION}\n*상태:* ${REVIEW_STATE}\n*링크:* ${PR_URL}\"}" \
+            $SLACK_WEBHOOK_URL


### PR DESCRIPTION
## #️⃣ 이슈 번호

#402

<br>

## 🛠️ 작업 내용

- GitHub Noti 커스터마이징

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 풀 리퀘스트 리뷰 이벤트 발생 시 슬랙 알림을 자동으로 전송하는 워크플로우가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->