### PR TITLE
[AN] 분실물 화면 서버 연동

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -6,6 +6,8 @@ import com.daedan.festabook.data.datasource.remote.device.DeviceDataSource
 import com.daedan.festabook.data.datasource.remote.device.DeviceDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.faq.FAQDataSource
 import com.daedan.festabook.data.datasource.remote.faq.FAQDataSourceImpl
+import com.daedan.festabook.data.datasource.remote.lostitem.LostItemDataSource
+import com.daedan.festabook.data.datasource.remote.lostitem.LostItemDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.notice.NoticeDataSource
 import com.daedan.festabook.data.datasource.remote.notice.NoticeDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.organization.FestivalDataSource
@@ -28,6 +30,7 @@ import com.daedan.festabook.data.repository.ScheduleRepositoryImpl
 import com.daedan.festabook.data.service.api.ApiClient.deviceService
 import com.daedan.festabook.data.service.api.ApiClient.faqService
 import com.daedan.festabook.data.service.api.ApiClient.festivalService
+import com.daedan.festabook.data.service.api.ApiClient.lostItemService
 import com.daedan.festabook.data.service.api.ApiClient.noticeService
 import com.daedan.festabook.data.service.api.ApiClient.organizationBookmarkService
 import com.daedan.festabook.data.service.api.ApiClient.placeService
@@ -76,6 +79,10 @@ class AppContainer(
         FestivalDataSourceImpl(festivalService)
     }
 
+    private val lostItemDataSource: LostItemDataSource by lazy {
+        LostItemDataSourceImpl(lostItemService)
+    }
+
     val placeDetailRepository: PlaceDetailRepository by lazy {
         PlaceDetailRepositoryImpl(placeDetailDataSource)
     }
