### PR TITLE
[BE] 일정 post, update API의 Request, Response DTO 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
@@ -1,7 +1,10 @@
 package com.daedan.festabook.event.controller;
 
 import com.daedan.festabook.event.dto.EventRequest;
+import com.daedan.festabook.event.dto.EventResponse;
 import com.daedan.festabook.event.dto.EventResponses;
+import com.daedan.festabook.event.dto.EventUpdateRequest;
+import com.daedan.festabook.event.dto.EventUpdateResponse;
 import com.daedan.festabook.event.service.EventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,23 +36,23 @@ public class EventController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true)
     })
-    public void createEvent(
+    public EventResponse createEvent(
             @RequestBody EventRequest request
     ) {
-        eventService.createEvent(request);
+        return eventService.createEvent(request);
     }
 
     @PatchMapping("/events/{eventId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "일정 수정")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", useReturnTypeSchema = true)
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     })
-    public void updateEvent(
+    public EventUpdateResponse updateEvent(
             @PathVariable Long eventId,
-            @RequestBody EventRequest request
+            @RequestBody EventUpdateRequest request
     ) {
-        eventService.updateEvent(eventId, request);
+        return eventService.updateEvent(eventId, request);
     }
 
     @DeleteMapping("/events/{eventId}")

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
@@ -1,7 +1,9 @@
 package com.daedan.festabook.event.controller;
 
 import com.daedan.festabook.event.dto.EventDateRequest;
+import com.daedan.festabook.event.dto.EventDateResponse;
 import com.daedan.festabook.event.dto.EventDateResponses;
+import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.service.EventDateService;
 import com.daedan.festabook.global.argumentresolver.FestivalId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,11 +37,11 @@ public class EventDateController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true)
     })
-    public void createEventDate(
+    public EventDateResponse createEventDate(
             @Parameter(hidden = true) @FestivalId Long festivalId,
             @RequestBody EventDateRequest request
     ) {
-        eventDateService.createEventDate(festivalId, request);
+        return eventDateService.createEventDate(festivalId, request);
     }
 
     @PatchMapping("/{eventDateId}")
@@ -48,11 +50,12 @@ public class EventDateController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true)
     })
