### PR TITLE
[BE] 우리 패키지 내에 있는 클래스 빈들만 포함하도록 포인트컷 수정

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
@@ -12,9 +12,10 @@ import org.springframework.stereotype.Component;
 public class LoggingAspect {
 
     @Around("""
-        within(@org.springframework.web.bind.annotation.RestController *) || 
-        within(@org.springframework.stereotype.Service *) ||
-        within(@org.springframework.stereotype.Repository *)) """
+            execution(* com.daedan.festabook..*.*(..)) &&
+            (within(@org.springframework.web.bind.annotation.RestController *) || 
+            within(@org.springframework.stereotype.Service *) ||
+            within(@org.springframework.stereotype.Repository *))) """
     )
     public Object allLayersLogging(ProceedingJoinPoint joinPoint) throws Throwable {
 

--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
@@ -13,14 +13,17 @@ public class LoggingAspect {
 
     @Around("""
             execution(* com.daedan.festabook..*.*(..)) &&
-            (within(@org.springframework.web.bind.annotation.RestController *) || 
-            within(@org.springframework.stereotype.Service *) ||
-            within(@org.springframework.stereotype.Repository *))) """
+            (
+                within(@org.springframework.web.bind.annotation.RestController *) ||
+                within(@org.springframework.stereotype.Service *) ||
+                execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))
+            )
+            """
     )
     public Object allLayersLogging(ProceedingJoinPoint joinPoint) throws Throwable {
 
         log.info("[Method Call] | Class: {} | Method: {} | Args: {}",
-                joinPoint.getSignature().getName(),
+                joinPoint.getSignature().getDeclaringTypeName(),
                 joinPoint.getSignature().getName(),
                 joinPoint.getArgs()
         );


### PR DESCRIPTION
## #️⃣ 이슈 번호

#452 

<br>

## 🛠️ 작업 내용

- AOP를 적용할 빈들을 패키지 내에 있도록 수정
- repository 빈들의 경우에는 구현체가 패키지 내에 있지 않아서 적용되지 않는 문제 해결

<br>

## 🙇🏻 중점 리뷰 요청

- 필터에서 찍는 정보들도 감춰야할지 아닐지 고민됩니다. 의견 남겨주세요

## 이미지
<img width="1614" height="207" alt="image" src="https://github.com/user-attachments/assets/3ca43edd-705d-41d1-8b5f-da15ed888a29" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 리팩터링
  * 로깅 적용 범위를 앱 전반에서 특정 패키지의 주요 컴포넌트로 축소했습니다. 불필요한 호출 로그가 감소해 로그 가독성이 향상되고, 일부 경우 실행 오버헤드가 줄어 응답성이 미세하게 개선될 수 있습니다. 기능 동작이나 외부 API 변경은 없으며, 사전/사후 로그와 실행 시간 측정 로직은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->