@@ -104,7 +111,7 @@ class AppContainer(
     }
 
     val lostItemRepository: LostItemRepository by lazy {
-        LostItemRepositoryImpl()
+        LostItemRepositoryImpl(lostItemDataSource)
     }
 
     init {

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/faq/FAQDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/faq/FAQDataSource.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.datasource.remote.faq
 
 import com.daedan.festabook.data.datasource.remote.ApiResult
-import com.daedan.festabook.data.model.response.FAQResponse
+import com.daedan.festabook.data.model.response.faq.FAQResponse
 
 interface FAQDataSource {
     suspend fun fetchAllFAQs(): ApiResult<List<FAQResponse>>

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/faq/FAQDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/faq/FAQDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.datasource.remote.faq
 
 import com.daedan.festabook.data.datasource.remote.ApiResult
-import com.daedan.festabook.data.model.response.FAQResponse
+import com.daedan.festabook.data.model.response.faq.FAQResponse
 import com.daedan.festabook.data.service.FAQService
 
 class FAQDataSourceImpl(

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/lostitem/LostItemDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/lostitem/LostItemDataSource.kt
@@ -1,0 +1,8 @@
+package com.daedan.festabook.data.datasource.remote.lostitem
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.model.response.lostitem.LostItemResponse
+
+interface LostItemDataSource {
+    suspend fun fetchAllLostItem(): ApiResult<List<LostItemResponse>>
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/lostitem/LostItemDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/lostitem/LostItemDataSourceImpl.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.data.datasource.remote.lostitem
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.model.response.lostitem.LostItemResponse
+import com.daedan.festabook.data.service.LostItemService
+
+class LostItemDataSourceImpl(
+    private val lostItemService: LostItemService,
+) : LostItemDataSource {
+    override suspend fun fetchAllLostItem(): ApiResult<List<LostItemResponse>> =
+        ApiResult.toApiResult { lostItemService.fetchAllLostItems() }
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/faq/FAQResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/faq/FAQResponse.kt
@@ -1,4 +1,4 @@
-package com.daedan.festabook.data.model.response
+package com.daedan.festabook.data.model.response.faq
 
 import com.daedan.festabook.domain.model.FAQItem
 import kotlinx.serialization.SerialName

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/lostitem/LostItemResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/lostitem/LostItemResponse.kt
@@ -1,0 +1,29 @@
+package com.daedan.festabook.data.model.response.lostitem
+
+import com.daedan.festabook.domain.model.LostItem
+import com.daedan.festabook.domain.model.LostItemStatus
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LostItemResponse(
+    @SerialName("lostItemId")
+    val lostItemId: Long,
+    @SerialName("imageUrl")
+    val imageUrl: String,
+    @SerialName("storageLocation")
+    val storageLocation: String,
+    @SerialName("status")
+    val status: LostItemStatus,
+    @SerialName("createdAt")
+    val createdAt: String,
+)
+
+fun LostItemResponse.toDomain(): LostItem =
+    LostItem(
+        lostItemId = lostItemId,
+        imageUrl = imageUrl,
+        storageLocation = storageLocation,
+        status = status,
+        createdAt = createdAt,
+    )

--- a/android/app/src/main/java/com/daedan/festabook/data/model/response/lostitem/LostItemResponse.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/model/response/lostitem/LostItemResponse.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.data.model.response.lostitem
 
 import com.daedan.festabook.domain.model.LostItem
 import com.daedan.festabook.domain.model.LostItemStatus
+import com.daedan.festabook.domain.model.toLocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -25,5 +26,5 @@ fun LostItemResponse.toDomain(): LostItem =
         imageUrl = imageUrl,
         storageLocation = storageLocation,
         status = status,
-        createdAt = createdAt,
+        createdAt = createdAt.toLocalDateTime(),
     )

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/FAQRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/FAQRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.repository
 
 import com.daedan.festabook.data.datasource.remote.faq.FAQDataSource
-import com.daedan.festabook.data.model.response.toDomain
+import com.daedan.festabook.data.model.response.faq.toDomain
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.model.FAQItem
 import com.daedan.festabook.domain.repository.FAQRepository

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
@@ -13,5 +13,9 @@ class LostItemRepositoryImpl(
         lostItemDataSource
             .fetchAllLostItem()
             .toResult()
-            .mapCatching { it.map { lostItemResponse -> lostItemResponse.toDomain() } }
+            .mapCatching { lostItemResponses ->
+                lostItemResponses
+                    .map { lostItemResponse -> lostItemResponse.toDomain() }
+                    .sortedByDescending { it.createdAt }
+            }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/LostItemRepositoryImpl.kt
@@ -1,60 +1,17 @@
 package com.daedan.festabook.data.repository
 
+import com.daedan.festabook.data.datasource.remote.lostitem.LostItemDataSource
+import com.daedan.festabook.data.model.response.lostitem.toDomain
+import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.model.LostItem
 import com.daedan.festabook.domain.repository.LostItemRepository
 
-class LostItemRepositoryImpl : LostItemRepository {
-    override fun getAllLostItems(): List<LostItem> =
-        listOf(
-            LostItem(
-                imageId = 1L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "도서관",
-            ),
-            LostItem(
-                imageId = 2L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "학생회관",
-            ),
-            LostItem(
-                imageId = 3L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "체육관",
-            ),
-            LostItem(
-                imageId = 4L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "강의동",
-            ),
-            LostItem(
-                imageId = 5L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "기숙사",
-            ),
-            LostItem(
-                imageId = 6L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "편의점",
-            ),
-            LostItem(
-                imageId = 7L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "카페",
-            ),
-            LostItem(
-                imageId = 8L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "주차장",
-            ),
-            LostItem(
-                imageId = 9L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "정문",
-            ),
-            LostItem(
-                imageId = 10L,
-                imageUrl = "https://picsum.photos/200/300",
-                storageLocation = "후문",
-            ),
-        )
+class LostItemRepositoryImpl(
+    private val lostItemDataSource: LostItemDataSource,
+) : LostItemRepository {
+    override suspend fun getAllLostItems(): Result<List<LostItem>> =
+        lostItemDataSource
+            .fetchAllLostItem()
+            .toResult()
+            .mapCatching { it.map { lostItemResponse -> lostItemResponse.toDomain() } }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/ScheduleRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/ScheduleRepositoryImpl.kt
@@ -12,7 +12,9 @@ class ScheduleRepositoryImpl(
 ) : ScheduleRepository {
     override suspend fun fetchAllScheduleDates(): Result<List<ScheduleDate>> {
         val response = scheduleDataSource.fetchScheduleDates().toResult()
-        return response.mapCatching { scheduleDateResponses -> scheduleDateResponses.map { it.toDomain() } }
+        return response.mapCatching { scheduleDateResponses ->
+            scheduleDateResponses.map { it.toDomain() }.sortedBy { it.date }
+        }
     }
 
     override suspend fun fetchScheduleEventsById(eventDateId: Long): Result<List<ScheduleEvent>> {

--- a/android/app/src/main/java/com/daedan/festabook/data/service/FAQService.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/FAQService.kt
@@ -1,6 +1,6 @@
 package com.daedan.festabook.data.service
 
-import com.daedan.festabook.data.model.response.FAQResponse
+import com.daedan.festabook.data.model.response.faq.FAQResponse
 import retrofit2.Response
 import retrofit2.http.GET
 

--- a/android/app/src/main/java/com/daedan/festabook/data/service/LostItemService.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/LostItemService.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.data.service
+
+import com.daedan.festabook.data.model.response.lostitem.LostItemResponse
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface LostItemService {
+    @GET("lost-items")
+    suspend fun fetchAllLostItems(): Response<List<LostItemResponse>>
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/service/api/ApiClient.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/api/ApiClient.kt
@@ -4,6 +4,7 @@ import com.daedan.festabook.BuildConfig
 import com.daedan.festabook.data.service.DeviceService
 import com.daedan.festabook.data.service.FAQService
 import com.daedan.festabook.data.service.FestivalService
+import com.daedan.festabook.data.service.LostItemService
 import com.daedan.festabook.data.service.NoticeService
 import com.daedan.festabook.data.service.OrganizationBookmarkService
 import com.daedan.festabook.data.service.PlaceService
@@ -46,4 +47,6 @@ object ApiClient {
     val faqService: FAQService by lazy { retrofit.create(FAQService::class.java) }
 
     val festivalService: FestivalService = retrofit.create(FestivalService::class.java)
+
+    val lostItemService: LostItemService by lazy { retrofit.create(LostItemService::class.java) }
 }

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
@@ -1,9 +1,13 @@
 package com.daedan.festabook.domain.model
 
+import java.time.LocalDateTime
+
 data class LostItem(
     val lostItemId: Long,
     val imageUrl: String,
     val storageLocation: String,
     val status: LostItemStatus,
-    val createdAt: String,
+    val createdAt: LocalDateTime,
 )
+
+fun String.toLocalDateTime() = LocalDateTime.parse(this)

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/LostItem.kt
@@ -1,7 +1,9 @@
 package com.daedan.festabook.domain.model
 
 data class LostItem(
-    val imageId: Long,
+    val lostItemId: Long,
     val imageUrl: String,
     val storageLocation: String,
+    val status: LostItemStatus,
+    val createdAt: String,
 )

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/LostItemStatus.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/LostItemStatus.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.domain.model
+
+enum class LostItemStatus {
+    PENDING,
+    COMPLETED,
+}

--- a/android/app/src/main/java/com/daedan/festabook/domain/repository/LostItemRepository.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/repository/LostItemRepository.kt
@@ -3,5 +3,5 @@ package com.daedan.festabook.domain.repository
 import com.daedan.festabook.domain.model.LostItem
 
 interface LostItemRepository {
-    fun getAllLostItems(): List<LostItem>
+    suspend fun getAllLostItems(): Result<List<LostItem>>
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemModalDialogFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemModalDialogFragment.kt
@@ -14,10 +14,11 @@ import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentLostItemModalDialogBinding
 import com.daedan.festabook.presentation.common.getObject
 import com.daedan.festabook.presentation.news.lost.model.LostItemUiModel
+import timber.log.Timber
 
 class LostItemModalDialogFragment : DialogFragment() {
-    private val lostItem: LostItemUiModel by lazy {
-        arguments?.getObject(KEY_LOST_ITEM) ?: LostItemUiModel()
+    private val lostItem: LostItemUiModel? by lazy {
+        arguments?.getObject(KEY_LOST_ITEM)
     }
 
     private lateinit var binding: FragmentLostItemModalDialogBinding
@@ -53,13 +54,17 @@ class LostItemModalDialogFragment : DialogFragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-
-        binding.ivModalLostItemImage.load(lostItem.imageUrl)
-        binding.tvModalLostItemStorageLocation.text =
-            binding.tvModalLostItemStorageLocation.context.getString(
-                R.string.modal_lost_item,
-                lostItem.storageLocation,
-            )
+        lostItem?.let {
+            binding.ivModalLostItemImage.load(it.imageUrl)
+            binding.tvModalLostItemStorageLocation.text =
+                binding.tvModalLostItemStorageLocation.context.getString(
+                    R.string.modal_lost_item,
+                    it.storageLocation,
+                )
+        } ?: run {
+            Timber.e("선택한 분실물이 존재하지 않습니다.")
+            dismissAllowingStateLoss()
+        }
     }
 
     override fun onStart() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/adapter/LostItemAdapter.kt
@@ -28,7 +28,7 @@ class LostItemAdapter(
                 override fun areItemsTheSame(
                     oldItem: LostItemUiModel,
                     newItem: LostItemUiModel,
-                ): Boolean = oldItem.imageId == newItem.imageId
+                ): Boolean = oldItem.lostItemId == newItem.lostItemId
 
                 override fun areContentsTheSame(
                     oldItem: LostItemUiModel,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
@@ -2,18 +2,27 @@ package com.daedan.festabook.presentation.news.lost.model
 
 import android.os.Parcelable
 import com.daedan.festabook.domain.model.LostItem
+import com.daedan.festabook.domain.model.LostItemStatus
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class LostItemUiModel(
-    val imageId: Long = -1L,
+    val lostItemId: Long = -1L,
     val imageUrl: String = "",
     val storageLocation: String = "",
+    val status: LostItemUiStatus,
+    val createdAt: String = "",
 ) : Parcelable
 
 fun LostItem.toUiModel(): LostItemUiModel =
     LostItemUiModel(
-        imageId = imageId,
+        lostItemId = lostItemId,
         imageUrl = imageUrl,
         storageLocation = storageLocation,
+        status =
+            when (status) {
+                LostItemStatus.PENDING -> LostItemUiStatus.PENDING
+                LostItemStatus.COMPLETED -> LostItemUiStatus.COMPLETED
+            },
+        createdAt = createdAt,
     )

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.daedan.festabook.domain.model.LostItem
 import com.daedan.festabook.domain.model.LostItemStatus
 import kotlinx.parcelize.Parcelize
+import java.time.LocalDateTime
 
 @Parcelize
 data class LostItemUiModel(
@@ -24,5 +25,5 @@ fun LostItem.toUiModel(): LostItemUiModel =
                 LostItemStatus.PENDING -> LostItemUiStatus.PENDING
                 LostItemStatus.COMPLETED -> LostItemUiStatus.COMPLETED
             },
-        createdAt = createdAt,
+        createdAt = createdAt.toString(),
     )

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiStatus.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/model/LostItemUiStatus.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.presentation.news.lost.model
+
+enum class LostItemUiStatus {
+    PENDING,
+    COMPLETED,
+}

--- a/android/app/src/test/java/com/daedan/festabook/news/NewsTestFixture.kt
+++ b/android/app/src/test/java/com/daedan/festabook/news/NewsTestFixture.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.news
 
 import com.daedan.festabook.domain.model.FAQItem
 import com.daedan.festabook.domain.model.LostItem
+import com.daedan.festabook.domain.model.LostItemStatus
 import com.daedan.festabook.domain.model.Notice
 import java.time.LocalDateTime
 
@@ -39,5 +40,7 @@ val FAKE_LOST_ITEM =
             lostItemId = 1,
             imageUrl = "테스트 이미지 주소",
             storageLocation = "테스트 장소",
+            status = LostItemStatus.PENDING,
+            createdAt = LocalDateTime.of(2025, 1, 1, 0, 0, 0),
         ),
     )

--- a/android/app/src/test/java/com/daedan/festabook/news/NewsTestFixture.kt
+++ b/android/app/src/test/java/com/daedan/festabook/news/NewsTestFixture.kt
@@ -36,7 +36,7 @@ val FAKE_FAQS =
 val FAKE_LOST_ITEM =
     listOf(
         LostItem(
-            imageId = 1,
+            lostItemId = 1,
             imageUrl = "테스트 이미지 주소",
             storageLocation = "테스트 장소",
         ),

--- a/android/app/src/test/java/com/daedan/festabook/news/NewsViewModelTest.kt
+++ b/android/app/src/test/java/com/daedan/festabook/news/NewsViewModelTest.kt
@@ -46,7 +46,7 @@ class NewsViewModelTest {
         lostItemRepository = mockk()
         coEvery { noticeRepository.fetchNotices() } returns Result.success(FAKE_NOTICES)
         coEvery { faqRepository.getAllFAQ() } returns Result.success(FAKE_FAQS)
-        coEvery { lostItemRepository.getAllLostItems() } returns FAKE_LOST_ITEM
+        coEvery { lostItemRepository.getAllLostItems() } returns Result.success(FAKE_LOST_ITEM)
 
         newsViewModel =
             NewsViewModel(


### PR DESCRIPTION
## #️⃣ 이슈 번호

#423 

<br>

## 🛠️ 작업 내용

- 분실물 화면 서버 연동했습니다.
- 최근 시간일수록 위쪽에 로드되도록 구현했습니다.
- 추가로 일정도 정렬방식을 추가했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 예외처리를 신경쓴다고 했는데 놓친부분 있으면 알려주세요~~
- 새로고침 기능은 이슈를 하나 더 생성해서 구현할 예정입니다

```kotlin
package com.daedan.festabook.data.service.api.ApiClient

 val scheduleService: ScheduleService by lazy { retrofit.create(ScheduleService::class.java) }
    val noticeService: NoticeService = retrofit.create(NoticeService::class.java)
    val placeService: PlaceService = retrofit.create(PlaceService::class.java)
    val deviceService: DeviceService by lazy { retrofit.create(DeviceService::class.java) }
    val organizationBookmarkService: OrganizationBookmarkService by lazy {
        retrofit.create(
            OrganizationBookmarkService::class.java,
        )
    }
    val faqService: FAQService by lazy { retrofit.create(FAQService::class.java) }

    val festivalService: FestivalService = retrofit.create(FestivalService::class.java)

    val lostItemService: LostItemService by lazy { retrofit.create(LostItemService::class.java) }
```
이부분 지연초기화해도 상관없고 초기화를 먼저 해놓고 사용해도 상관이 없기는 할 것 같은데
하는김에 by lazy로 다 맞춰줄까 하는데 어떠신가용
<br>

## 📸 이미지 첨부 (Optional)


https://github.com/user-attachments/assets/c0be554c-7952-4201-9331-7942ad2ff650


