### PR TITLE
[BE] 플레이스 이미지 삭제 api 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,14 +1,35 @@
 package com.daedan.festabook.place.controller;
 
+import com.daedan.festabook.place.service.PlaceImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/places/{placeId}/images")
+@RequestMapping("/places")
 @Tag(name = "플레이스", description = "플레이스 관련 API")
 public class PlaceImageController {
 
+    private final PlaceImageService placeImageService;
+
+    @DeleteMapping("/images/{placeImageId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스의 이미지 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deletePlaceImageByPlaceImageId(
+            @PathVariable Long placeImageId
+    ) {
+        placeImageService.deletePlaceImageByPlaceImageId(placeImageId);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -15,6 +15,10 @@ public class PlaceImageService {
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceImageJpaRepository placeImageJpaRepository;
 
+    public void deletePlaceImageByPlaceImageId(Long placeImageId) {
+        placeImageJpaRepository.deleteById(placeImageId);
+    }
+
     private Place getPlaceById(Long placeId) {
         return placeJpaRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -62,6 +62,7 @@ public class PlaceImageControllerTest {
             // when & then
             RestAssured
                     .given()
+                    .when()
                     .delete("/places/images/{placeImageId}", placeImage.getId())
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -68,5 +68,18 @@ public class PlaceImageControllerTest {
 
             assertThat(placeImageJpaRepository.findById(placeImage.getId())).isEmpty();
         }
+
+        @Test
+        void 성공_존재하지_않는_플레이스_삭제() {
+            // given
+            Long notExistsPlaceId = 0L;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .delete("/places/images/{placeImageId}", notExistsPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -1,0 +1,72 @@
+package com.daedan.festabook.place.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PlaceImageControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Autowired
+    private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class deletePlaceImageByPlaceImageId {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceImage placeImage = PlaceImageFixture.create(place);
+            placeImageJpaRepository.save(placeImage);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .delete("/places/images/{placeImageId}", placeImage.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            assertThat(placeImageJpaRepository.findById(placeImage.getId())).isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -1,0 +1,45 @@
+package com.daedan.festabook.place.service;
+
+import static org.mockito.BDDMockito.then;
+
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PlaceImageServiceTest {
+
+    @Mock
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Mock
+    private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @InjectMocks
+    private PlaceImageService placeImageService;
+
+    @Nested
+    class deletePlaceImageByPlaceImageId {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeImageId = 1L;
+
+            // when
+            placeImageService.deletePlaceImageByPlaceImageId(placeImageId);
+
+            // then
+            then(placeImageJpaRepository).should()
+                    .deleteById(placeImageId);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

#464 

<br>

## 🛠️ 작업 내용

- 플레이스 이미지 삭제 로직을 구현하였습니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1159" height="382" alt="image" src="https://github.com/user-attachments/assets/d55bfc73-0bed-4e30-918d-50f3d125ca0f" />
