### PR TITLE
[BE] 공지사항 제목, 본문 검증 추가

### DIFF
--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -99,52 +98,6 @@ class AnnouncementControllerTest {
 
             then(fcmNotificationManager).should()
                     .sendToFestivalTopic(any(), any());
-        }
-
-        @ParameterizedTest(name = "제목 길이: {0}")
-        @ValueSource(ints = {1, 25, 50})
-        void 성공_제목_길이(int titleLength) {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            String title = "a".repeat(titleLength);
-            AnnouncementRequest request = AnnouncementRequestFixture.createWithTitle(title);
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .post("/announcements")
-                    .then()
-                    .statusCode(HttpStatus.CREATED.value())
-                    .body("title", equalTo(title));
-        }
-
-        @ParameterizedTest(name = "내용 길이: {0}")
-        @ValueSource(ints = {1, 500, 1000})
-        void 성공_내용_길이(int contentLength) {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            String content = "a".repeat(contentLength);
-            AnnouncementRequest request = AnnouncementRequestFixture.createWithContent(content);
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .post("/announcements")
-                    .then()
-                    .statusCode(HttpStatus.CREATED.value())
-                    .body("content", equalTo(content));
         }
 
         @Test
@@ -334,56 +287,6 @@ class AnnouncementControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .body("title", equalTo(request.title()))
                     .body("content", equalTo(request.content()));
-        }
-
-        @ParameterizedTest(name = "수정할 제목 길이: {0}")
-        @ValueSource(ints = {1, 25, 50})
-        void 성공_제목_길이_이하(int titleLength) {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Announcement announcement = AnnouncementFixture.create(festival);
-            announcementJpaRepository.save(announcement);
-
-            String title = "a".repeat(titleLength);
-            AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.createWithTitle(title);
-
-            // when & then
-            RestAssured
-                    .given()
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .patch("/announcements/{announcementId}", announcement.getId())
-                    .then()
-                    .statusCode(HttpStatus.OK.value())
-                    .body("title", equalTo(title));
-        }
-
-        @ParameterizedTest(name = "수정할 내용 길이: {0}")
-        @ValueSource(ints = {1, 500, 1000})
-        void 성공_내용_길이_이하(int contentLength) {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Announcement announcement = AnnouncementFixture.create(festival);
-            announcementJpaRepository.save(announcement);
-
-            String content = "a".repeat(contentLength);
-            AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.createWithContent(content);
-
-            // when & then
-            RestAssured
-                    .given()
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .patch("/announcements/{announcementId}", announcement.getId())
-                    .then()
-                    .statusCode(HttpStatus.OK.value())
-                    .body("content", equalTo(content));
         }
 
         @Test

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementFixture.java
@@ -19,6 +19,14 @@ public class AnnouncementFixture {
         return new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, DEFAULT_IS_PINNED, DEFAULT_FESTIVAL);
     }
 
