### PR TITLE
[BE] DTO 변수명 구체적으로 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/announcement/dto/AnnouncementResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/dto/AnnouncementResponse.java
@@ -4,7 +4,7 @@ import com.daedan.festabook.announcement.domain.Announcement;
 import java.time.LocalDateTime;
 
 public record AnnouncementResponse(
-        Long id,
+        Long announcementId,
         String title,
         String content,
         boolean isPinned,

--- a/backend/src/main/java/com/daedan/festabook/device/dto/DeviceResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/device/dto/DeviceResponse.java
@@ -3,7 +3,7 @@ package com.daedan.festabook.device.dto;
 import com.daedan.festabook.device.domain.Device;
 
 public record DeviceResponse(
-        Long id
+        Long deviceId
 ) {
 
     public static DeviceResponse from(Device device) {

--- a/backend/src/main/java/com/daedan/festabook/event/domain/Event.java
+++ b/backend/src/main/java/com/daedan/festabook/event/domain/Event.java
@@ -23,6 +23,10 @@ public class Event implements Comparable<Event> {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private EventDate eventDate;
+
     @Column(nullable = false)
     private LocalTime startTime;
 
@@ -35,40 +39,36 @@ public class Event implements Comparable<Event> {
     @Column(nullable = false)
     private String location;
 
-    @JoinColumn(nullable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private EventDate eventDate;
-
     protected Event(
             Long id,
+            EventDate eventDate,
             LocalTime startTime,
             LocalTime endTime,
             String title,
-            String location,
-            EventDate eventDate
+            String location
     ) {
         this.id = id;
+        this.eventDate = eventDate;
         this.startTime = startTime;
         this.endTime = endTime;
         this.title = title;
         this.location = location;
-        this.eventDate = eventDate;
     }
 
     public Event(
+            EventDate eventDate,
             LocalTime startTime,
             LocalTime endTime,
             String title,
-            String location,
-            EventDate eventDate
+            String location
     ) {
         this(
                 null,
+                eventDate,
                 startTime,
                 endTime,
                 title,
-                location,
-                eventDate
+                location
         );
     }
 

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventDateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventDateResponse.java
@@ -4,7 +4,7 @@ import com.daedan.festabook.event.domain.EventDate;
 import java.time.LocalDate;
 
 public record EventDateResponse(
-        Long id,
+        Long eventDateId,
         LocalDate date
 ) {
 

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventRequest.java
@@ -7,6 +7,9 @@ import java.time.LocalTime;
 
 public record EventRequest(
 
+        @Schema(description = "일정 날짜 ID", example = "1")
+        Long eventDateId,
+
         @Schema(description = "일정 시작 시간", example = "01:00")
         LocalTime startTime,
 
@@ -17,19 +20,16 @@ public record EventRequest(
         String title,
 
         @Schema(description = "일정 진행 위치", example = "알고리즘 밸리 정문")
-        String location,
-
-        @Schema(description = "일정 날짜 ID", example = "1")
-        Long eventDateId
+        String location
 ) {
 
     public Event toEntity(EventDate eventDate) {
         return new Event(
+                eventDate,
                 startTime,
                 endTime,
                 title,
-                location,
-                eventDate
+                location
         );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventResponse.java
@@ -7,7 +7,7 @@ import java.time.Clock;
 import java.time.LocalTime;
 
 public record EventResponse(
-        Long id,
+        Long eventId,
         EventStatus status,
         @JsonFormat(pattern = "HH:mm") LocalTime startTime,
         @JsonFormat(pattern = "HH:mm") LocalTime endTime,

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationResponse.java
@@ -3,7 +3,7 @@ package com.daedan.festabook.festival.dto;
 import com.daedan.festabook.festival.domain.FestivalNotification;
 
 public record FestivalNotificationResponse(
-        Long id
+        Long festivalNotificationId
 ) {
 
     public static FestivalNotificationResponse from(FestivalNotification festivalNotification) {

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record FestivalResponse(
-        Long id,
+        Long festivalId,
         String universityName,
         FestivalImageResponses festivalImages,
         String festivalName,

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceCoordinateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceCoordinateResponse.java
@@ -4,7 +4,7 @@ import com.daedan.festabook.festival.dto.FestivalCoordinateResponse;
 import com.daedan.festabook.place.domain.Place;
 
 public record PlaceCoordinateResponse(
-        Long id,
+        Long placeId,
         FestivalCoordinateResponse coordinate
 ) {
 

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceFavoriteResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceFavoriteResponse.java
@@ -3,7 +3,7 @@ package com.daedan.festabook.place.dto;
 import com.daedan.festabook.place.domain.PlaceFavorite;
 
 public record PlaceFavoriteResponse(
-        Long id
+        Long placeFavoriteId
 ) {
 
     public static PlaceFavoriteResponse from(PlaceFavorite placeFavorite) {

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponse.java
@@ -5,7 +5,7 @@ import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceCategory;
 
 public record PlaceGeographyResponse(
-        Long id,
+        Long placeId,
         PlaceCategory category,
         FestivalCoordinateResponse markerCoordinate
 ) {

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlacePreviewResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlacePreviewResponse.java
@@ -6,7 +6,7 @@ import com.daedan.festabook.place.domain.PlaceDetail;
 import com.daedan.festabook.place.domain.PlaceImage;
 
 public record PlacePreviewResponse(
-        Long id,
+        Long placeId,
         String imageUrl,
         PlaceCategory category,
         String title,

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceResponse.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record PlaceResponse(
-        Long id,
+        Long placeId,
         PlaceImageResponses placeImages,
         PlaceCategory category,
         String title,

--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -20,9 +20,9 @@ import com.daedan.festabook.announcement.dto.AnnouncementUpdateRequest;
 import com.daedan.festabook.announcement.dto.AnnouncementUpdateRequestFixture;
 import com.daedan.festabook.announcement.infrastructure.AnnouncementJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.notification.infrastructure.FcmNotificationManager;
-import com.daedan.festabook.festival.domain.FestivalFixture;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.List;
@@ -157,13 +157,13 @@ class AnnouncementControllerTest {
                     .body("pinned", hasSize(expectedPinnedSize))
                     .body("unpinned.size()", equalTo(expectedUnpinnedSize))
                     .body("pinned[0].size()", equalTo(expectedFieldSize))
-                    .body("pinned[0].id", equalTo(announcement1.getId().intValue()))
+                    .body("pinned[0].announcementId", equalTo(announcement1.getId().intValue()))
                     .body("pinned[0].title", equalTo(announcement1.getTitle()))
                     .body("pinned[0].content", equalTo(announcement1.getContent()))
                     .body("pinned[0].isPinned", equalTo(announcement1.isPinned()))
                     .body("pinned[0].createdAt", notNullValue())
                     .body("unpinned[0].size()", equalTo(expectedFieldSize))
-                    .body("unpinned[0].id", equalTo(announcement2.getId().intValue()))
+                    .body("unpinned[0].announcementId", equalTo(announcement2.getId().intValue()))
                     .body("unpinned[0].title", equalTo(announcement2.getTitle()))
                     .body("unpinned[0].content", equalTo(announcement2.getContent()))
                     .body("unpinned[0].isPinned", equalTo(announcement2.isPinned()))
@@ -219,7 +219,7 @@ class AnnouncementControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .extract()
                     .jsonPath()
-                    .getList("pinned.id", Long.class);
+                    .getList("pinned.announcementId", Long.class);
 
             assertSoftly(s -> {
                 s.assertThat(result.get(0)).isEqualTo(announcement3.getId());
@@ -254,7 +254,7 @@ class AnnouncementControllerTest {
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("pinned.size()", equalTo(expectedSize))
-                    .body("pinned.id", containsInAnyOrder(
+                    .body("pinned.announcementId", containsInAnyOrder(
                             targetAnnouncements.get(0).getId().intValue(),
                             targetAnnouncements.get(1).getId().intValue(),
                             targetAnnouncements.get(2).getId().intValue()

--- a/backend/src/test/java/com/daedan/festabook/device/controller/DeviceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/device/controller/DeviceControllerTest.java
@@ -51,7 +51,7 @@ class DeviceControllerTest {
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
-                    .body("id", notNullValue());
+                    .body("deviceId", notNullValue());
         }
 
         @Test
@@ -69,9 +69,9 @@ class DeviceControllerTest {
                     .post("/devices")
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
-                    .body("id", notNullValue())
+                    .body("deviceId", notNullValue())
                     .extract()
-                    .path("id");
+                    .path("deviceId");
 
             int expectedFieldSize = 1;
 
@@ -85,7 +85,7 @@ class DeviceControllerTest {
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
-                    .body("id", equalTo(expectedId));
+                    .body("deviceId", equalTo(expectedId));
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/device/domain/DeviceFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/device/domain/DeviceFixture.java
@@ -31,10 +31,10 @@ public class DeviceFixture {
     }
 
     public static Device create(
-            Long id
+            Long deviceId
     ) {
         return new Device(
-                id,
+                deviceId,
                 DEFAULT_DEVICE_IDENTIFIER,
                 DEFAULT_FCM_TOKEN
         );

--- a/backend/src/test/java/com/daedan/festabook/device/domain/DeviceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/device/domain/DeviceTest.java
@@ -12,9 +12,6 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DeviceTest {
 
-    private final String DEFAULT_DEVICE_IDENTIFIER = "device-abc123";
-    private final String DEFAULT_FCM_TOKEN = "fcm-token-xyz";
-
     @Nested
     class validateDeviceIdentifier {
 

--- a/backend/src/test/java/com/daedan/festabook/device/service/DeviceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/device/service/DeviceServiceTest.java
@@ -51,7 +51,7 @@ class DeviceServiceTest {
             DeviceResponse result = deviceService.registerDevice(request);
 
             // then
-            assertThat(result.id()).isEqualTo(expectedId);
+            assertThat(result.deviceId()).isEqualTo(expectedId);
             then(deviceJpaRepository).should()
                     .save(any());
         }
@@ -70,7 +70,7 @@ class DeviceServiceTest {
             DeviceResponse result = deviceService.registerDevice(request);
 
             // then
-            assertThat(result.id()).isEqualTo(expectedId);
+            assertThat(result.deviceId()).isEqualTo(expectedId);
             then(deviceJpaRepository).should(never())
                     .save(any());
         }

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventControllerTest.java
@@ -113,11 +113,11 @@ class EventControllerTest {
             Long eventId = event.getId();
 
             EventRequest request = EventRequestFixture.create(
+                    eventDate.getId(),
                     LocalTime.of(3, 0),
                     LocalTime.of(4, 0),
                     "updated title",
-                    "updated location",
-                    eventDate.getId()
+                    "updated location"
             );
 
             // when & then

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventControllerTest.java
@@ -15,8 +15,8 @@ import com.daedan.festabook.event.dto.EventRequestFixture;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
-import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.time.Clock;
@@ -213,7 +213,7 @@ class EventControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .body("$", hasSize(expectedSize))
                     .body("[0].size()", equalTo(expectedFieldSize))
-                    .body("[0].id", equalTo(event.getId().intValue()))
+                    .body("[0].eventId", equalTo(event.getId().intValue()))
                     .body("[0].status", equalTo(EventStatus.ONGOING.name()))
                     .body("[0].startTime", equalTo(event.getStartTime().toString()))
                     .body("[0].endTime", equalTo(event.getEndTime().toString()))

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
@@ -139,7 +139,7 @@ class EventDateControllerTest {
         }
 
         @Test
-        void 성공_존재하지_않는_일정_날짜_ID_204_응답() {
+        void 성공_존재하지_않는_일정_날짜_ID_404_응답() {
             // given
             Festival festival = FestivalFixture.create();
             festivalJpaRepository.save(festival);

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
@@ -14,8 +14,8 @@ import com.daedan.festabook.event.dto.EventDateRequestFixture;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
-import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.time.Clock;
@@ -238,7 +238,7 @@ class EventDateControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .body("$", hasSize(expectedSize))
                     .body("[0].size()", equalTo(expectedFieldSize))
-                    .body("[0].id", equalTo(eventDate.getId().intValue()))
+                    .body("[0].eventDateId", equalTo(eventDate.getId().intValue()))
                     .body("[0].date", equalTo(eventDate.getDate().toString()));
         }
 

--- a/backend/src/test/java/com/daedan/festabook/event/domain/EventFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/domain/EventFixture.java
@@ -15,19 +15,19 @@ public class EventFixture {
 
     public static Event create(
             Long eventId,
+            EventDate eventDate,
             LocalTime startTime,
             LocalTime endTime,
             String title,
-            String location,
-            EventDate eventDate
+            String location
     ) {
         return new Event(
                 eventId,
+                eventDate,
                 startTime,
                 endTime,
                 title,
-                location,
-                eventDate
+                location
         );
     }
 
@@ -35,21 +35,21 @@ public class EventFixture {
             String title
     ) {
         return new Event(
+                DEFAULT_EVENT_DATE,
                 DEFAULT_START_TIME,
                 DEFAULT_END_TIME,
                 title,
-                DEFAULT_LOCATION,
-                DEFAULT_EVENT_DATE
+                DEFAULT_LOCATION
         );
     }
 
     public static Event create() {
         return new Event(
+                DEFAULT_EVENT_DATE,
                 DEFAULT_START_TIME,
                 DEFAULT_END_TIME,
                 DEFAULT_TITLE,
-                DEFAULT_LOCATION,
-                DEFAULT_EVENT_DATE
+                DEFAULT_LOCATION
         );
     }
 
@@ -57,11 +57,11 @@ public class EventFixture {
             EventDate eventDate
     ) {
         return new Event(
+                eventDate,
                 DEFAULT_START_TIME,
                 DEFAULT_END_TIME,
                 DEFAULT_TITLE,
-                DEFAULT_LOCATION,
-                eventDate
+                DEFAULT_LOCATION
         );
     }
 
@@ -71,27 +71,27 @@ public class EventFixture {
             EventDate eventDate
     ) {
         return new Event(
+                eventDate,
                 startTime,
                 endTime,
                 DEFAULT_TITLE,
-                DEFAULT_LOCATION,
-                eventDate
+                DEFAULT_LOCATION
         );
     }
 
     public static Event create(
+            EventDate eventDate,
             LocalTime startTime,
             LocalTime endTime,
             String title,
-            String location,
-            EventDate eventDate
+            String location
     ) {
         return new Event(
+                eventDate,
                 startTime,
                 endTime,
                 title,
-                location,
-                eventDate
+                location
         );
     }
 

--- a/backend/src/test/java/com/daedan/festabook/event/domain/EventFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/domain/EventFixture.java
@@ -14,7 +14,7 @@ public class EventFixture {
     private static final EventDate DEFAULT_EVENT_DATE = EventDateFixture.create();
 
     public static Event create(
-            Long id,
+            Long eventId,
             LocalTime startTime,
             LocalTime endTime,
             String title,
@@ -22,7 +22,7 @@ public class EventFixture {
             EventDate eventDate
     ) {
         return new Event(
-                id,
+                eventId,
                 startTime,
                 endTime,
                 title,

--- a/backend/src/test/java/com/daedan/festabook/event/domain/EventTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/domain/EventTest.java
@@ -29,19 +29,19 @@ class EventTest {
             // given
             EventDate eventDate = EventDateFixture.create(LocalDate.of(2025, 5, 5));
             Event originalEvent = EventFixture.create(
+                    eventDate,
                     LocalTime.of(1, 0),
                     LocalTime.of(2, 0),
                     "Original Title",
-                    "Original Location",
-                    eventDate
+                    "Original Location"
             );
 
             Event newEvent = EventFixture.create(
+                    eventDate,
                     LocalTime.of(3, 0),
                     LocalTime.of(4, 0),
                     "Updated Title",
-                    "Updated Location",
-                    eventDate
+                    "Updated Location"
             );
 
             // when

--- a/backend/src/test/java/com/daedan/festabook/event/dto/EventRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/dto/EventRequestFixture.java
@@ -11,18 +11,18 @@ public class EventRequestFixture {
     private final static Long DEFAULT_EVENT_DATE_ID = 1L;
 
     public static EventRequest create(
+            Long eventDateId,
             LocalTime startTime,
             LocalTime endTime,
             String title,
-            String location,
-            Long eventDateId
+            String location
     ) {
         return new EventRequest(
+                eventDateId,
                 startTime,
                 endTime,
                 title,
-                location,
-                eventDateId
+                location
         );
     }
 
@@ -30,21 +30,21 @@ public class EventRequestFixture {
             Long eventDateId
     ) {
         return new EventRequest(
+                eventDateId,
                 DEFAULT_START_TIME,
                 DEFAULT_END_TIME,
                 DEFAULT_TITLE,
-                DEFAULT_LOCATION,
-                eventDateId
+                DEFAULT_LOCATION
         );
     }
 
     public static EventRequest create() {
         return new EventRequest(
+                DEFAULT_EVENT_DATE_ID,
                 DEFAULT_START_TIME,
                 DEFAULT_END_TIME,
                 DEFAULT_TITLE,
-                DEFAULT_LOCATION,
-                DEFAULT_EVENT_DATE_ID
+                DEFAULT_LOCATION
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
@@ -16,9 +16,9 @@ import com.daedan.festabook.event.dto.EventDateResponses;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
-import com.daedan.festabook.festival.domain.FestivalFixture;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -69,7 +69,7 @@ class EventDateServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.id()).isEqualTo(eventDate.getId());
+                s.assertThat(result.eventDateId()).isEqualTo(eventDate.getId());
                 s.assertThat(result.date()).isEqualTo(eventDate.getDate());
             });
         }

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.event.domain.Event;
 import com.daedan.festabook.event.domain.EventDate;
 import com.daedan.festabook.event.domain.EventDateFixture;
@@ -19,6 +18,7 @@ import com.daedan.festabook.event.dto.EventResponse;
 import com.daedan.festabook.event.dto.EventResponses;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -85,7 +85,7 @@ class EventServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.id()).isEqualTo(eventId);
+                s.assertThat(result.eventId()).isEqualTo(eventId);
                 s.assertThat(result.startTime()).isEqualTo(event.getStartTime());
                 s.assertThat(result.endTime()).isEqualTo(event.getEndTime());
                 s.assertThat(result.title()).isEqualTo(event.getTitle());

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventServiceTest.java
@@ -71,11 +71,11 @@ class EventServiceTest {
             Long eventId = 1L;
             Event event = EventFixture.create(
                     eventId,
+                    eventDate,
                     request.startTime(),
                     request.endTime(),
                     request.title(),
-                    request.location(),
-                    eventDate
+                    request.location()
             );
             given(eventJpaRepository.save(any()))
                     .willReturn(event);
@@ -138,11 +138,11 @@ class EventServiceTest {
             );
 
             EventRequest eventRequest = EventRequestFixture.create(
+                    eventDateId,
                     updatedEvent.getStartTime(),
                     updatedEvent.getEndTime(),
                     updatedEvent.getTitle(),
-                    updatedEvent.getLocation(),
-                    eventDateId
+                    updatedEvent.getLocation()
             );
 
             // when
@@ -199,11 +199,11 @@ class EventServiceTest {
             setFixedClock();
 
             Event event = EventFixture.create(
+                    EventDateFixture.create(LocalDate.of(2025, 5, 5)),
                     LocalTime.of(16, 0, 0),
                     LocalTime.of(16, 0, 0),
                     "title",
-                    "location",
-                    EventDateFixture.create(LocalDate.of(2025, 5, 5))
+                    "location"
             );
 
             Long eventDateId = 1L;

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationControllerTest.java
@@ -82,7 +82,7 @@ class FestivalNotificationControllerTest {
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
-                    .body("id", notNullValue());
+                    .body("festivalNotificationId", notNullValue());
 
             then(fcmNotificationManager).should()
                     .subscribeFestivalTopic(any(), any());

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalFixture.java
@@ -86,10 +86,10 @@ public class FestivalFixture {
     }
 
     public static Festival create(
-            Long id
+            Long festivalId
     ) {
         return new Festival(
-                id,
+                festivalId,
                 DEFAULT_UNIVERSITY_NAME,
                 DEFAULT_FESTIVAL_NAME,
                 DEFAULT_START_DATE,

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageFixture.java
@@ -6,7 +6,6 @@ import java.util.stream.IntStream;
 
 public class FestivalImageFixture {
 
-    private static final Festival DEFAULT_FESTIVAL = FestivalFixture.create();
     private static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
     private static final Integer DEFAULT_SEQUENCE = 3;
 
@@ -32,12 +31,12 @@ public class FestivalImageFixture {
     }
 
     public static FestivalImage create(
-            Long id,
+            Long festivalImageId,
             Festival festival,
             Integer sequence
     ) {
         return new FestivalImage(
-                id,
+                festivalImageId,
                 festival,
                 DEFAULT_IMAGE_URL,
                 sequence

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalNotificationFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalNotificationFixture.java
@@ -9,33 +9,33 @@ public class FestivalNotificationFixture {
     private static final Device DEFAULT_DEVICE = DeviceFixture.create();
 
     public static FestivalNotification create(
-            Long id
+            Long festivalNotificationId
     ) {
         return new FestivalNotification(
-                id,
+                festivalNotificationId,
                 DEFAULT_FESTIVAL,
                 DEFAULT_DEVICE
         );
     }
 
     public static FestivalNotification create(
-            Long id,
+            Long festivalNotificationId,
             Festival festival
     ) {
         return new FestivalNotification(
-                id,
+                festivalNotificationId,
                 festival,
                 DEFAULT_DEVICE
         );
     }
 
     public static FestivalNotification create(
-            Long id,
+            Long festivalNotificationId,
             Festival festival,
             Device device
     ) {
         return new FestivalNotification(
-                id,
+                festivalNotificationId,
                 festival,
                 device
         );

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.BDDMockito.then;
 import com.daedan.festabook.device.domain.Device;
 import com.daedan.festabook.device.domain.DeviceFixture;
 import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.domain.FestivalNotification;
@@ -21,6 +20,7 @@ import com.daedan.festabook.festival.dto.FestivalNotificationRequestFixture;
 import com.daedan.festabook.festival.dto.FestivalNotificationResponse;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.festival.infrastructure.FestivalNotificationJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -80,7 +80,7 @@ class FestivalNotificationServiceTest {
                     festivalId, request);
 
             // then
-            assertThat(result.id()).isEqualTo(festivalNotificationId);
+            assertThat(result.festivalNotificationId()).isEqualTo(festivalNotificationId);
             then(festivalNotificationJpaRepository).should()
                     .save(any());
             then(festivalNotificationManager).should()

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -12,8 +12,8 @@ import com.daedan.festabook.device.domain.DeviceFixture;
 import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
 import com.daedan.festabook.festival.domain.Coordinate;
 import com.daedan.festabook.festival.domain.Festival;
-import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
@@ -105,7 +105,7 @@ class PlaceControllerTest {
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
-                    .body("id", notNullValue())
+                    .body("placeId", notNullValue())
                     .body("category", equalTo(expectedPlaceCategory.toString()))
 
                     .body("placeImages", empty())
@@ -229,7 +229,7 @@ class PlaceControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .body("$", hasSize(expectedSize))
                     .body("[0].size()", equalTo(expectedFieldSize))
-                    .body("[0].id", equalTo(place.getId().intValue()))
+                    .body("[0].placeId", equalTo(place.getId().intValue()))
                     .body("[0].imageUrl", equalTo(placeImage.getImageUrl()))
                     .body("[0].category", equalTo(place.getCategory().name()))
                     .body("[0].title", equalTo(placeDetail.getTitle()))
@@ -370,7 +370,7 @@ class PlaceControllerTest {
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("size()", equalTo(expectedFieldSize))
-                    .body("id", equalTo(place.getId().intValue()))
+                    .body("placeId", equalTo(place.getId().intValue()))
                     .body("placeImages", hasSize(expectedPlaceImagesSize))
                     .body("placeImages[0].id", equalTo(placeImage1.getId().intValue()))
                     .body("placeImages[0].imageUrl", equalTo(placeImage1.getImageUrl()))

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceFavoriteControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceFavoriteControllerTest.java
@@ -84,7 +84,7 @@ class PlaceFavoriteControllerTest {
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
-                    .body("id", notNullValue());
+                    .body("placeFavoriteId", notNullValue());
         }
 
         @Test

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
@@ -88,7 +88,7 @@ class PlaceGeographyControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .body("$", hasSize(expectedSize))
                     .body("[0].size()", equalTo(expectedFieldSize))
-                    .body("[0].id", equalTo(place.getId().intValue()))
+                    .body("[0].placeId", equalTo(place.getId().intValue()))
                     .body("[0].category", equalTo(place.getCategory().name()))
                     .body("[0].markerCoordinate.size()", equalTo(expectedMarkerFieldSize))
                     .body("[0].markerCoordinate.latitude", equalTo(place.getCoordinate().getLatitude()))

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
@@ -170,7 +170,7 @@ class PlaceGeographyControllerTest {
                     .body("size()", equalTo(expectedFieldSize))
                     .body("$", hasKey("coordinate"))
                     .body("coordinate.size()", equalTo(expectedCoordinateSize))
-                    .body("id", equalTo(place.getId().intValue()))
+                    .body("placeId", equalTo(place.getId().intValue()))
                     .body("coordinate.latitude", equalTo(request.latitude()))
                     .body("coordinate.longitude", equalTo(request.longitude()));
         }

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFavoriteFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFavoriteFixture.java
@@ -5,12 +5,12 @@ import com.daedan.festabook.device.domain.Device;
 public class PlaceFavoriteFixture {
 
     public static PlaceFavorite create(
-            Long id,
+            Long placeFavoriteId,
             Place place,
             Device device
     ) {
         return new PlaceFavorite(
-                id,
+                placeFavoriteId,
                 place,
                 device
         );

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceFixture.java
@@ -19,10 +19,10 @@ public class PlaceFixture {
     }
 
     public static Place create(
-            Long id
+            Long placeId
     ) {
         return new Place(
-                id,
+                placeId,
                 DEFAULT_FESTIVAL,
                 DEFAULT_CATEGORY,
                 DEFAULT_COORDINATE
@@ -65,13 +65,13 @@ public class PlaceFixture {
     }
 
     public static Place create(
-            Long id,
+            Long placeId,
             Festival festival,
             Double latitude,
             Double longitude
     ) {
         return new Place(
-                id,
+                placeId,
                 festival,
                 DEFAULT_CATEGORY,
                 new Coordinate(latitude, longitude)
@@ -90,12 +90,12 @@ public class PlaceFixture {
     }
 
     public static Place createWithNullDefaults(
-            Long id,
+            Long placeId,
             Festival festival,
             PlaceCategory placeCategory
     ) {
         return new Place(
-                id,
+                placeId,
                 festival,
                 placeCategory,
                 null

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceFavoriteServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceFavoriteServiceTest.java
@@ -71,7 +71,7 @@ class PlaceFavoriteServiceTest {
             PlaceFavoriteResponse result = placeFavoriteService.addPlaceFavorite(placeId, request);
 
             // then
-            assertThat(result.id()).isEqualTo(placeFavoriteId);
+            assertThat(result.placeFavoriteId()).isEqualTo(placeFavoriteId);
             then(placeFavoriteJpaRepository).should()
                     .save(any());
         }

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceGeographyServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceGeographyServiceTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceCategory;
 import com.daedan.festabook.place.domain.PlaceCoordinateRequestFixture;
@@ -113,7 +113,7 @@ class PlaceGeographyServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.id()).isEqualTo(placeId);
+                s.assertThat(result.placeId()).isEqualTo(placeId);
                 s.assertThat(result.coordinate().latitude()).isEqualTo(request.latitude());
                 s.assertThat(result.coordinate().longitude()).isEqualTo(request.longitude());
             });

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
@@ -8,10 +8,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
@@ -90,7 +90,7 @@ class PlaceServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.id()).isEqualTo(expectedPlaceId);
+                s.assertThat(result.placeId()).isEqualTo(expectedPlaceId);
                 s.assertThat(result.category()).isEqualTo(expectedPlaceCategory);
 
                 s.assertThat(result.placeImages().responses()).isEmpty();
@@ -214,7 +214,7 @@ class PlaceServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.id()).isEqualTo(expectedPlaceId);
+                s.assertThat(result.placeId()).isEqualTo(expectedPlaceId);
                 s.assertThat(result.category()).isEqualTo(place.getCategory());
 
                 s.assertThat(result.description()).isEqualTo(placeDetail.getDescription());
@@ -246,7 +246,7 @@ class PlaceServiceTest {
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.id()).isEqualTo(expectedPlaceId);
+                s.assertThat(result.placeId()).isEqualTo(expectedPlaceId);
                 s.assertThat(result.category()).isEqualTo(place.getCategory());
 
                 s.assertThat(result.description()).isNull();

--- a/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
@@ -106,10 +106,10 @@ public class QuestionFixture {
     }
 
     public static Question create(
-            Long id
+            Long questionId
     ) {
         return new Question(
-                id,
+                questionId,
                 DEFAULT_FESTIVAL,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
@@ -118,11 +118,11 @@ public class QuestionFixture {
     }
 
     public static Question create(
-            Long id,
+            Long questionId,
             Integer sequence
     ) {
         return new Question(
-                id,
+                questionId,
                 DEFAULT_FESTIVAL,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,

--- a/backend/src/test/java/com/daedan/festabook/question/dto/QuestionSequenceUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/question/dto/QuestionSequenceUpdateRequestFixture.java
@@ -7,11 +7,11 @@ import java.util.stream.IntStream;
 public class QuestionSequenceUpdateRequestFixture {
 
     public static QuestionSequenceUpdateRequest create(
-            Long id,
+            Long questionId,
             Integer sequence
     ) {
         return new QuestionSequenceUpdateRequest(
-                id,
+                questionId,
                 sequence
         );
     }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#381

<br>

## 🛠️ 작업 내용

- DTO 변수명 구체적으로 변경

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 여러 응답 객체의 필드명이 기존의 id에서 보다 명확한 식별자명(예: announcementId, eventDateId, festivalNotificationId, festivalId, placeId, placeFavoriteId, deviceId, eventId 등)으로 변경되었습니다. 이로 인해 API 응답에서 반환되는 JSON 필드명도 함께 변경되었습니다.
  * 이벤트 관련 도메인 및 요청 객체에서 eventDate 필드가 명확히 추가 및 재배치되어 이벤트와 이벤트 날짜 간 관계가 명확해졌습니다.

* **Tests**
  * 테스트 코드 내에서 변경된 식별자명에 맞춰 응답 필드명 검증 로직이 모두 수정되었습니다.
  * 이벤트, 페스티벌, 장소, 디바이스 등 여러 도메인 테스트에서 필드명 변경에 따른 검증 및 Fixture 메서드 파라미터 명칭이 일관되게 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->