### PR TITLE
[BE] 플레이스 공지 삭제 api 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
@@ -1,9 +1,16 @@
 package com.daedan.festabook.place.controller;
 
 import com.daedan.festabook.place.service.PlaceAnnouncementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,4 +20,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlaceAnnouncementController {
 
     private final PlaceAnnouncementService placeAnnouncementService;
+
+    @DeleteMapping("/announcements/{placeAnnouncementId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스의 공지 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deleteByPlaceAnnouncementId(
+            @PathVariable Long placeAnnouncementId
+    ) {
+        placeAnnouncementService.deleteByPlaceAnnouncementId(placeAnnouncementId);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceAnnouncement.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceAnnouncement.java
@@ -46,7 +46,8 @@ public class PlaceAnnouncement {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public PlaceAnnouncement(
+    protected PlaceAnnouncement(
+            Long id,
             Place place,
             String title,
             String content
@@ -54,9 +55,23 @@ public class PlaceAnnouncement {
         validateTitle(title);
         validateContent(content);
 
+        this.id = id;
         this.place = place;
         this.title = title;
         this.content = content;
+    }
+
+    public PlaceAnnouncement(
+            Place place,
+            String title,
+            String content
+    ) {
+        this(
+                null,
+                place,
+                title,
+                content
+        );
     }
 
     private void validateTitle(String title) {

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -11,4 +11,8 @@ public class PlaceAnnouncementService {
 
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
+
+    public void deleteByPlaceAnnouncementId(Long placeAnnouncementId) {
+        placeAnnouncementJpaRepository.deleteById(placeAnnouncementId);
+    }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -62,6 +62,7 @@ class PlaceAnnouncementControllerTest {
             // when & then
             RestAssured
                     .given()
+                    .when()
                     .delete("/places/announcements/{placeAnnouncementId}", placeAnnouncement.getId())
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -68,5 +68,18 @@ class PlaceAnnouncementControllerTest {
 
             assertThat(placeAnnouncementJpaRepository.findById(placeAnnouncement.getId())).isEmpty();
         }
+
+        @Test
+        void 성공_존재하지_않는_플레이스_공지() {
+            // given
+            Long notExistsPlaceAnnouncementId = 0L;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .delete("/places/announcements/{placeAnnouncementId}", notExistsPlaceAnnouncementId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -1,16 +1,27 @@
 package com.daedan.festabook.place.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
+import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -31,5 +42,31 @@ class PlaceAnnouncementControllerTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+    }
+
+    @Nested
+    class deleteByPlaceAnnouncementId {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create(place);
+            placeAnnouncementJpaRepository.save(placeAnnouncement);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .delete("/places/announcements/{placeAnnouncementId}", placeAnnouncement.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            assertThat(placeAnnouncementJpaRepository.findById(placeAnnouncement.getId())).isEmpty();
+        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementFixture.java
@@ -14,6 +14,15 @@ public class PlaceAnnouncementFixture {
         );
     }
 
+    public static PlaceAnnouncement create(Long id) {
+        return new PlaceAnnouncement(
+                id,
+                DEFAULT_PLACE,
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT
+        );
+    }
+
     public static PlaceAnnouncement create(
             Place place
     ) {

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
@@ -1,9 +1,13 @@
 package com.daedan.festabook.place.service;
 
+import static org.mockito.BDDMockito.then;
+
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -21,4 +25,20 @@ class PlaceAnnouncementServiceTest {
 
     @InjectMocks
     private PlaceAnnouncementService placeAnnouncementService;
+
+    @Nested
+    class deleteByPlaceAnnouncementId {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeAnnouncementId = 1L;
+
+            // when
+            placeAnnouncementService.deleteByPlaceAnnouncementId(placeAnnouncementId);
+
+            // then
+            then(placeAnnouncementJpaRepository).should().deleteById(placeAnnouncementId);
+        }
+    }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
@@ -38,7 +38,8 @@ class PlaceAnnouncementServiceTest {
             placeAnnouncementService.deleteByPlaceAnnouncementId(placeAnnouncementId);
 
             // then
-            then(placeAnnouncementJpaRepository).should().deleteById(placeAnnouncementId);
+            then(placeAnnouncementJpaRepository).should()
+                    .deleteById(placeAnnouncementId);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#463 

<br>

## 🛠️ 작업 내용

- 플레이스 공지 삭제 api를 구현하였습니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1146" height="429" alt="image" src="https://github.com/user-attachments/assets/619da68b-12ad-44bd-92da-b96eafdcecf7" />