+    public static Announcement createWithTitle(String title) {
+        return new Announcement(title, DEFAULT_CONTENT, DEFAULT_IS_PINNED, DEFAULT_FESTIVAL);
+    }
+
+    public static Announcement createWithContent(String content) {
+        return new Announcement(DEFAULT_TITLE, content, DEFAULT_IS_PINNED, DEFAULT_FESTIVAL);
+    }
+
     public static Announcement create(
             boolean isPinned
     ) {
@@ -52,6 +60,15 @@ public class AnnouncementFixture {
             Festival festival
     ) {
         return new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, isPinned, festival);
+    }
+
+    public static Announcement create(
+            String title,
+            String content,
+            boolean isPinned,
+            Festival festival
+    ) {
+        return new Announcement(title, content, isPinned, festival);
     }
 
     public static List<Announcement> createList(

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -51,10 +51,8 @@ class AnnouncementTest {
         }
 
         @ParameterizedTest(name = "제목: {0}")
-        @CsvSource(value = {
-                "null",
-                "'    '"
-        }, nullValues = "null")
+        @NullAndEmptySource
+        @ValueSource(strings = "    ")
         void 예외_제목_null_혹은_빈문자열(String invalidTitle) {
             assertThatThrownBy(() -> AnnouncementFixture.createWithTitle(invalidTitle))
                     .isInstanceOf(BusinessException.class)
@@ -99,10 +97,8 @@ class AnnouncementTest {
         }
 
         @ParameterizedTest(name = "내용: {0}")
-        @CsvSource(value = {
-                "null",
-                "'    '"
-        }, nullValues = "null")
+        @NullAndEmptySource
+        @ValueSource(strings = "    ")
         void 예외_내용_null_혹은_빈문자열(String invalidContent) {
             assertThatThrownBy(() -> AnnouncementFixture.createWithContent(invalidContent))
                     .isInstanceOf(BusinessException.class)

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
@@ -1,0 +1,160 @@
+package com.daedan.festabook.announcement.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.global.exception.BusinessException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AnnouncementTest {
+
+    private static final int MAX_TITLE_LENGTH = 50;
+    private static final int MAX_CONTENT_LENGTH = 1000;
+
+    @Nested
+    class validateAnnouncement {
+
+        @Test
+        void 성공() {
+            // given
+            String title = "플레이스 공지 제목";
+            String content = "플레이스 공지 내용";
+            boolean isPinned = false;
+            Festival festival = FestivalFixture.create();
+
+            // when & then
+            assertThatCode(() -> AnnouncementFixture.create(title, content, isPinned, festival))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class validateTitle {
+
+        @Test
+        void 성공() {
+            // given
+            String title = "공지사항 제목";
+
+            // when & then
+            assertThatCode(() -> AnnouncementFixture.createWithTitle(title))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest(name = "제목: {0}")
+        @CsvSource(value = {
+                "null",
+                "'    '"
+        }, nullValues = "null")
+        void 예외_제목_null_혹은_빈문자열(String invalidTitle) {
+            assertThatThrownBy(() -> AnnouncementFixture.createWithTitle(invalidTitle))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("공지사항 제목은 비어 있을 수 없습니다.");
+        }
+
+        @ParameterizedTest(name = "제목 길이: {0}")
+        @ValueSource(ints = {25, MAX_TITLE_LENGTH})
+        void 성공_제목_길이_이하(int titleLength) {
+            // given
+            String title = "a".repeat(titleLength);
+
+            // when & then
+            assertThatCode(() -> AnnouncementFixture.createWithTitle(title))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest(name = "제목 길이: {0}")
+        @ValueSource(ints = {MAX_TITLE_LENGTH + 1, 100})
+        void 예외_제목_길이_초과(int invalidTitleLength) {
+            // given
+            String title = "a".repeat(invalidTitleLength);
+
+            // when & then
+            assertThatThrownBy(() -> AnnouncementFixture.createWithTitle(title))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(String.format("공지사항 제목은 %s자를 초과할 수 없습니다.", MAX_TITLE_LENGTH));
+        }
+    }
+
+    @Nested
+    class validateContent {
+
+        @Test
+        void 성공() {
+            // given
+            String content = "공지사항 내용";
+
+            // when & then
+            assertThatCode(() -> AnnouncementFixture.createWithContent(content))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest(name = "내용: {0}")
+        @CsvSource(value = {
+                "null",
+                "'    '"
+        }, nullValues = "null")
+        void 예외_내용_null_혹은_빈문자열(String invalidContent) {
+            assertThatThrownBy(() -> AnnouncementFixture.createWithContent(invalidContent))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("공지사항 본문은 비어 있을 수 없습니다.");
+        }
+
+        @ParameterizedTest(name = "내용 길이: {0}")
+        @ValueSource(ints = {500, MAX_CONTENT_LENGTH})
+        void 성공_내용_길이_이하(int contentLength) {
+            // given
+            String content = "a".repeat(contentLength);
+
+            // when & then
+            assertThatCode(() -> AnnouncementFixture.createWithContent(content))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest(name = "내용 길이: {0}")
+        @ValueSource(ints = {MAX_CONTENT_LENGTH + 1, 2000})
+        void 예외_내용_길이_초과(int invalidContentLength) {
+            // given
+            String content = "a".repeat(invalidContentLength);
+
+            // when & then
+            assertThatThrownBy(() -> AnnouncementFixture.createWithContent(content))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(String.format("공지사항 본문은 %s자를 초과할 수 없습니다.", MAX_CONTENT_LENGTH));
+        }
+    }
+
+    @Nested
+    class validateFestival {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+
+            // when & then
+            assertThatCode(() -> AnnouncementFixture.create(festival))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 예외_축제_null() {
+            // given
+            Festival festival = null;
+
+            // when & then
+            assertThatThrownBy(() -> AnnouncementFixture.create(festival))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("축제는 null일 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementRequestFixture.java
@@ -14,6 +14,26 @@ public class AnnouncementRequestFixture {
         );
     }
 
+    public static AnnouncementRequest createWithTitle(
+            String title
+    ) {
+        return new AnnouncementRequest(
+                title,
+                DEFAULT_CONTENT,
+                DEFAULT_IS_PINNED
+        );
+    }
+
+    public static AnnouncementRequest createWithContent(
+            String content
+    ) {
+        return new AnnouncementRequest(
+                DEFAULT_TITLE,
+                content,
+                DEFAULT_IS_PINNED
+        );
+    }
+
     public static AnnouncementRequest create(
             boolean isPinned
     ) {

--- a/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementUpdateRequestFixture.java
@@ -12,6 +12,20 @@ public class AnnouncementUpdateRequestFixture {
         );
     }
 
+    public static AnnouncementUpdateRequest createWithTitle(String title) {
+        return new AnnouncementUpdateRequest(
+                title,
+                DEFAULT_CONTENT
+        );
+    }
+
+    public static AnnouncementUpdateRequest createWithContent(String content) {
+        return new AnnouncementUpdateRequest(
+                DEFAULT_TITLE,
+                content
+        );
+    }
+
     public static AnnouncementUpdateRequest create(String title, String content) {
         return new AnnouncementUpdateRequest(
                 title,


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #499 

<br>

## 🛠️ 작업 내용

- 공지사항 제목, 본문 검증 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 공지사항 입력값 유효성 검증 추가
    - 제목: 필수, 최대 50자
    - 본문: 필수, 최대 1000자
    - 축제 정보: 필수
  * 검증 실패 시 400 오류와 안내 메시지를 반환하여 잘못된 요청을 즉시 차단합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->