### PR TITLE
[BE] Place의 세부 사항 수정 로직 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
@@ -5,6 +5,8 @@ import com.daedan.festabook.place.dto.PlacePreviewResponses;
 import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
+import com.daedan.festabook.place.dto.PlaceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceUpdateResponse;
 import com.daedan.festabook.place.service.PlacePreviewService;
 import com.daedan.festabook.place.service.PlaceService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -43,6 +46,19 @@ public class PlaceController {
             @RequestBody PlaceRequest request
     ) {
         return placeService.createPlace(festivalId, request);
+    }
+
+    @PutMapping("/{placeId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제에 대한 플레이스 세부사항 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public PlaceUpdateResponse updatePlaceByPlaceId(
+            @PathVariable Long placeId,
+            @RequestBody PlaceUpdateRequest request
+    ) {
+        return placeService.updatePlaceByPlaceId(placeId, request);
     }
 
     @GetMapping

--- a/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
@@ -126,6 +126,30 @@ public class Place {
         this.coordinate = coordinate;
     }
 
+    public void update(
+            PlaceCategory category,
+            String title,
+            String description,
+            String location,
+            String host,
+            LocalTime startTime,
+            LocalTime endTime
+    ) {
+        validateTitle(title);
+        validateDescription(description);
+        validateLocation(location);
+        validateHost(host);
+        validateTime(startTime, endTime);
+
+        this.category = category;
+        this.title = title;
+        this.description = description;
+        this.location = location;
+        this.host = host;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
     private void validateTitle(String title) {
         if (title == null) {
             return;

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceCategory;
+import java.time.LocalTime;
+
+public record PlaceUpdateRequest(
+        PlaceCategory placeCategory,
+        String title,
+        String description,
+        String location,
+        String host,
+        LocalTime startTime,
+        LocalTime endTime
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceUpdateResponse.java
@@ -1,0 +1,29 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceCategory;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+
+public record PlaceUpdateResponse(
+        PlaceCategory placeCategory,
+        String title,
+        String description,
+        String location,
+        String host,
+        @JsonFormat(pattern = "HH:mm") LocalTime startTime,
+        @JsonFormat(pattern = "HH:mm") LocalTime endTime
+) {
+
+    public static PlaceUpdateResponse from(Place place) {
+        return new PlaceUpdateResponse(
+                place.getCategory(),
+                place.getTitle(),
+                place.getDescription(),
+                place.getLocation(),
+                place.getHost(),
+                place.getStartTime(),
+                place.getEndTime()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
@@ -9,6 +9,8 @@ import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
+import com.daedan.festabook.place.dto.PlaceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceUpdateResponse;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
@@ -36,6 +38,23 @@ public class PlaceService {
         Place savedPlace = placeJpaRepository.save(notSavedPlace);
 
         return PlaceResponse.from(savedPlace);
+    }
+
+    @Transactional
+    public PlaceUpdateResponse updatePlaceByPlaceId(Long placeId, PlaceUpdateRequest request) {
+        Place place = getPlaceById(placeId);
+
+        place.update(
+                request.placeCategory(),
+                request.title(),
+                request.description(),
+                request.location(),
+                request.host(),
+                request.startTime(),
+                request.endTime()
+        );
+
+        return PlaceUpdateResponse.from(place);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceControllerTest.java
@@ -24,6 +24,8 @@ import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.domain.PlaceImageFixture;
 import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceRequestFixture;
+import com.daedan.festabook.place.dto.PlaceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceUpdateRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
@@ -110,6 +112,41 @@ class PlaceControllerTest {
                     .body("location", nullValue())
                     .body("host", nullValue())
                     .body("description", nullValue());
+        }
+    }
+
+    @Nested
+    class updatePlaceByPlaceId {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceUpdateRequest placeUpdateRequest = PlaceUpdateRequestFixture.create();
+
+            int expectedFieldSize = 7;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(placeUpdateRequest)
+                    .put("/places/{placeId}", place.getId())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("placeCategory", equalTo(placeUpdateRequest.placeCategory().name()))
+                    .body("title", equalTo(placeUpdateRequest.title()))
+                    .body("description", equalTo(placeUpdateRequest.description()))
+                    .body("location", equalTo(placeUpdateRequest.location()))
+                    .body("host", equalTo(placeUpdateRequest.host()))
+                    .body("startTime", equalTo(placeUpdateRequest.startTime().toString()))
+                    .body("endTime", equalTo(placeUpdateRequest.endTime().toString()));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
@@ -3,6 +3,7 @@ package com.daedan.festabook.place.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.daedan.festabook.festival.domain.Coordinate;
 import com.daedan.festabook.festival.domain.CoordinateFixture;
@@ -299,6 +300,196 @@ class PlaceTest {
 
             // then
             assertThat(result).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class update {
+
+        @Test
+        void 성공() {
+            // given
+            PlaceCategory placeCategory = PlaceCategory.FOOD_TRUCK;
+            String title = "수정된 이름";
+            String description = "수정된 설명";
+            String location = "수정된 위치";
+            String host = "수정된 호스트";
+            LocalTime startTime = LocalTime.of(9, 10);
+            LocalTime endTime = LocalTime.of(23, 14);
+
+            Place place = PlaceFixture.create();
+
+            // when
+            place.update(
+                    placeCategory,
+                    title,
+                    description,
+                    location,
+                    host,
+                    startTime,
+                    endTime
+            );
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(place.getCategory()).isEqualTo(placeCategory);
+                s.assertThat(place.getTitle()).isEqualTo(title);
+                s.assertThat(place.getDescription()).isEqualTo(description);
+                s.assertThat(place.getLocation()).isEqualTo(location);
+                s.assertThat(place.getHost()).isEqualTo(host);
+                s.assertThat(place.getStartTime()).isEqualTo(startTime);
+                s.assertThat(place.getEndTime()).isEqualTo(endTime);
+            });
+        }
+
+        @Test
+        void 예외_제목() {
+            // given
+            PlaceCategory placeCategory = PlaceCategory.FOOD_TRUCK;
+            String description = "수정된 설명";
+            String location = "수정된 위치";
+            String host = "수정된 호스트";
+            LocalTime startTime = LocalTime.of(9, 10);
+            LocalTime endTime = LocalTime.of(23, 14);
+
+            Place place = PlaceFixture.create();
+
+            String longTitle = "m".repeat(21);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                place.update(
+                        placeCategory,
+                        longTitle,
+                        description,
+                        location,
+                        host,
+                        startTime,
+                        endTime
+                );
+            })
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("초과할 수 없습니다.");
+        }
+
+        @Test
+        void 예외_설명() {
+            // given
+            PlaceCategory placeCategory = PlaceCategory.FOOD_TRUCK;
+            String title = "수정된 이름";
+            String location = "수정된 위치";
+            String host = "수정된 호스트";
+            LocalTime startTime = LocalTime.of(9, 10);
+            LocalTime endTime = LocalTime.of(23, 14);
+
+            Place place = PlaceFixture.create();
+
+            String longDescription = "m".repeat(101);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                place.update(
+                        placeCategory,
+                        title,
+                        longDescription,
+                        location,
+                        host,
+                        startTime,
+                        endTime
+                );
+            })
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("초과할 수 없습니다.");
+        }
+
+        @Test
+        void 예외_위치() {
+            // given
+            PlaceCategory placeCategory = PlaceCategory.FOOD_TRUCK;
+            String title = "수정된 이름";
+            String description = "수정된 설명";
+            String host = "수정된 호스트";
+            LocalTime startTime = LocalTime.of(9, 10);
+            LocalTime endTime = LocalTime.of(23, 14);
+
+            Place place = PlaceFixture.create();
+
+            String longLocation = "m".repeat(101);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                place.update(
+                        placeCategory,
+                        title,
+                        description,
+                        longLocation,
+                        host,
+                        startTime,
+                        endTime
+                );
+            })
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("초과할 수 없습니다.");
+        }
+
+        @Test
+        void 예외_호스트() {
+            // given
+            PlaceCategory placeCategory = PlaceCategory.FOOD_TRUCK;
+            String title = "수정된 이름";
+            String description = "수정된 설명";
+            String location = "수정된 위치";
+            LocalTime startTime = LocalTime.of(9, 10);
+            LocalTime endTime = LocalTime.of(23, 14);
+
+            Place place = PlaceFixture.create();
+
+            String longHost = "m".repeat(101);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                place.update(
+                        placeCategory,
+                        title,
+                        description,
+                        location,
+                        longHost,
+                        startTime,
+                        endTime
+                );
+            })
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("초과할 수 없습니다.");
+        }
+
+        @Test
+        void 예외_시간() {
+            // given
+            PlaceCategory placeCategory = PlaceCategory.FOOD_TRUCK;
+            String title = "수정된 이름";
+            String description = "수정된 설명";
+            String location = "수정된 위치";
+            String host = "수정된 호스트";
+            LocalTime startTime = LocalTime.of(9, 10);
+
+            Place place = PlaceFixture.create();
+
+            LocalTime emptyTime = null;
+
+            // when & then
+            assertThatThrownBy(() -> {
+                place.update(
+                        placeCategory,
+                        title,
+                        description,
+                        location,
+                        host,
+                        startTime,
+                        emptyTime
+                );
+            })
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("플레이스의 시작 날짜, 종료 날짜는 모두 비어 있거나 모두 입력되어야 합니다.");
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceUpdateRequestFixture.java
@@ -1,0 +1,49 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceCategory;
+import java.time.LocalTime;
+
+public class PlaceUpdateRequestFixture {
+
+    private static final PlaceCategory DEFAULT_CATEGORY = PlaceCategory.FOOD_TRUCK;
+    private static final String DEFAULT_TITLE = "수정된 이름";
+    private static final String DEFAULT_DESCRIPTION = "수정된 설명";
+    private static final String DEFAULT_LOCATION = "수정된 위치";
+    private static final String DEFAULT_HOST = "수정된 호스트";
+    private static final LocalTime DEFAULT_START_TIME = LocalTime.of(14, 12);
+    private static final LocalTime DEFAULT_END_TIME = LocalTime.of(14, 39);
+
+    public static PlaceUpdateRequest create(
+
+    ) {
+        return new PlaceUpdateRequest(
+                DEFAULT_CATEGORY,
+                DEFAULT_TITLE,
+                DEFAULT_DESCRIPTION,
+                DEFAULT_LOCATION,
+                DEFAULT_HOST,
+                DEFAULT_START_TIME,
+                DEFAULT_END_TIME
+        );
+    }
+
+    public static PlaceUpdateRequest create(
+            PlaceCategory placeCategory,
+            String title,
+            String description,
+            String location,
+            String host,
+            LocalTime startTime,
+            LocalTime endTime
+    ) {
+        return new PlaceUpdateRequest(
+                placeCategory,
+                title,
+                description,
+                location,
+                host,
+                startTime,
+                endTime
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
@@ -23,10 +23,14 @@ import com.daedan.festabook.place.dto.PlaceRequest;
 import com.daedan.festabook.place.dto.PlaceRequestFixture;
 import com.daedan.festabook.place.dto.PlaceResponse;
 import com.daedan.festabook.place.dto.PlaceResponses;
+import com.daedan.festabook.place.dto.PlaceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceUpdateRequestFixture;
+import com.daedan.festabook.place.dto.PlaceUpdateResponse;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceFavoriteJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -116,6 +120,44 @@ class PlaceServiceTest {
 
             then(placeJpaRepository).should(never())
                     .save(any());
+        }
+    }
+
+    @Nested
+    class updatePlaceByPlaceId {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeId = 1L;
+            PlaceUpdateRequest request = PlaceUpdateRequestFixture.create(
+                    PlaceCategory.BAR,
+                    "수정된 플레이스 이름",
+                    "수정된 플레이스 설명",
+                    "수정된 위치",
+                    "수정된 호스트",
+                    LocalTime.of(12, 00),
+                    LocalTime.of(13, 00)
+            );
+
+            Place place = PlaceFixture.create(placeId);
+
+            given(placeJpaRepository.findById(placeId))
+                    .willReturn(Optional.of(place));
+
+            // when
+            PlaceUpdateResponse result = placeService.updatePlaceByPlaceId(placeId, request);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.placeCategory()).isEqualTo(request.placeCategory());
+                s.assertThat(result.title()).isEqualTo(request.title());
+                s.assertThat(result.description()).isEqualTo(request.description());
+                s.assertThat(result.location()).isEqualTo(request.location());
+                s.assertThat(result.host()).isEqualTo(request.host());
+                s.assertThat(result.startTime()).isEqualTo(request.startTime());
+                s.assertThat(result.endTime()).isEqualTo(request.endTime());
+            });
         }
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#462 

<br>

## 🛠️ 작업 내용

- 플레이스 세부 사항 수정 기능을 추가하였습니다.
- 특정 id에 해당하는 플레이스의 아래 정보를 수정합니다.
    - category, title, description, location, host, startTime, endTime

<br>

## 📸 이미지 첨부 (Optional)

<img width="1160" height="834" alt="image" src="https://github.com/user-attachments/assets/65784000-2acb-455b-b9ed-cf38b95c167e" />