-    public void updateEventDate(
+    public EventDateUpdateResponse updateEventDate(
+            @Parameter(hidden = true) @FestivalId Long festivalId,
             @PathVariable Long eventDateId,
             @RequestBody EventDateRequest request
     ) {
-        eventDateService.updateEventDate(eventDateId, request);
+        return eventDateService.updateEventDate(festivalId, eventDateId, request);
     }
 
     @DeleteMapping("/{eventDateId}")

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
@@ -3,6 +3,7 @@ package com.daedan.festabook.event.controller;
 import com.daedan.festabook.event.dto.EventDateRequest;
 import com.daedan.festabook.event.dto.EventDateResponse;
 import com.daedan.festabook.event.dto.EventDateResponses;
+import com.daedan.festabook.event.dto.EventDateUpdateRequest;
 import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.service.EventDateService;
 import com.daedan.festabook.global.argumentresolver.FestivalId;
@@ -53,7 +54,7 @@ public class EventDateController {
     public EventDateUpdateResponse updateEventDate(
             @Parameter(hidden = true) @FestivalId Long festivalId,
             @PathVariable Long eventDateId,
-            @RequestBody EventDateRequest request
+            @RequestBody EventDateUpdateRequest request
     ) {
         return eventDateService.updateEventDate(festivalId, eventDateId, request);
     }

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
@@ -45,10 +45,10 @@ public class EventDateController {
     }
 
     @PatchMapping("/{eventDateId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "일정 수정")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", useReturnTypeSchema = true)
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     })
     public EventDateUpdateResponse updateEventDate(
             @Parameter(hidden = true) @FestivalId Long festivalId,

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventDateUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventDateUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.daedan.festabook.event.dto;
+
+import com.daedan.festabook.event.domain.EventDate;
+import com.daedan.festabook.festival.domain.Festival;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record EventDateUpdateRequest(
+
+        @Schema(description = "일정 날짜", example = "2025-07-18")
+        LocalDate date
+) {
+
+    public EventDate toEntity(Festival festival) {
+        return new EventDate(
+                festival,
+                date
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventDateUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventDateUpdateRequest.java
@@ -1,7 +1,5 @@
 package com.daedan.festabook.event.dto;
 
-import com.daedan.festabook.event.domain.EventDate;
-import com.daedan.festabook.festival.domain.Festival;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
@@ -10,11 +8,4 @@ public record EventDateUpdateRequest(
         @Schema(description = "일정 날짜", example = "2025-07-18")
         LocalDate date
 ) {
-
-    public EventDate toEntity(Festival festival) {
-        return new EventDate(
-                festival,
-                date
-        );
-    }
 }

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventDateUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventDateUpdateResponse.java
@@ -1,0 +1,17 @@
+package com.daedan.festabook.event.dto;
+
+import com.daedan.festabook.event.domain.EventDate;
+import java.time.LocalDate;
+
+public record EventDateUpdateResponse(
+        Long eventDateId,
+        LocalDate date
+) {
+
+    public static EventDateUpdateResponse from(EventDate eventDate) {
+        return new EventDateUpdateResponse(
+                eventDate.getId(),
+                eventDate.getDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.daedan.festabook.event.dto;
+
+import com.daedan.festabook.event.domain.Event;
+import com.daedan.festabook.event.domain.EventDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+
+public record EventUpdateRequest(
+
+        @Schema(description = "일정 날짜 ID", example = "1")
+        Long eventDateId,
+
+        @Schema(description = "일정 시작 시간", example = "01:00")
+        LocalTime startTime,
+
+        @Schema(description = "일정 종료 시간", example = "02:00")
+        LocalTime endTime,
+
+        @Schema(description = "일정 제목", example = "미소가 알려주는 고급 알고리즘 컨퍼런스")
+        String title,
+
+        @Schema(description = "일정 진행 위치", example = "알고리즘 밸리 정문")
+        String location
+) {
+
+    public Event toEntity(EventDate eventDate) {
+        return new Event(
+                eventDate,
+                startTime,
+                endTime,
+                title,
+                location
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/event/dto/EventUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/event/dto/EventUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.daedan.festabook.event.dto;
+
+import com.daedan.festabook.event.domain.Event;
+import com.daedan.festabook.event.domain.EventStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Clock;
+import java.time.LocalTime;
+
+public record EventUpdateResponse(
+        Long eventId,
+        EventStatus status,
+        @JsonFormat(pattern = "HH:mm") LocalTime startTime,
+        @JsonFormat(pattern = "HH:mm") LocalTime endTime,
+        String title,
+        String location
+) {
+
+    public static EventUpdateResponse from(Event event, Clock clock) {
+        return new EventUpdateResponse(
+                event.getId(),
+                event.determineStatus(clock),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getTitle(),
+                event.getLocation()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/event/service/EventDateService.java
+++ b/backend/src/main/java/com/daedan/festabook/event/service/EventDateService.java
@@ -4,6 +4,7 @@ import com.daedan.festabook.event.domain.EventDate;
 import com.daedan.festabook.event.dto.EventDateRequest;
 import com.daedan.festabook.event.dto.EventDateResponse;
 import com.daedan.festabook.event.dto.EventDateResponses;
+import com.daedan.festabook.event.dto.EventDateUpdateRequest;
 import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
@@ -37,7 +38,7 @@ public class EventDateService {
     }
 
     @Transactional
-    public EventDateUpdateResponse updateEventDate(Long festivalId, Long eventDateId, EventDateRequest request) {
+    public EventDateUpdateResponse updateEventDate(Long festivalId, Long eventDateId, EventDateUpdateRequest request) {
         validateDuplicatedEventDate(festivalId, request.date());
 
         EventDate eventDate = getEventDateById(eventDateId);

--- a/backend/src/main/java/com/daedan/festabook/event/service/EventDateService.java
+++ b/backend/src/main/java/com/daedan/festabook/event/service/EventDateService.java
@@ -4,11 +4,12 @@ import com.daedan.festabook.event.domain.EventDate;
 import com.daedan.festabook.event.dto.EventDateRequest;
 import com.daedan.festabook.event.dto.EventDateResponse;
 import com.daedan.festabook.event.dto.EventDateResponses;
+import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +37,13 @@ public class EventDateService {
     }
 
     @Transactional
-    public void updateEventDate(Long eventDateId, EventDateRequest request) {
+    public EventDateUpdateResponse updateEventDate(Long festivalId, Long eventDateId, EventDateRequest request) {
+        validateDuplicatedEventDate(festivalId, request.date());
+
         EventDate eventDate = getEventDateById(eventDateId);
         eventDate.updateDate(request.date());
+
+        return EventDateUpdateResponse.from(eventDate);
     }
 
     @Transactional

--- a/backend/src/main/java/com/daedan/festabook/event/service/EventService.java
+++ b/backend/src/main/java/com/daedan/festabook/event/service/EventService.java
@@ -5,6 +5,8 @@ import com.daedan.festabook.event.domain.EventDate;
 import com.daedan.festabook.event.dto.EventRequest;
 import com.daedan.festabook.event.dto.EventResponse;
 import com.daedan.festabook.event.dto.EventResponses;
+import com.daedan.festabook.event.dto.EventUpdateRequest;
+import com.daedan.festabook.event.dto.EventUpdateResponse;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
@@ -33,13 +35,13 @@ public class EventService {
     }
 
     @Transactional
-    public EventResponse updateEvent(Long eventId, EventRequest request) {
+    public EventUpdateResponse updateEvent(Long eventId, EventUpdateRequest request) {
         Event event = getEventById(eventId);
 
         Event newEvent = request.toEntity(event.getEventDate());
         event.updateEvent(newEvent);
 
-        return EventResponse.from(event, clock);
+        return EventUpdateResponse.from(event, clock);
     }
 
     public void deleteEventByEventId(Long eventId) {

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
@@ -127,6 +127,8 @@ class EventDateControllerTest {
 
             EventDateRequest request = EventDateRequestFixture.create(eventDate.getDate().plusDays(1));
 
+            int expectedSize = 2;
+
             // when & then
             RestAssured
                     .given()
@@ -136,7 +138,10 @@ class EventDateControllerTest {
                     .when()
                     .patch("/event-dates/{eventDateId}", eventDate.getId())
                     .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedSize))
+                    .body("eventDateId", equalTo(eventDate.getId().intValue()))
+                    .body("date", equalTo(request.date().toString()));
 
             assertSoftly(s -> {
                 EventDate updatedEventDate = eventDateJpaRepository.findById(eventDate.getId()).orElseThrow();

--- a/backend/src/test/java/com/daedan/festabook/event/domain/EventDateFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/domain/EventDateFixture.java
@@ -22,6 +22,17 @@ public class EventDateFixture {
         );
     }
 
+    public static EventDate create(
+            Long eventDateId,
+            Festival festival
+    ) {
+        return new EventDate(
+                eventDateId,
+                festival,
+                DEFAULT_DATE
+        );
+    }
+
     public static EventDate create() {
         return new EventDate(
                 DEFAULT_FESTIVAL,

--- a/backend/src/test/java/com/daedan/festabook/event/dto/EventDateUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/dto/EventDateUpdateRequestFixture.java
@@ -1,0 +1,22 @@
+package com.daedan.festabook.event.dto;
+
+import java.time.LocalDate;
+
+public class EventDateUpdateRequestFixture {
+
+    private final static LocalDate DEFAULT_DATE = LocalDate.of(2025, 7, 18);
+
+    public static EventDateUpdateRequest create(
+            LocalDate date
+    ) {
+        return new EventDateUpdateRequest(
+                date
+        );
+    }
+
+    public static EventDateUpdateRequest create() {
+        return new EventDateUpdateRequest(
+                DEFAULT_DATE
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/event/dto/EventUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/dto/EventUpdateRequestFixture.java
@@ -1,0 +1,38 @@
+package com.daedan.festabook.event.dto;
+
+import java.time.LocalTime;
+
+public class EventUpdateRequestFixture {
+
+    private final static LocalTime DEFAULT_START_TIME = LocalTime.of(1, 0);
+    private final static LocalTime DEFAULT_END_TIME = LocalTime.of(2, 0);
+    private final static String DEFAULT_TITLE = "title";
+    private final static String DEFAULT_LOCATION = "location";
+    private final static Long DEFAULT_EVENT_DATE_ID = 1L;
+
+    public static EventUpdateRequest create(
+            Long eventDateId,
+            LocalTime startTime,
+            LocalTime endTime,
+            String title,
+            String location
+    ) {
+        return new EventUpdateRequest(
+                eventDateId,
+                startTime,
+                endTime,
+                title,
+                location
+        );
+    }
+
+    public static EventUpdateRequest create() {
+        return new EventUpdateRequest(
+                DEFAULT_EVENT_DATE_ID,
+                DEFAULT_START_TIME,
+                DEFAULT_END_TIME,
+                DEFAULT_TITLE,
+                DEFAULT_LOCATION
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/event/dto/EventUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/dto/EventUpdateRequestFixture.java
@@ -4,11 +4,11 @@ import java.time.LocalTime;
 
 public class EventUpdateRequestFixture {
 
+    private final static Long DEFAULT_EVENT_DATE_ID = 1L;
     private final static LocalTime DEFAULT_START_TIME = LocalTime.of(1, 0);
     private final static LocalTime DEFAULT_END_TIME = LocalTime.of(2, 0);
     private final static String DEFAULT_TITLE = "title";
     private final static String DEFAULT_LOCATION = "location";
-    private final static Long DEFAULT_EVENT_DATE_ID = 1L;
 
     public static EventUpdateRequest create(
             Long eventDateId,

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
@@ -13,6 +13,8 @@ import com.daedan.festabook.event.dto.EventDateRequest;
 import com.daedan.festabook.event.dto.EventDateRequestFixture;
 import com.daedan.festabook.event.dto.EventDateResponse;
 import com.daedan.festabook.event.dto.EventDateResponses;
+import com.daedan.festabook.event.dto.EventDateUpdateRequest;
+import com.daedan.festabook.event.dto.EventDateUpdateRequestFixture;
 import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
@@ -113,7 +115,7 @@ class EventDateServiceTest {
             EventDate eventDate = EventDateFixture.create(eventDateId, festival);
             given(eventDateJpaRepository.findById(eventDateId))
                     .willReturn(Optional.of(eventDate));
-            EventDateRequest request = EventDateRequestFixture.create(eventDate.getDate().plusDays(1));
+            EventDateUpdateRequest request = EventDateUpdateRequestFixture.create(eventDate.getDate().plusDays(1));
 
             // when
             EventDateUpdateResponse result = eventDateService.updateEventDate(
@@ -133,7 +135,7 @@ class EventDateServiceTest {
         void 예외_이미_존재하는_일정_날짜() {
             // given
             Long eventDateId = 1L;
-            EventDateRequest request = EventDateRequestFixture.create();
+            EventDateUpdateRequest request = EventDateUpdateRequestFixture.create();
             given(eventDateJpaRepository.existsByFestivalIdAndDate(DEFAULT_FESTIVAL_ID, request.date()))
                     .willReturn(true);
 

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
@@ -13,6 +13,7 @@ import com.daedan.festabook.event.dto.EventDateRequest;
 import com.daedan.festabook.event.dto.EventDateRequestFixture;
 import com.daedan.festabook.event.dto.EventDateResponse;
 import com.daedan.festabook.event.dto.EventDateResponses;
+import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
@@ -108,16 +109,38 @@ class EventDateServiceTest {
         void 성공() {
             // given
             Long eventDateId = 1L;
-            EventDateRequest request = EventDateRequestFixture.create();
-            EventDate eventDate = EventDateFixture.create(request.date());
+            Festival festival = FestivalFixture.create(DEFAULT_FESTIVAL_ID);
+            EventDate eventDate = EventDateFixture.create(eventDateId, festival);
             given(eventDateJpaRepository.findById(eventDateId))
                     .willReturn(Optional.of(eventDate));
+            EventDateRequest request = EventDateRequestFixture.create(eventDate.getDate().plusDays(1));
 
             // when
-            eventDateService.updateEventDate(eventDateId, request);
+            EventDateUpdateResponse result = eventDateService.updateEventDate(
+                    DEFAULT_FESTIVAL_ID,
+                    eventDateId,
+                    request
+            );
 
             // then
-            assertThat(eventDate.getDate()).isEqualTo(request.date());
+            assertSoftly(s -> {
+                s.assertThat(result.eventDateId()).isEqualTo(eventDate.getId());
+                s.assertThat(result.date()).isEqualTo(request.date());
+            });
+        }
+
+        @Test
+        void 예외_이미_존재하는_일정_날짜() {
+            // given
+            Long eventDateId = 1L;
+            EventDateRequest request = EventDateRequestFixture.create();
+            given(eventDateJpaRepository.existsByFestivalIdAndDate(DEFAULT_FESTIVAL_ID, request.date()))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> eventDateService.updateEventDate(DEFAULT_FESTIVAL_ID, eventDateId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("이미 존재하는 일정 날짜입니다.");
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventServiceTest.java
@@ -16,6 +16,9 @@ import com.daedan.festabook.event.dto.EventRequest;
 import com.daedan.festabook.event.dto.EventRequestFixture;
 import com.daedan.festabook.event.dto.EventResponse;
 import com.daedan.festabook.event.dto.EventResponses;
+import com.daedan.festabook.event.dto.EventUpdateRequest;
+import com.daedan.festabook.event.dto.EventUpdateRequestFixture;
+import com.daedan.festabook.event.dto.EventUpdateResponse;
 import com.daedan.festabook.event.infrastructure.EventDateJpaRepository;
 import com.daedan.festabook.event.infrastructure.EventJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
@@ -137,7 +140,7 @@ class EventServiceTest {
                     eventDate
             );
 
-            EventRequest eventRequest = EventRequestFixture.create(
+            EventUpdateRequest eventUpdateRequest = EventUpdateRequestFixture.create(
                     eventDateId,
                     updatedEvent.getStartTime(),
                     updatedEvent.getEndTime(),
@@ -146,7 +149,7 @@ class EventServiceTest {
             );
 
             // when
-            EventResponse result = eventService.updateEvent(eventId, eventRequest);
+            EventUpdateResponse result = eventService.updateEvent(eventId, eventUpdateRequest);
 
             // then
             assertSoftly(s -> {
@@ -161,7 +164,7 @@ class EventServiceTest {
         void 예외_존재하지_않는_이벤트() {
             // given
             Long eventId = 1L;
-            EventRequest request = EventRequestFixture.create();
+            EventUpdateRequest request = EventUpdateRequestFixture.create();
 
             given(eventJpaRepository.findById(eventId))
                     .willReturn(Optional.empty());


### PR DESCRIPTION
## #️⃣ 이슈 번호

#406 

<br>

## 🛠️ 작업 내용

- update EventDate 수정할 날짜 중복 시 예외 발생 처리
- post, update API의 Request DTO 추가
- post, update API의 Response DTO 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 이벤트/일정 생성·수정 시 응답 본문을 반환합니다. 응답에는 ID, 상태, 시작/종료 시간(HH:mm), 제목, 장소, 날짜 등이 포함됩니다.
  - 수정 API의 요청/응답 형식이 명확히 분리되어 더 일관된 필드 구조와 200 OK 응답을 제공합니다.
- **Bug Fixes**
  - 동일 축제 내 중복 일정 날짜 검증을 추가하여 중복 시 400 BAD_REQUEST와 명확한 오류 메시지를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->