### PR TITLE
[BE] 플레이스 이미지 순서 변경 api 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,14 +1,38 @@
 package com.daedan.festabook.place.controller;
 
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
+import com.daedan.festabook.place.service.PlaceImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/places/{placeId}/images")
-@Tag(name = "플레이스", description = "플레이스 관련 API")
+@RequestMapping("/places")
+@Tag(name = "플레이스 이미지", description = "플레이스 이미지 관련 API")
 public class PlaceImageController {
 
+    private final PlaceImageService placeImageService;
+
+    @PatchMapping("/images/sequences")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제에 대한 플레이스의 이미지들 순서 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public PlaceImageSequenceUpdateResponses updateFestivalImagesSequence(
+            @RequestBody List<PlaceImageSequenceUpdateRequest> requests
+    ) {
+        return placeImageService.updatePlaceImagesSequence(requests);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PlaceImage {
+public class PlaceImage implements Comparable<PlaceImage> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,14 +31,38 @@ public class PlaceImage {
     @Column(nullable = false)
     private Integer sequence;
 
+    protected PlaceImage(
+            Long id,
+            Place place,
+            String imageUrl,
+            Integer sequence
+    ) {
+        this.id = id;
+        this.place = place;
+        this.imageUrl = imageUrl;
+        this.sequence = sequence;
+    }
+
     // TODO PlaceImage 최대 5개 검증 로직 구현
     public PlaceImage(
             Place place,
             String imageUrl,
             Integer sequence
     ) {
-        this.place = place;
-        this.imageUrl = imageUrl;
+        this(
+                null,
+                place,
+                imageUrl,
+                sequence
+        );
+    }
+
+    public void updateSequence(int sequence) {
         this.sequence = sequence;
+    }
+
+    @Override
+    public int compareTo(PlaceImage otherPlaceImage) {
+        return sequence.compareTo(otherPlaceImage.sequence);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.daedan.festabook.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceImageSequenceUpdateRequest(
+
+        @Schema(description = "플레이스 이미지 ID", example = "1")
+        Long placeImageId,
+
+        @Schema(description = "변경할 순서", example = "1")
+        Integer sequence
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceImage;
+
+public record PlaceImageSequenceUpdateResponse(
+        Long placeImageId,
+        int sequence
+) {
+
+    public static PlaceImageSequenceUpdateResponse from(PlaceImage placeImage) {
+        return new PlaceImageSequenceUpdateResponse(
+                placeImage.getId(),
+                placeImage.getSequence()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponses.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponses.java
@@ -1,0 +1,18 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.List;
+
+public record PlaceImageSequenceUpdateResponses(
+        @JsonValue List<PlaceImageSequenceUpdateResponse> responses
+) {
+
+    public static PlaceImageSequenceUpdateResponses from(List<PlaceImage> placeImages) {
+        return new PlaceImageSequenceUpdateResponses(
+                placeImages.stream()
+                        .map(PlaceImageSequenceUpdateResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -2,11 +2,18 @@ package com.daedan.festabook.place.service;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,8 +22,29 @@ public class PlaceImageService {
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceImageJpaRepository placeImageJpaRepository;
 
+    @Transactional
+    public PlaceImageSequenceUpdateResponses updatePlaceImagesSequence(List<PlaceImageSequenceUpdateRequest> requests) {
+        // TODO: sequence DTO 값 검증 추가
+        List<PlaceImage> placeImages = new ArrayList<>();
+
+        for (PlaceImageSequenceUpdateRequest request : requests) {
+            PlaceImage placeImage = getPlaceImageById(request.placeImageId());
+            placeImage.updateSequence(request.sequence());
+            placeImages.add(placeImage);
+        }
+
+        Collections.sort(placeImages);
+
+        return PlaceImageSequenceUpdateResponses.from(placeImages);
+    }
+
     private Place getPlaceById(Long placeId) {
         return placeJpaRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private PlaceImage getPlaceImageById(Long placeImageId) {
+        return placeImageJpaRepository.findById(placeImageId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스 이미지입니다.", HttpStatus.NOT_FOUND));
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -1,0 +1,98 @@
+package com.daedan.festabook.place.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequestFixture;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PlaceImageControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Autowired
+    private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class updateFestivalImagesSequence {
+
+        @Test
+        void 성공_수정_후_응답값_오름차순_정렬() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceImage placeImage1 = PlaceImageFixture.create(place, 1);
+            PlaceImage placeImage2 = PlaceImageFixture.create(place, 2);
+            PlaceImage placeImage3 = PlaceImageFixture.create(place, 3);
+            placeImageJpaRepository.saveAll(List.of(placeImage1, placeImage2, placeImage3));
+
+            List<PlaceImageSequenceUpdateRequest> requests = List.of(
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImage1.getId(), 3),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImage2.getId(), 2),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImage3.getId(), 1)
+            );
+
+            int expectedSize = 3;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(requests)
+                    .when()
+                    .patch("/places/images/sequences")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasSize(expectedSize))
+
+                    .body("[0].placeImageId", equalTo(placeImage3.getId().intValue()))
+                    .body("[0].sequence", equalTo(1))
+
+                    .body("[1].placeImageId", equalTo(placeImage2.getId().intValue()))
+                    .body("[1].sequence", equalTo(2))
+
+                    .body("[2].placeImageId", equalTo(placeImage1.getId().intValue()))
+                    .body("[2].sequence", equalTo(3));
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
@@ -36,6 +36,18 @@ public class PlaceImageFixture {
     }
 
     public static PlaceImage create(
+            Long placeImageId,
+            Integer sequence
+    ) {
+        return new PlaceImage(
+                placeImageId,
+                DEFAULT_PLACE,
+                DEFAULT_IMAGE_URL,
+                sequence
+        );
+    }
+
+    public static PlaceImage create(
             Place place,
             String imageUrl,
             Integer sequence

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequestFixture.java
@@ -1,0 +1,24 @@
+package com.daedan.festabook.place.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PlaceImageSequenceUpdateRequestFixture {
+
+    public static PlaceImageSequenceUpdateRequest create(
+            Long placeImageId,
+            int sequence
+    ) {
+        return new PlaceImageSequenceUpdateRequest(
+                placeImageId,
+                sequence
+        );
+    }
+
+    public static List<PlaceImageSequenceUpdateRequest> createList(int size) {
+        return IntStream.range(1, size + 1)
+                .mapToObj(i -> create((long) i, i))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -1,0 +1,93 @@
+package com.daedan.festabook.place.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequestFixture;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlaceImageServiceTest {
+
+    @Mock
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Mock
+    private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @InjectMocks
+    private PlaceImageService placeImageService;
+
+    @Nested
+    class updatePlaceImagesSequence {
+
+        @Test
+        void 성공_수정_후_응답값_오름차순_정렬() {
+            // given
+            Long placeImageId1 = 1L;
+            Long placeImageId2 = 2L;
+            Long placeImageId3 = 3L;
+
+            PlaceImage placeImage1 = PlaceImageFixture.create(placeImageId1, 1);
+            PlaceImage placeImage2 = PlaceImageFixture.create(placeImageId2, 2);
+            PlaceImage placeImage3 = PlaceImageFixture.create(placeImageId3, 3);
+
+            List<PlaceImageSequenceUpdateRequest> requests = List.of(
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImageId1, 3),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImageId2, 2),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImageId3, 1)
+            );
+
+            given(placeImageJpaRepository.findById(placeImageId1))
+                    .willReturn(Optional.of(placeImage1));
+            given(placeImageJpaRepository.findById(placeImageId2))
+                    .willReturn(Optional.of(placeImage2));
+            given(placeImageJpaRepository.findById(placeImageId3))
+                    .willReturn(Optional.of(placeImage3));
+
+            // when
+            PlaceImageSequenceUpdateResponses result = placeImageService.updatePlaceImagesSequence(requests);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.responses().get(0).placeImageId()).isEqualTo(placeImageId3);
+                s.assertThat(result.responses().get(0).sequence()).isEqualTo(1);
+
+                s.assertThat(result.responses().get(1).placeImageId()).isEqualTo(placeImageId2);
+                s.assertThat(result.responses().get(1).sequence()).isEqualTo(2);
+
+                s.assertThat(result.responses().get(2).placeImageId()).isEqualTo(placeImageId1);
+                s.assertThat(result.responses().get(2).sequence()).isEqualTo(3);
+            });
+        }
+
+        @Test
+        void 예외_존재하지_않는_플레이스_이미지() {
+            // given
+            List<PlaceImageSequenceUpdateRequest> requests = PlaceImageSequenceUpdateRequestFixture.createList(1);
+
+            // when & then
+            assertThatThrownBy(() -> placeImageService.updatePlaceImagesSequence(requests))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 플레이스 이미지입니다.");
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

#464 

<br>

## 🛠️ 작업 내용

- 플레이스 이미지 순서 변경 api 구현

<br>

## 📸 이미지 첨부 (Optional)

<img width="1159" height="716" alt="image" src="https://github.com/user-attachments/assets/d9013a93-c1c0-4964-a45e-2e03e6a1be96" />

