### PR TITLE
[BE] 플레이스 이미지 생성 api 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,0 +1,14 @@
+package com.daedan.festabook.place.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/places/{placeId}/images")
+@Tag(name = "플레이스", description = "플레이스 관련 API")
+public class PlaceImageController {
+
+}

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/places/{placeId}/images")
+@RequestMapping("/places")
 @Tag(name = "플레이스 이미지", description = "플레이스 이미지 관련 API")
 public class PlaceImageController {
 
     private final PlaceImageService placeImageService;
 
-    @PostMapping
+    @PostMapping("/{placeId}/images")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "특정 축제에 대한 플레이스의 이미지 생성")
     @ApiResponses(value = {

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/places/{placeId}/images")
-@Tag(name = "플레이스", description = "플레이스 이미지 관련 API")
+@Tag(name = "플레이스 이미지", description = "플레이스 이미지 관련 API")
 public class PlaceImageController {
 
     private final PlaceImageService placeImageService;

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,14 +1,39 @@
 package com.daedan.festabook.place.controller;
 
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageResponse;
+import com.daedan.festabook.place.service.PlaceImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/places/{placeId}/images")
-@Tag(name = "플레이스", description = "플레이스 관련 API")
+@Tag(name = "플레이스", description = "플레이스 이미지 관련 API")
 public class PlaceImageController {
 
+    private final PlaceImageService placeImageService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "특정 축제에 대한 플레이스의 이미지 생성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+    })
+    public PlaceImageResponse addPlaceImage(
+            @PathVariable Long placeId,
+            @RequestBody PlaceImageRequest request
+    ) {
+        return placeImageService.addPlaceImage(placeId, request);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
@@ -31,14 +31,29 @@ public class PlaceImage {
     @Column(nullable = false)
     private Integer sequence;
 
+    protected PlaceImage(
+            Long id,
+            Place place,
+            String imageUrl,
+            Integer sequence
+    ) {
+        this.id = id;
+        this.place = place;
+        this.imageUrl = imageUrl;
+        this.sequence = sequence;
+    }
+
     // TODO PlaceImage 최대 5개 검증 로직 구현
     public PlaceImage(
             Place place,
             String imageUrl,
             Integer sequence
     ) {
-        this.place = place;
-        this.imageUrl = imageUrl;
-        this.sequence = sequence;
+        this(
+                null,
+                place,
+                imageUrl,
+                sequence
+        );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
@@ -43,7 +43,6 @@ public class PlaceImage {
         this.sequence = sequence;
     }
 
-    // TODO PlaceImage 최대 5개 검증 로직 구현
     public PlaceImage(
             Place place,
             String imageUrl,

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record PlaceImageRequest(
 
-        @Schema(description = "플레이스 좌표 위도", example = "https://festabook.net/image/poster.jpg")
+        @Schema(description = "플레이스 이미지 url", example = "https://festabook.net/image/poster.jpg")
         String imageUrl
 ) {
 }

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageRequest.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceImageRequest(
+
+        @Schema(description = "플레이스 좌표 위도", example = "https://festabook.net/image/poster.jpg")
+        String imageUrl
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
@@ -3,13 +3,19 @@ package com.daedan.festabook.place.infrastructure;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceImage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlaceImageJpaRepository extends JpaRepository<PlaceImage, Long> {
 
     List<PlaceImage> findAllByPlaceIdOrderBySequenceAsc(Long placeId);
 
     List<PlaceImage> findAllByPlaceInAndSequence(List<Place> places, int sequence);
+
+    @Query("SELECT MAX(p.sequence) FROM PlaceImage p WHERE p.place = :place")
+    Optional<Integer> findMaxSequenceByPlace(@Param("place") Place place);
 
     void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -1,0 +1,22 @@
+package com.daedan.festabook.place.service;
+
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceImageService {
+
+    private final PlaceJpaRepository placeJpaRepository;
+    private final PlaceImageJpaRepository placeImageJpaRepository;
+
+    private Place getPlaceById(Long placeId) {
+        return placeJpaRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -2,18 +2,49 @@ package com.daedan.festabook.place.service;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageResponse;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceImageService {
 
+    private static final int MAX_IMAGE_SEQUENCE = 5;
+
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceImageJpaRepository placeImageJpaRepository;
+
+    // TODO: sequence 동시성 해결
+    @Transactional
+    public PlaceImageResponse addPlaceImage(Long placeId, PlaceImageRequest request) {
+        Place place = getPlaceById(placeId);
+
+        int currentMaxSequence = placeImageJpaRepository.findMaxSequenceByPlace(place)
+                .orElseGet(() -> 0);
+        Integer newSequence = currentMaxSequence + 1;
+        validateMaxImageSequence(newSequence);
+
+        PlaceImage placeImage = new PlaceImage(place, request.imageUrl(), newSequence);
+        PlaceImage savedPlaceImage = placeImageJpaRepository.save(placeImage);
+
+        return PlaceImageResponse.from(savedPlaceImage);
+    }
+
+    private void validateMaxImageSequence(int newSequence) {
+        if (newSequence > MAX_IMAGE_SEQUENCE) {
+            throw new BusinessException(
+                    String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+    }
 
     private Place getPlaceById(Long placeId) {
         return placeJpaRepository.findById(placeId)

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -1,0 +1,76 @@
+package com.daedan.festabook.place.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PlaceImageControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private PlaceJpaRepository placeJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class addPlaceImage {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            String imageUrl = "https://example.com/image/1";
+            PlaceImageRequest placeImageRequest = new PlaceImageRequest(imageUrl);
+
+            int expectedFieldSize = 3;
+            int expectedSequence = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(placeImageRequest)
+                    .post("/places/{placeId}/images", place.getId())
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("id", notNullValue())
+                    .body("imageUrl", equalTo(imageUrl))
+                    .body("sequence", equalTo(expectedSequence));
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -9,6 +9,7 @@ import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -54,7 +55,7 @@ public class PlaceImageControllerTest {
             placeJpaRepository.save(place);
 
             String imageUrl = "https://example.com/image/1";
-            PlaceImageRequest placeImageRequest = new PlaceImageRequest(imageUrl);
+            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create(imageUrl);
 
             int expectedFieldSize = 3;
             int expectedSequence = 1;

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
@@ -15,6 +15,19 @@ public class PlaceImageFixture {
     }
 
     public static PlaceImage create(
+            Long id,
+            Place place,
+            int sequence
+    ) {
+        return new PlaceImage(
+                id,
+                place,
+                DEFAULT_IMAGE_URL,
+                sequence
+        );
+    }
+
+    public static PlaceImage create(
             Place place
     ) {
         return new PlaceImage(

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageRequestFixture.java
@@ -7,4 +7,10 @@ public class PlaceImageRequestFixture {
     public static PlaceImageRequest create() {
         return new PlaceImageRequest(DEFAULT_IMAGE_URL);
     }
+
+    public static PlaceImageRequest create(
+            String imageUrl
+    ) {
+        return new PlaceImageRequest(imageUrl);
+    }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageRequestFixture.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.place.dto;
+
+public class PlaceImageRequestFixture {
+
+    private static final String DEFAULT_IMAGE_URL = "https://example.com/images/1";
+
+    public static PlaceImageRequest create() {
+        return new PlaceImageRequest(DEFAULT_IMAGE_URL);
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -1,0 +1,115 @@
+package com.daedan.festabook.place.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
+import com.daedan.festabook.place.dto.PlaceImageResponse;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlaceImageServiceTest {
+
+    private static final int MAX_IMAGE_SEQUENCE = 5;
+
+    @Mock
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Mock
+    private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @InjectMocks
+    private PlaceImageService placeImageService;
+
+    @Nested
+    class addPlaceImage {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeId = 1L;
+            Place place = PlaceFixture.create(placeId);
+
+            int maxSequence = 1;
+            int newSequence = maxSequence + 1;
+
+            Long savePlaceImageId = 2L;
+            PlaceImage savedPlaceImage = PlaceImageFixture.create(savePlaceImageId, place, newSequence);
+
+            given(placeJpaRepository.findById(placeId))
+                    .willReturn(Optional.of(place));
+            given(placeImageJpaRepository.findMaxSequenceByPlace(place))
+                    .willReturn(Optional.of(maxSequence));
+            given(placeImageJpaRepository.save(any()))
+                    .willReturn(savedPlaceImage);
+
+            PlaceImageRequest placeImageRequest = new PlaceImageRequest(savedPlaceImage.getImageUrl());
+
+            // when
+            PlaceImageResponse result = placeImageService.addPlaceImage(placeId, placeImageRequest);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.id()).isEqualTo(savePlaceImageId);
+                s.assertThat(result.imageUrl()).isEqualTo(savedPlaceImage.getImageUrl());
+                s.assertThat(result.sequence()).isEqualTo(newSequence);
+            });
+        }
+
+        @Test
+        void 예외_존재하지_않는_플레이스() {
+            // given
+            Long invalidPlaceId = 1L;
+
+            given(placeJpaRepository.findById(invalidPlaceId))
+                    .willReturn(Optional.empty());
+
+            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> placeImageService.addPlaceImage(invalidPlaceId, placeImageRequest))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 플레이스입니다.");
+        }
+
+        @Test
+        void 예외_최대_이미지_수_초과() {
+            // given
+            Long placeId = 1L;
+            Place place = PlaceFixture.create(placeId);
+
+            int invalidSequence = MAX_IMAGE_SEQUENCE + 1;
+
+            given(placeJpaRepository.findById(placeId))
+                    .willReturn(Optional.of(place));
+            given(placeImageJpaRepository.findMaxSequenceByPlace(place))
+                    .willReturn(Optional.of(invalidSequence));
+
+            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> placeImageService.addPlaceImage(placeId, placeImageRequest))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE));
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

#464 

<br>

## 🛠️ 작업 내용

- 플레이스 이미지 생성 api를 구현하였습니다.

## 참고사항
be/464에 merge를 해서 최종적으로 464 이슈에 올라온 api들을 한번에 merge할 계획입니다.

<br>

## 📸 이미지 첨부 (Optional)
<img width="1179" height="759" alt="image" src="https://github.com/user-attachments/assets/fb22c15b-b25f-433c-b44e-29da9ee75e10" />

