### PR TITLE
[BE] 플레이스 이미지 생성(추가), 순서 변경, 삭제 api 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlaceImageController {
 
     private final PlaceImageService placeImageService;
+
+    @DeleteMapping("/images/{placeImageId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스의 이미지 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deletePlaceImageByPlaceImageId(
+            @PathVariable Long placeImageId
+    ) {
+        placeImageService.deletePlaceImageByPlaceImageId(placeImageId);
+    }
 
     @PostMapping("/{placeId}/images")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,0 +1,14 @@
+package com.daedan.festabook.place.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/places/{placeId}/images")
+@Tag(name = "플레이스", description = "플레이스 관련 API")
+public class PlaceImageController {
+
+}

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,5 +1,11 @@
 package com.daedan.festabook.place.controller;
 
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
+import com.daedan.festabook.place.service.PlaceImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import com.daedan.festabook.place.dto.PlaceImageRequest;
 import com.daedan.festabook.place.dto.PlaceImageResponse;
 import com.daedan.festabook.place.service.PlaceImageService;
@@ -7,7 +13,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,18 +35,6 @@ public class PlaceImageController {
 
     private final PlaceImageService placeImageService;
 
-    @DeleteMapping("/images/{placeImageId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "특정 플레이스의 이미지 삭제")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
-    })
-    public void deletePlaceImageByPlaceImageId(
-            @PathVariable Long placeImageId
-    ) {
-        placeImageService.deletePlaceImageByPlaceImageId(placeImageId);
-    }
-
     @PostMapping("/{placeId}/images")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "특정 축제에 대한 플레이스의 이미지 생성")
