### PR TITLE
[FE] 분실물 학생회 페이지 수정 및 API 연결

### DIFF
--- a/frontend/src/contexts/DataProvider.jsx
+++ b/frontend/src/contexts/DataProvider.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { DataContext } from './DataContext';
 import { initialData } from '../data/initialData';
 import { getCurrentDate } from '../utils/date';
-import { scheduleAPI, qnaAPI } from '../utils/api';
+import { scheduleAPI, qnaAPI, lostItemAPI } from '../utils/api';
 
 export const DataProvider = ({ children }) => {
     const [data, setData] = useState(initialData);
@@ -10,6 +10,7 @@ export const DataProvider = ({ children }) => {
     const [isLoadingDates, setIsLoadingDates] = useState(false);
     const [isLoadingEvents, setIsLoadingEvents] = useState(false);
     const [isLoadingQna, setIsLoadingQna] = useState(false);
+    const [isLoadingLostItems, setIsLoadingLostItems] = useState(false);
     
     const fetchEventDates = async () => {
         try {
@@ -28,7 +29,7 @@ export const DataProvider = ({ children }) => {
                 ...prev,
                 schedule: scheduleFromServer
             }));
-        } catch (error) {
+        } catch {
             // 초기 로드 실패 시 빈 배열로 설정
             setEventDates([]);
             setData(prev => ({
@@ -48,7 +49,7 @@ export const DataProvider = ({ children }) => {
                 ...prev,
                 qnaItems: questions
             }));
-        } catch (error) {
+        } catch {
             // 초기 로드 실패 시 빈 배열로 설정
             setData(prev => ({
                 ...prev,
@@ -58,11 +59,31 @@ export const DataProvider = ({ children }) => {
             setIsLoadingQna(false);
         }
     };
+
+    const fetchLostItems = async () => {
+        try {
+            setIsLoadingLostItems(true);
+            const lostItems = await lostItemAPI.getLostItems();
+            setData(prev => ({
+                ...prev,
+                lostItems: lostItems
+            }));
+        } catch {
+            // 초기 로드 실패 시 빈 배열로 설정
+            setData(prev => ({
+                ...prev,
+                lostItems: []
+            }));
+        } finally {
+            setIsLoadingLostItems(false);
+        }
+    };
     
-    // 컴포넌트 마운트 시 축제 날짜 목록과 QnA 조회
+    // 컴포넌트 마운트 시 축제 날짜 목록, QnA, 분실물 조회
     useEffect(() => {
         fetchEventDates();
         fetchQnaItems();
+        fetchLostItems();
     }, []);
 
     const getNextId = (arr) => (arr.length > 0 ? Math.max(...arr.map(item => item.id)) + 1 : 1);
@@ -79,25 +100,86 @@ export const DataProvider = ({ children }) => {
             setData(d => ({ ...d, notices: d.notices.map(n => n.id === id ? { ...n, pinned: !n.pinned } : n)}));
             showToast(notice.pinned ? '공지사항 고정이 해제되었습니다.' : '공지사항이 고정되었습니다.');
         },
-        addLostItem: (item) => setData(d => ({ ...d, lostItems: [{ id: getNextId(d.lostItems), ...item, pickupStatus: 'PENDING', createdAt: new Date().toISOString() }, ...d.lostItems] })),
-        updateLostItem: (id, updated) => setData(d => ({ ...d, lostItems: d.lostItems.map(i => i.id === id ? { ...i, ...updated } : i) })),
-        deleteLostItem: (id) => setData(d => ({ ...d, lostItems: d.lostItems.filter(i => i.id !== id) })),
-        toggleLostItemStatus: (id, showToast) => {
-            let newStatus = '';
-            setData(d => ({ ...d, lostItems: d.lostItems.map(i => {
-                if (i.id === id) { 
-                    newStatus = i.pickupStatus === 'PENDING' ? 'COMPLETED' : 'PENDING'; 
-                    return { ...i, pickupStatus: newStatus }; 
+        // 분실물 등록 (서버 연동) - 전체 재조회 없이 로컬 상태만 갱신
+        addLostItem: async (item, showToast) => {
+            try {
+                const newItem = await lostItemAPI.createLostItem(item);
+                setData(prev => ({
+                    ...prev,
+                    lostItems: [newItem, ...prev.lostItems]
+                }));
+                if (showToast) showToast('분실물이 등록되었습니다.');
+                return newItem;
+            } catch (error) {
+                if (showToast) showToast(error.message || '분실물 등록에 실패했습니다.');
+                throw error;
+            }
+        },
+
+        // 분실물 수정 (서버 연동) - 전체 재조회 없이 해당 항목만 갱신
+        updateLostItem: async (id, updated, showToast) => {
+            try {
+                const result = await lostItemAPI.updateLostItem(id, updated);
+                setData(prev => ({
+                    ...prev,
+                    lostItems: prev.lostItems.map(i =>
+                        i.id === id
+                            ? { ...i, imageUrl: result.imageUrl, storageLocation: result.storageLocation }
+                            : i
+                    )
+                }));
+                if (showToast) showToast('분실물 정보가 수정되었습니다.');
+                return result;
+            } catch (error) {
+                if (showToast) showToast(error.message || '분실물 수정에 실패했습니다.');
+                throw error;
+            }
+        },
+
+        // 분실물 삭제 (서버 연동) - 전체 재조회 없이 로컬에서 제거
+        deleteLostItem: async (id, showToast) => {
+            try {
+                await lostItemAPI.deleteLostItem(id);
+                setData(prev => ({
+                    ...prev,
+                    lostItems: prev.lostItems.filter(i => i.id !== id)
+                }));
+                if (showToast) showToast('분실물이 삭제되었습니다.');
+            } catch (error) {
+                if (showToast) showToast(error.message || '분실물 삭제에 실패했습니다.');
+                throw error;
+            }
+        },
+
+        // 분실물 상태 변경 (서버 연동) - 전체 재조회 없이 해당 항목만 갱신
+        toggleLostItemStatus: async (id, showToast) => {
+            try {
+                const currentItem = data.lostItems.find(item => item.id === id);
+                if (!currentItem) {
+                    if (showToast) showToast('분실물을 찾을 수 없습니다.');
+                    return;
                 }
-                return i;
-            })}));
-            showToast(`상태가 [${newStatus === 'PENDING' ? '보관중' : '수령완료'}]으로 변경되었습니다.`);
+                const newStatus = currentItem.pickupStatus === 'PENDING' ? 'COMPLETED' : 'PENDING';
+                const result = await lostItemAPI.updateLostItemStatus(id, newStatus);
+                setData(prev => ({
+                    ...prev,
+                    lostItems: prev.lostItems.map(i =>
+                        i.id === id ? { ...i, pickupStatus: result.pickupStatus } : i
+                    )
+                }));
+                const statusText = newStatus === 'PENDING' ? '보관중' : '수령완료';
+                if (showToast) showToast(`상태가 [${statusText}]로 변경되었습니다.`);
+                return result;
+            } catch (error) {
+                if (showToast) showToast(error.message || '분실물 상태 변경에 실패했습니다.');
+                throw error;
+            }
         },
         // QnA 관련 액션들 (서버 연동)
         addQnaItem: async (item, showToast) => {
             try {
                 setIsLoadingQna(true);
-                const newQuestions = await qnaAPI.createQuestion(item);
+                await qnaAPI.createQuestion(item);
                 
                 // 서버에서 전체 QnA 목록을 다시 조회하여 최신 상태로 업데이트
                 const questions = await qnaAPI.getQuestions();
@@ -153,7 +235,7 @@ export const DataProvider = ({ children }) => {
         updateQnaSequences: async (sequences, showToast) => {
             try {
                 setIsLoadingQna(true);
-                const updatedSequences = await qnaAPI.updateQuestionSequences(sequences);
+                await qnaAPI.updateQuestionSequences(sequences);
                 // 서버에서 전체 QnA 목록을 다시 조회하여 최신 상태로 업데이트
                 const questions = await qnaAPI.getQuestions();
                 setData(prev => ({
@@ -372,9 +454,11 @@ export const DataProvider = ({ children }) => {
         // 새로운 상태 제공
         fetchEventDates,
         fetchQnaItems,
+        fetchLostItems,
         isLoadingDates,
         isLoadingEvents,
         isLoadingQna,
+        isLoadingLostItems,
         eventDates
     };
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -18,28 +18,153 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// 응답 인터셉터 - 에러 처리
-api.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 400) {
-      // 백엔드에서 제공하는 에러 메시지 사용
-      const message = error.response.data?.message || '잘못된 요청입니다.';
-      throw new Error(message);
+// 축제 관련 API
+export const festivalAPI = {
+  // 축제 정보 조회
+  getFestival: async () => {
+    try {
+      const response = await api.get('/festivals');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch festival:', error);
+      throw new Error('축제 정보 조회에 실패했습니다.');
     }
-    if (error.response?.status === 404) {
-      throw new Error('요청한 리소스를 찾을 수 없습니다.');
+  },
+
+  // 축제 정보 수정
+  updateFestivalInfo: async (festivalInfo) => {
+    try {
+      const response = await api.patch('/festivals/information', festivalInfo);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to update festival info:', error);
+      throw new Error('축제 정보 수정에 실패했습니다.');
     }
-    if (error.response?.status === 500) {
-      throw new Error('서버 내부 오류가 발생했습니다.');
+  },
+
+  // 축제 이미지 추가
+  addFestivalImage: async (imageData) => {
+    try {
+      const response = await api.post('/festivals/images', imageData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to add festival image:', error);
+      throw new Error('축제 이미지 추가에 실패했습니다.');
     }
-    // 네트워크 에러 등
-    if (!error.response) {
-      throw new Error('네트워크 연결을 확인해주세요.');
+  },
+
+  // 축제 이미지 순서 변경
+  updateFestivalImageSequences: async (sequences) => {
+    try {
+      const response = await api.patch('/festivals/images/sequences', sequences);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to update festival image sequences:', error);
+      throw new Error('축제 이미지 순서 변경에 실패했습니다.');
     }
-    throw error;
+  },
+
+  // 축제 이미지 삭제
+  deleteFestivalImage: async (festivalImageId) => {
+    try {
+      await api.delete(`/festivals/images/${festivalImageId}`);
+    } catch (error) {
+      console.error('Failed to delete festival image:', error);
+      throw new Error('축제 이미지 삭제에 실패했습니다.');
+    }
   }
-);
+};
+
+// 공지사항 관련 API
+export const announcementAPI = {
+  // 모든 공지사항 조회
+  getAnnouncements: async () => {
+    try {
+      const response = await api.get('/announcements');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch announcements:', error);
+      throw new Error('공지사항 조회에 실패했습니다.');
+    }
+  },
+
+  // 공지사항 생성
+  createAnnouncement: async (announcementData) => {
+    try {
+      await api.post('/announcements', announcementData);
+    } catch (error) {
+      console.error('Failed to create announcement:', error);
+      throw new Error('공지사항 생성에 실패했습니다.');
+    }
+  },
+
+  // 공지사항 수정
+  updateAnnouncement: async (id, announcementData) => {
+    try {
+      await api.patch(`/announcements/${id}`, announcementData);
+    } catch (error) {
+      console.error('Failed to update announcement:', error);
+      throw new Error('공지사항 수정에 실패했습니다.');
+    }
+  },
+
+  // 공지사항 삭제
+  deleteAnnouncement: async (id) => {
+    try {
+      await api.delete(`/announcements/${id}`);
+    } catch (error) {
+      console.error('Failed to delete announcement:', error);
+      throw new Error('공지사항 삭제에 실패했습니다.');
+    }
+  },
+
+  // 공지사항 고정/해제
+  toggleAnnouncementPin: async (id, pinned) => {
+    try {
+      const response = await api.patch(`/announcements/${id}/pin`, { pinned });
+      return response;
+    } catch (error) {
+      console.error('Failed to toggle announcement pin:', error);
+      throw new Error('공지사항 고정 상태 변경에 실패했습니다.');
+    }
+  }
+};
+
+// 플레이스 관련 API
+export const placeAPI = {
+  // 모든 플레이스 조회
+  getPlaces: async () => {
+    try {
+      const response = await api.get('/places');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch places:', error);
+      throw new Error('플레이스 조회에 실패했습니다.');
+    }
+  },
+
+  // 플레이스 생성
+  createPlace: async (placeData) => {
+    try {
+      const response = await api.post('/places', placeData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to create place:', error);
+      throw new Error('플레이스 생성에 실패했습니다.');
+    }
+  },
+
+  // 플레이스 삭제
+  deletePlace: async (id) => {
+    try {
+      const response = await api.delete(`/places/${id}`);
+      return response;
+    } catch (error) {
+      console.error('Failed to delete place:', error);
+      throw new Error('플레이스 삭제에 실패했습니다.');
+    }
+  }
+};
 
 // 축제 날짜 관련 API
 export const scheduleAPI = {
@@ -112,27 +237,27 @@ export const scheduleAPI = {
     }
   },
 
-  // 일정 수정
-  updateEvent: async (eventId, eventData) => {
-    try {
-      await api.patch(`/event-dates/events/${eventId}`, eventData);
-      // 성공 시 204 응답, body 없음 - 재조회 필요
-    } catch (error) {
-      console.error('Failed to update event:', error);
-      throw new Error('일정 수정에 실패했습니다.');
-    }
-  },
+    // 일정 수정
+    updateEvent: async (eventId, eventData) => {
+        try {
+            await api.patch(`/event-dates/events/${eventId}`, eventData);
+            // 성공 시 204 응답, body 없음 - 재조회 필요
+        } catch (error) {
+            console.error('Failed to update event:', error);
+            throw new Error('일정 수정에 실패했습니다.');
+        }
+    },
 
-  // 일정 삭제
-  deleteEvent: async (eventId) => {
-    try {
-      await api.delete(`/event-dates/events/${eventId}`);
-      // 성공 시 204 응답, body 없음 - 재조회 필요
-    } catch (error) {
-      console.error('Failed to delete event:', error);
-      throw new Error('일정 삭제에 실패했습니다.');
+    // 일정 삭제
+    deleteEvent: async (eventId) => {
+        try {
+            await api.delete(`/event-dates/events/${eventId}`);
+            // 성공 시 204 응답, body 없음 - 재조회 필요
+        } catch (error) {
+            console.error('Failed to delete event:', error);
+            throw new Error('일정 삭제에 실패했습니다.');
+        }
     }
-  }
 };
 
 // QnA 관련 API
@@ -195,83 +320,83 @@ export const qnaAPI = {
 
 // 분실물 관련 API
 export const lostItemAPI = {
-  // 모든 분실물 조회
-  getLostItems: async () => {
-    try {
-      const response = await api.get('/lost-items');
-      // 백엔드 응답을 프론트엔드 형식으로 변환
-      return response.data.map(item => ({
-        id: item.lostItemId,
-        imageUrl: item.imageUrl,
-        storageLocation: item.storageLocation,
-        pickupStatus: item.status,
-        createdAt: item.createdAt
-      }));
-    } catch (error) {
-      console.error('Failed to fetch lost items:', error);
-      throw new Error('분실물 조회에 실패했습니다.');
-    }
-  },
+    // 모든 분실물 조회
+    getLostItems: async () => {
+        try {
+            const response = await api.get('/lost-items');
+            // 백엔드 응답을 프론트엔드 형식으로 변환
+            return response.data.map(item => ({
+                id: item.lostItemId,
+                imageUrl: item.imageUrl,
+                storageLocation: item.storageLocation,
+                pickupStatus: item.pickupStatus,
+                createdAt: item.createdAt
+            }));
+        } catch (error) {
+            console.error('Failed to fetch lost items:', error);
+            throw new Error('분실물 조회에 실패했습니다.');
+        }
+    },
 
-  // 분실물 등록
-  createLostItem: async (lostItemData) => {
-    try {
-      const response = await api.post('/lost-items', lostItemData);
-      // LostItemResponse를 프론트엔드 형식으로 변환
-      return {
-        id: response.data.lostItemId,
-        imageUrl: response.data.imageUrl,
-        storageLocation: response.data.storageLocation,
-        pickupStatus: response.data.status,
-        createdAt: response.data.createdAt
-      };
-    } catch (error) {
-      console.error('Failed to create lost item:', error);
-      throw new Error('분실물 등록에 실패했습니다.');
-    }
-  },
+    // 분실물 등록
+    createLostItem: async (lostItemData) => {
+        try {
+            const response = await api.post('/lost-items', lostItemData);
+            // LostItemResponse를 프론트엔드 형식으로 변환
+            return {
+                id: response.data.lostItemId,
+                imageUrl: response.data.imageUrl,
+                storageLocation: response.data.storageLocation,
+                pickupStatus: response.data.pickupStatus,
+                createdAt: response.data.createdAt
+            };
+        } catch (error) {
+            console.error('Failed to create lost item:', error);
+            throw new Error('분실물 등록에 실패했습니다.');
+        }
+    },
 
-  // 분실물 수정
-  updateLostItem: async (lostItemId, updateData) => {
-    try {
-      const response = await api.patch(`/lost-items/${lostItemId}`, updateData);
-      // LostItemUpdateResponse를 프론트엔드 형식으로 변환
-      return {
-        id: response.data.lostItemId,
-        imageUrl: response.data.imageUrl,
-        storageLocation: response.data.storageLocation
-      };
-    } catch (error) {
-      console.error('Failed to update lost item:', error);
-      throw new Error('분실물 수정에 실패했습니다.');
-    }
-  },
+    // 분실물 수정
+    updateLostItem: async (lostItemId, updateData) => {
+        try {
+            const response = await api.patch(`/lost-items/${lostItemId}`, updateData);
+            // LostItemUpdateResponse를 프론트엔드 형식으로 변환
+            return {
+                id: response.data.lostItemId,
+                imageUrl: response.data.imageUrl,
+                storageLocation: response.data.storageLocation
+            };
+        } catch (error) {
+            console.error('Failed to update lost item:', error);
+            throw new Error('분실물 수정에 실패했습니다.');
+        }
+    },
 
-  // 분실물 삭제  
-  deleteLostItem: async (lostItemId) => {
-    try {
-      await api.delete(`/lost-items/${lostItemId}`);
-      // 204 No Content - 반환값 없음
-    } catch (error) {
-      console.error('Failed to delete lost item:', error);
-      throw new Error('분실물 삭제에 실패했습니다.');
-    }
-  },
+    // 분실물 삭제
+    deleteLostItem: async (lostItemId) => {
+        try {
+            await api.delete(`/lost-items/${lostItemId}`);
+            // 204 No Content - 반환값 없음
+        } catch (error) {
+            console.error('Failed to delete lost item:', error);
+            throw new Error('분실물 삭제에 실패했습니다.');
+        }
+    },
 
-  // 분실물 상태 변경
-  updateLostItemStatus: async (lostItemId, status) => {
-    try {
-      const response = await api.patch(`/lost-items/${lostItemId}/status`, { status });
-      // LostItemStatusUpdateResponse를 프론트엔드 형식으로 변환
-      return {
-        id: response.data.lostItemId,
-        pickupStatus: response.data.status
-      };
-    } catch (error) {
-      console.error('Failed to update lost item status:', error);
-      throw new Error('분실물 상태 변경에 실패했습니다.');
+    // 분실물 상태 변경
+    updateLostItemStatus: async (lostItemId, status) => {
+        try {
+            const response = await api.patch(`/lost-items/${lostItemId}/status`, { pickupStatus : status});
+            // LostItemStatusUpdateResponse를 프론트엔드 형식으로 변환
+            return {
+                id: response.data.lostItemId,
+                pickupStatus: response.data.pickupStatus
+            };
+        } catch (error) {
+            console.error('Failed to update lost item status:', error);
+            throw new Error('분실물 상태 변경에 실패했습니다.');
+        }
     }
-  }
 };
 
 export default api;


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #431 

<br>

## 🛠️ 작업 내용

- 분실물 추가/수정/삭제/토글 기능 추가

<br>

## 📸 이미지 첨부

<img width="811" height="435" alt="스크린샷 2025-08-10 오전 1 00 48" src="https://github.com/user-attachments/assets/aebc065e-c01a-45c0-9a47-d7e6cd2b2371" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 분실물 데이터를 서버와 동기화하여 관리할 수 있도록 개선되었습니다.
  * 분실물 목록을 불러오는 중 로딩 상태와 에러 메시지가 표시됩니다.
  * 분실물 등록, 수정, 삭제, 상태 변경 시 서버와 연동되며, 성공 및 실패 시 알림이 제공됩니다.

* **버그 수정**
  * 서버 요청 중 발생하는 오류를 사용자에게 명확하게 안내하고, 재시도 기능이 추가되었습니다.

* **UI/UX 개선**
  * 분실물 목록 로딩 중 스피너 및 오류 발생 시 재시도 버튼이 표시됩니다.
  * 빈 목록, 로딩 실패 등 다양한 상태에 맞는 안내 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->