@@ -48,5 +46,29 @@ public class PlaceImageController {
             @RequestBody PlaceImageRequest request
     ) {
         return placeImageService.addPlaceImage(placeId, request);
+    }
+
+    @PatchMapping("/images/sequences")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제에 대한 플레이스의 이미지들 순서 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public PlaceImageSequenceUpdateResponses updateFestivalImagesSequence(
+            @RequestBody List<PlaceImageSequenceUpdateRequest> requests
+    ) {
+        return placeImageService.updatePlaceImagesSequence(requests);
+    }
+
+    @DeleteMapping("/images/{placeImageId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스의 이미지 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deletePlaceImageByPlaceImageId(
+            @PathVariable Long placeImageId
+    ) {
+        placeImageService.deletePlaceImageByPlaceImageId(placeImageId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceImageController.java
@@ -1,14 +1,39 @@
 package com.daedan.festabook.place.controller;
 
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageResponse;
+import com.daedan.festabook.place.service.PlaceImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/places/{placeId}/images")
-@Tag(name = "플레이스", description = "플레이스 관련 API")
+@RequestMapping("/places")
+@Tag(name = "플레이스 이미지", description = "플레이스 이미지 관련 API")
 public class PlaceImageController {
 
+    private final PlaceImageService placeImageService;
+
+    @PostMapping("/{placeId}/images")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "특정 축제에 대한 플레이스의 이미지 생성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+    })
+    public PlaceImageResponse addPlaceImage(
+            @PathVariable Long placeId,
+            @RequestBody PlaceImageRequest request
+    ) {
+        return placeImageService.addPlaceImage(placeId, request);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PlaceImage {
+public class PlaceImage implements Comparable<PlaceImage> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,5 +54,14 @@ public class PlaceImage {
                 imageUrl,
                 sequence
         );
+    }
+
+    public void updateSequence(int sequence) {
+        this.sequence = sequence;
+    }
+
+    @Override
+    public int compareTo(PlaceImage otherPlaceImage) {
+        return sequence.compareTo(otherPlaceImage.sequence);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceImage.java
@@ -31,14 +31,28 @@ public class PlaceImage {
     @Column(nullable = false)
     private Integer sequence;
 
-    // TODO PlaceImage 최대 5개 검증 로직 구현
+    protected PlaceImage(
+            Long id,
+            Place place,
+            String imageUrl,
+            Integer sequence
+    ) {
+        this.id = id;
+        this.place = place;
+        this.imageUrl = imageUrl;
+        this.sequence = sequence;
+    }
+
     public PlaceImage(
             Place place,
             String imageUrl,
             Integer sequence
     ) {
-        this.place = place;
-        this.imageUrl = imageUrl;
-        this.sequence = sequence;
+        this(
+                null,
+                place,
+                imageUrl,
+                sequence
+        );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageRequest.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceImageRequest(
+
+        @Schema(description = "플레이스 이미지 url", example = "https://festabook.net/image/poster.jpg")
+        String imageUrl
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.daedan.festabook.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceImageSequenceUpdateRequest(
+
+        @Schema(description = "플레이스 이미지 ID", example = "1")
+        Long placeImageId,
+
+        @Schema(description = "변경할 순서", example = "1")
+        Integer sequence
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceImage;
+
+public record PlaceImageSequenceUpdateResponse(
+        Long placeImageId,
+        int sequence
+) {
+
+    public static PlaceImageSequenceUpdateResponse from(PlaceImage placeImage) {
+        return new PlaceImageSequenceUpdateResponse(
+                placeImage.getId(),
+                placeImage.getSequence()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponses.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateResponses.java
@@ -1,0 +1,18 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.List;
+
+public record PlaceImageSequenceUpdateResponses(
+        @JsonValue List<PlaceImageSequenceUpdateResponse> responses
+) {
+
+    public static PlaceImageSequenceUpdateResponses from(List<PlaceImage> placeImages) {
+        return new PlaceImageSequenceUpdateResponses(
+                placeImages.stream()
+                        .map(PlaceImageSequenceUpdateResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
@@ -17,5 +17,7 @@ public interface PlaceImageJpaRepository extends JpaRepository<PlaceImage, Long>
     @Query("SELECT MAX(p.sequence) FROM PlaceImage p WHERE p.place = :place")
     Optional<Integer> findMaxSequenceByPlace(@Param("place") Place place);
 
+    Long countByPlace(Place place);
+
     void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
@@ -3,13 +3,19 @@ package com.daedan.festabook.place.infrastructure;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceImage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlaceImageJpaRepository extends JpaRepository<PlaceImage, Long> {
 
     List<PlaceImage> findAllByPlaceIdOrderBySequenceAsc(Long placeId);
 
     List<PlaceImage> findAllByPlaceInAndSequence(List<Place> places, int sequence);
+
+    @Query("SELECT MAX(p.sequence) FROM PlaceImage p WHERE p.place = :place")
+    Optional<Integer> findMaxSequenceByPlace(@Param("place") Place place);
 
     void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -42,16 +42,6 @@ public class PlaceImageService {
         return PlaceImageResponse.from(savedPlaceImage);
     }
 
-    private void validateMaxImageCount(Place place) {
-        Long imageCount = placeImageJpaRepository.countByPlace(place);
-        if (imageCount > MAX_IMAGE_COUNT) {
-            throw new BusinessException(
-                    String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_COUNT),
-                    HttpStatus.BAD_REQUEST
-            );
-        }
-    }
-
     @Transactional
     public PlaceImageSequenceUpdateResponses updatePlaceImagesSequence(List<PlaceImageSequenceUpdateRequest> requests) {
         // TODO: sequence DTO 값 검증 추가
@@ -70,6 +60,16 @@ public class PlaceImageService {
 
     public void deletePlaceImageByPlaceImageId(Long placeImageId) {
         placeImageJpaRepository.deleteById(placeImageId);
+    }
+
+    private void validateMaxImageCount(Place place) {
+        Long imageCount = placeImageJpaRepository.countByPlace(place);
+        if (imageCount > MAX_IMAGE_COUNT) {
+            throw new BusinessException(
+                    String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_COUNT),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
     }
 
     private Place getPlaceById(Long placeId) {

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlaceImageService {
 
-    private static final int MAX_IMAGE_COUNT = 5;
+    private static final Long MAX_IMAGE_COUNT = 5L;
 
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceImageJpaRepository placeImageJpaRepository;

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -1,0 +1,22 @@
+package com.daedan.festabook.place.service;
+
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceImageService {
+
+    private final PlaceJpaRepository placeJpaRepository;
+    private final PlaceImageJpaRepository placeImageJpaRepository;
+
+    private Place getPlaceById(Long placeId) {
+        return placeJpaRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -64,7 +64,7 @@ public class PlaceImageService {
 
     private void validateMaxImageCount(Place place) {
         Long imageCount = placeImageJpaRepository.countByPlace(place);
-        if (imageCount > MAX_IMAGE_COUNT) {
+        if (imageCount >= MAX_IMAGE_COUNT) {
             throw new BusinessException(
                     String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_COUNT),
                     HttpStatus.BAD_REQUEST

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -46,6 +46,10 @@ public class PlaceImageService {
         }
     }
 
+    public void deletePlaceImageByPlaceImageId(Long placeImageId) {
+        placeImageJpaRepository.deleteById(placeImageId);
+    }
+
     private Place getPlaceById(Long placeId) {
         return placeJpaRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -2,18 +2,49 @@ package com.daedan.festabook.place.service;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageResponse;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceImageService {
 
+    private static final int MAX_IMAGE_SEQUENCE = 5;
+
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceImageJpaRepository placeImageJpaRepository;
+
+    // TODO: sequence 동시성 해결
+    @Transactional
+    public PlaceImageResponse addPlaceImage(Long placeId, PlaceImageRequest request) {
+        Place place = getPlaceById(placeId);
+
+        int currentMaxSequence = placeImageJpaRepository.findMaxSequenceByPlace(place)
+                .orElseGet(() -> 0);
+        Integer newSequence = currentMaxSequence + 1;
+        validateMaxImageSequence(newSequence);
+
+        PlaceImage placeImage = new PlaceImage(place, request.imageUrl(), newSequence);
+        PlaceImage savedPlaceImage = placeImageJpaRepository.save(placeImage);
+
+        return PlaceImageResponse.from(savedPlaceImage);
+    }
+
+    private void validateMaxImageSequence(int newSequence) {
+        if (newSequence > MAX_IMAGE_SEQUENCE) {
+            throw new BusinessException(
+                    String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+    }
 
     private Place getPlaceById(Long placeId) {
         return placeJpaRepository.findById(placeId)

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -3,10 +3,16 @@ package com.daedan.festabook.place.service;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
+import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.dto.PlaceImageRequest;
 import com.daedan.festabook.place.dto.PlaceImageResponse;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -46,6 +52,23 @@ public class PlaceImageService {
         }
     }
 
+    @Transactional
+    public PlaceImageSequenceUpdateResponses updatePlaceImagesSequence(List<PlaceImageSequenceUpdateRequest> requests) {
+        // TODO: sequence DTO 값 검증 추가
+        List<PlaceImage> placeImages = new ArrayList<>();
+
+        for (PlaceImageSequenceUpdateRequest request : requests) {
+            PlaceImage placeImage = getPlaceImageById(request.placeImageId());
+            placeImage.updateSequence(request.sequence());
+            placeImages.add(placeImage);
+        }
+
+        Collections.sort(placeImages);
+
+        return PlaceImageSequenceUpdateResponses.from(placeImages);
+    }
+
+
     public void deletePlaceImageByPlaceImageId(Long placeImageId) {
         placeImageJpaRepository.deleteById(placeImageId);
     }
@@ -53,5 +76,10 @@ public class PlaceImageService {
     private Place getPlaceById(Long placeId) {
         return placeJpaRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private PlaceImage getPlaceImageById(Long placeImageId) {
+        return placeImageJpaRepository.findById(placeImageId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스 이미지입니다.", HttpStatus.NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceImageService.java
@@ -3,11 +3,10 @@ package com.daedan.festabook.place.service;
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceImage;
-import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
-import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
-import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.dto.PlaceImageRequest;
 import com.daedan.festabook.place.dto.PlaceImageResponse;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import java.util.ArrayList;
@@ -22,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlaceImageService {
 
-    private static final int MAX_IMAGE_SEQUENCE = 5;
+    private static final int MAX_IMAGE_COUNT = 5;
 
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceImageJpaRepository placeImageJpaRepository;
@@ -35,7 +34,7 @@ public class PlaceImageService {
         int currentMaxSequence = placeImageJpaRepository.findMaxSequenceByPlace(place)
                 .orElseGet(() -> 0);
         Integer newSequence = currentMaxSequence + 1;
-        validateMaxImageSequence(newSequence);
+        validateMaxImageCount(place);
 
         PlaceImage placeImage = new PlaceImage(place, request.imageUrl(), newSequence);
         PlaceImage savedPlaceImage = placeImageJpaRepository.save(placeImage);
@@ -43,10 +42,11 @@ public class PlaceImageService {
         return PlaceImageResponse.from(savedPlaceImage);
     }
 
-    private void validateMaxImageSequence(int newSequence) {
-        if (newSequence > MAX_IMAGE_SEQUENCE) {
+    private void validateMaxImageCount(Place place) {
+        Long imageCount = placeImageJpaRepository.countByPlace(place);
+        if (imageCount > MAX_IMAGE_COUNT) {
             throw new BusinessException(
-                    String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE),
+                    String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_COUNT),
                     HttpStatus.BAD_REQUEST
             );
         }
@@ -67,7 +67,6 @@ public class PlaceImageService {
 
         return PlaceImageSequenceUpdateResponses.from(placeImages);
     }
-
 
     public void deletePlaceImageByPlaceImageId(Long placeImageId) {
         placeImageJpaRepository.deleteById(placeImageId);

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -1,19 +1,19 @@
 package com.daedan.festabook.place.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceFixture;
-import com.daedan.festabook.place.dto.PlaceImageRequest;
-import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
 import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
 import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
 import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
@@ -162,12 +162,12 @@ public class PlaceImageControllerTest {
         @Test
         void 성공_존재하지_않는_플레이스_삭제() {
             // given
-            Long notExistsPlaceId = 0L;
+            Long invalidPlaceImageId = 0L;
 
             // when & then
             RestAssured
                     .given()
-                    .delete("/places/images/{placeImageId}", notExistsPlaceId)
+                    .delete("/places/images/{placeImageId}", invalidPlaceImageId)
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
         }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.place.controller;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,10 +14,13 @@ import com.daedan.festabook.place.dto.PlaceImageRequest;
 import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
 import com.daedan.festabook.place.domain.PlaceImage;
 import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -79,6 +83,53 @@ public class PlaceImageControllerTest {
                     .body("id", notNullValue())
                     .body("imageUrl", equalTo(imageUrl))
                     .body("sequence", equalTo(expectedSequence));
+        }
+    }
+
+    @Nested
+    class updateFestivalImagesSequence {
+
+        @Test
+        void 성공_수정_후_응답값_오름차순_정렬() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceImage placeImage1 = PlaceImageFixture.create(place, 1);
+            PlaceImage placeImage2 = PlaceImageFixture.create(place, 2);
+            PlaceImage placeImage3 = PlaceImageFixture.create(place, 3);
+            placeImageJpaRepository.saveAll(List.of(placeImage1, placeImage2, placeImage3));
+
+            List<PlaceImageSequenceUpdateRequest> requests = List.of(
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImage1.getId(), 3),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImage2.getId(), 2),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImage3.getId(), 1)
+            );
+
+            int expectedSize = 3;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(requests)
+                    .when()
+                    .patch("/places/images/sequences")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasSize(expectedSize))
+
+                    .body("[0].placeImageId", equalTo(placeImage3.getId().intValue()))
+                    .body("[0].sequence", equalTo(1))
+
+                    .body("[1].placeImageId", equalTo(placeImage2.getId().intValue()))
+                    .body("[1].sequence", equalTo(2))
+
+                    .body("[2].placeImageId", equalTo(placeImage1.getId().intValue()))
+                    .body("[2].sequence", equalTo(3));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.place.controller;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
@@ -10,6 +11,9 @@ import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceImageRequest;
 import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -33,6 +37,9 @@ public class PlaceImageControllerTest {
 
     @Autowired
     private PlaceJpaRepository placeJpaRepository;
+
+    @Autowired
+    private PlaceImageJpaRepository placeImageJpaRepository;
 
     @LocalServerPort
     private int port;
@@ -72,6 +79,46 @@ public class PlaceImageControllerTest {
                     .body("id", notNullValue())
                     .body("imageUrl", equalTo(imageUrl))
                     .body("sequence", equalTo(expectedSequence));
+        }
+    }
+
+    @Nested
+    class deletePlaceImageByPlaceImageId {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceImage placeImage = PlaceImageFixture.create(place);
+            placeImageJpaRepository.save(placeImage);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .when()
+                    .delete("/places/images/{placeImageId}", placeImage.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            assertThat(placeImageJpaRepository.findById(placeImage.getId())).isEmpty();
+        }
+
+        @Test
+        void 성공_존재하지_않는_플레이스_삭제() {
+            // given
+            Long notExistsPlaceId = 0L;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .delete("/places/images/{placeImageId}", notExistsPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -66,7 +66,7 @@ public class PlaceImageControllerTest {
             placeJpaRepository.save(place);
 
             String imageUrl = "https://example.com/image/1";
-            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create(imageUrl);
+            PlaceImageRequest request = PlaceImageRequestFixture.create(imageUrl);
 
             int expectedFieldSize = 3;
             int expectedSequence = 1;
@@ -75,7 +75,7 @@ public class PlaceImageControllerTest {
             RestAssured
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(placeImageRequest)
+                    .body(request)
                     .post("/places/{placeId}/images", place.getId())
                     .then()
                     .statusCode(HttpStatus.CREATED.value())

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceImageControllerTest.java
@@ -1,0 +1,77 @@
+package com.daedan.festabook.place.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PlaceImageControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private PlaceJpaRepository placeJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class addPlaceImage {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            String imageUrl = "https://example.com/image/1";
+            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create(imageUrl);
+
+            int expectedFieldSize = 3;
+            int expectedSequence = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(placeImageRequest)
+                    .post("/places/{placeId}/images", place.getId())
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("id", notNullValue())
+                    .body("imageUrl", equalTo(imageUrl))
+                    .body("sequence", equalTo(expectedSequence));
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
@@ -15,6 +15,19 @@ public class PlaceImageFixture {
     }
 
     public static PlaceImage create(
+            Long id,
+            Place place,
+            int sequence
+    ) {
+        return new PlaceImage(
+                id,
+                place,
+                DEFAULT_IMAGE_URL,
+                sequence
+        );
+    }
+
+    public static PlaceImage create(
             Place place
     ) {
         return new PlaceImage(

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceImageFixture.java
@@ -49,6 +49,18 @@ public class PlaceImageFixture {
     }
 
     public static PlaceImage create(
+            Long placeImageId,
+            Integer sequence
+    ) {
+        return new PlaceImage(
+                placeImageId,
+                DEFAULT_PLACE,
+                DEFAULT_IMAGE_URL,
+                sequence
+        );
+    }
+
+    public static PlaceImage create(
             Place place,
             String imageUrl,
             Integer sequence

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageRequestFixture.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.place.dto;
+
+public class PlaceImageRequestFixture {
+
+    private static final String DEFAULT_IMAGE_URL = "https://example.com/images/1";
+
+    public static PlaceImageRequest create() {
+        return new PlaceImageRequest(DEFAULT_IMAGE_URL);
+    }
+
+    public static PlaceImageRequest create(
+            String imageUrl
+    ) {
+        return new PlaceImageRequest(imageUrl);
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceImageSequenceUpdateRequestFixture.java
@@ -1,0 +1,24 @@
+package com.daedan.festabook.place.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PlaceImageSequenceUpdateRequestFixture {
+
+    public static PlaceImageSequenceUpdateRequest create(
+            Long placeImageId,
+            int sequence
+    ) {
+        return new PlaceImageSequenceUpdateRequest(
+                placeImageId,
+                sequence
+        );
+    }
+
+    public static List<PlaceImageSequenceUpdateRequest> createList(int size) {
+        return IntStream.range(1, size + 1)
+                .mapToObj(i -> create((long) i, i))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -34,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class PlaceImageServiceTest {
 
-    private static final int MAX_IMAGE_COUNT = 5;
+    private static final Long MAX_IMAGE_COUNT = 5L;
 
     @Mock
     private PlaceJpaRepository placeJpaRepository;
@@ -102,12 +102,15 @@ public class PlaceImageServiceTest {
             Long placeId = 1L;
             Place place = PlaceFixture.create(placeId);
 
-            int invalidSequence = MAX_IMAGE_COUNT + 1;
+            int sequence = 10;
+            Long imageCount = MAX_IMAGE_COUNT + 1;
 
             given(placeJpaRepository.findById(placeId))
                     .willReturn(Optional.of(place));
             given(placeImageJpaRepository.findMaxSequenceByPlace(place))
-                    .willReturn(Optional.of(invalidSequence));
+                    .willReturn(Optional.of(sequence));
+            given(placeImageJpaRepository.countByPlace(place))
+                    .willReturn(imageCount);
 
             PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create();
 

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -1,0 +1,115 @@
+package com.daedan.festabook.place.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.place.domain.PlaceImageFixture;
+import com.daedan.festabook.place.dto.PlaceImageRequest;
+import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
+import com.daedan.festabook.place.dto.PlaceImageResponse;
+import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlaceImageServiceTest {
+
+    private static final int MAX_IMAGE_SEQUENCE = 5;
+
+    @Mock
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Mock
+    private PlaceImageJpaRepository placeImageJpaRepository;
+
+    @InjectMocks
+    private PlaceImageService placeImageService;
+
+    @Nested
+    class addPlaceImage {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeId = 1L;
+            Place place = PlaceFixture.create(placeId);
+
+            int maxSequence = 1;
+            int newSequence = maxSequence + 1;
+
+            Long savePlaceImageId = 2L;
+            PlaceImage savedPlaceImage = PlaceImageFixture.create(savePlaceImageId, place, newSequence);
+
+            given(placeJpaRepository.findById(placeId))
+                    .willReturn(Optional.of(place));
+            given(placeImageJpaRepository.findMaxSequenceByPlace(place))
+                    .willReturn(Optional.of(maxSequence));
+            given(placeImageJpaRepository.save(any()))
+                    .willReturn(savedPlaceImage);
+
+            PlaceImageRequest placeImageRequest = new PlaceImageRequest(savedPlaceImage.getImageUrl());
+
+            // when
+            PlaceImageResponse result = placeImageService.addPlaceImage(placeId, placeImageRequest);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.id()).isEqualTo(savePlaceImageId);
+                s.assertThat(result.imageUrl()).isEqualTo(savedPlaceImage.getImageUrl());
+                s.assertThat(result.sequence()).isEqualTo(newSequence);
+            });
+        }
+
+        @Test
+        void 예외_존재하지_않는_플레이스() {
+            // given
+            Long invalidPlaceId = 1L;
+
+            given(placeJpaRepository.findById(invalidPlaceId))
+                    .willReturn(Optional.empty());
+
+            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> placeImageService.addPlaceImage(invalidPlaceId, placeImageRequest))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 플레이스입니다.");
+        }
+
+        @Test
+        void 예외_최대_이미지_수_초과() {
+            // given
+            Long placeId = 1L;
+            Place place = PlaceFixture.create(placeId);
+
+            int invalidSequence = MAX_IMAGE_SEQUENCE + 1;
+
+            given(placeJpaRepository.findById(placeId))
+                    .willReturn(Optional.of(place));
+            given(placeImageJpaRepository.findMaxSequenceByPlace(place))
+                    .willReturn(Optional.of(invalidSequence));
+
+            PlaceImageRequest placeImageRequest = PlaceImageRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> placeImageService.addPlaceImage(placeId, placeImageRequest))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE));
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -14,8 +14,12 @@ import com.daedan.festabook.place.domain.PlaceImageFixture;
 import com.daedan.festabook.place.dto.PlaceImageRequest;
 import com.daedan.festabook.place.dto.PlaceImageRequestFixture;
 import com.daedan.festabook.place.dto.PlaceImageResponse;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequestFixture;
+import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -111,6 +115,61 @@ public class PlaceImageServiceTest {
             assertThatThrownBy(() -> placeImageService.addPlaceImage(placeId, placeImageRequest))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE));
+        }
+    }
+
+    @Nested
+    class updatePlaceImagesSequence {
+
+        @Test
+        void 성공_수정_후_응답값_오름차순_정렬() {
+            // given
+            Long placeImageId1 = 1L;
+            Long placeImageId2 = 2L;
+            Long placeImageId3 = 3L;
+
+            PlaceImage placeImage1 = PlaceImageFixture.create(placeImageId1, 1);
+            PlaceImage placeImage2 = PlaceImageFixture.create(placeImageId2, 2);
+            PlaceImage placeImage3 = PlaceImageFixture.create(placeImageId3, 3);
+
+            List<PlaceImageSequenceUpdateRequest> requests = List.of(
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImageId1, 3),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImageId2, 2),
+                    PlaceImageSequenceUpdateRequestFixture.create(placeImageId3, 1)
+            );
+
+            given(placeImageJpaRepository.findById(placeImageId1))
+                    .willReturn(Optional.of(placeImage1));
+            given(placeImageJpaRepository.findById(placeImageId2))
+                    .willReturn(Optional.of(placeImage2));
+            given(placeImageJpaRepository.findById(placeImageId3))
+                    .willReturn(Optional.of(placeImage3));
+
+            // when
+            PlaceImageSequenceUpdateResponses result = placeImageService.updatePlaceImagesSequence(requests);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.responses().get(0).placeImageId()).isEqualTo(placeImageId3);
+                s.assertThat(result.responses().get(0).sequence()).isEqualTo(1);
+
+                s.assertThat(result.responses().get(1).placeImageId()).isEqualTo(placeImageId2);
+                s.assertThat(result.responses().get(1).sequence()).isEqualTo(2);
+
+                s.assertThat(result.responses().get(2).placeImageId()).isEqualTo(placeImageId1);
+                s.assertThat(result.responses().get(2).sequence()).isEqualTo(3);
+            });
+        }
+
+        @Test
+        void 예외_존재하지_않는_플레이스_이미지() {
+            // given
+            List<PlaceImageSequenceUpdateRequest> requests = PlaceImageSequenceUpdateRequestFixture.createList(1);
+
+            // when & then
+            assertThatThrownBy(() -> placeImageService.updatePlaceImagesSequence(requests))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 플레이스 이미지입니다.");
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -34,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class PlaceImageServiceTest {
 
-    private static final int MAX_IMAGE_SEQUENCE = 5;
+    private static final int MAX_IMAGE_COUNT = 5;
 
     @Mock
     private PlaceJpaRepository placeJpaRepository;
@@ -102,7 +102,7 @@ public class PlaceImageServiceTest {
             Long placeId = 1L;
             Place place = PlaceFixture.create(placeId);
 
-            int invalidSequence = MAX_IMAGE_SEQUENCE + 1;
+            int invalidSequence = MAX_IMAGE_COUNT + 1;
 
             given(placeJpaRepository.findById(placeId))
                     .willReturn(Optional.of(place));
@@ -114,7 +114,7 @@ public class PlaceImageServiceTest {
             // when & then
             assertThatThrownBy(() -> placeImageService.addPlaceImage(placeId, placeImageRequest))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE));
+                    .hasMessage(String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_COUNT));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
@@ -27,7 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class PlaceImageServiceTest {
+public class PlaceImageServiceTest {
 
     private static final int MAX_IMAGE_SEQUENCE = 5;
 
@@ -110,6 +111,23 @@ class PlaceImageServiceTest {
             assertThatThrownBy(() -> placeImageService.addPlaceImage(placeId, placeImageRequest))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(String.format("플레이스 이미지는 최대 %d개까지 저장할 수 있습니다.", MAX_IMAGE_SEQUENCE));
+        }
+    }
+
+    @Nested
+    class deletePlaceImageByPlaceImageId {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeImageId = 1L;
+
+            // when
+            placeImageService.deletePlaceImageByPlaceImageId(placeImageId);
+
+            // then
+            then(placeImageJpaRepository).should()
+                    .deleteById(placeImageId);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#464 

<br>

## 🛠️ 작업 내용

- 플레이스 이미지에 대한 생성(추가), 순서 변경, 삭제 api를 구현하였습니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 한번 다 리뷰했던 내용이라 가볍게 읽거나 바로 머지해도될 것 같습니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1448" height="231" alt="image" src="https://github.com/user-attachments/assets/7dfeeff9-a07b-413a-81c8-31a6743a53e1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 장소 이미지 관리 기능 추가: 장소별 이미지 등록(최대 5장), 이미지 순서 일괄 변경(요청 반영 후 오름차순 반환), 개별 이미지 삭제(멱등하게 204 응답).
- Documentation
  - API 문서 보강: 엔드포인트 및 요청/응답 스펙에 대한 설명 추가.
- Tests
  - 통합 및 단위 테스트 추가: 등록, 순서 변경, 삭제와 예외 흐름 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->