### PR TITLE
[FE] 공지사항 제목, 본문 제한 추가

### DIFF
--- a/frontend/src/components/modals/NoticeModal.jsx
+++ b/frontend/src/components/modals/NoticeModal.jsx
@@ -6,11 +6,26 @@ const NoticeModal = ({ notice, onSave, onClose }) => {
   const [content, setContent] = useState("");
   const [agreePush, setAgreePush] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
+
+  // 글자 수 제한 상수
+  const TITLE_MAX_LENGTH = 50;
+  const CONTENT_MAX_LENGTH = 1000;
+
   useEffect(() => {
     setTitle(notice?.title || "");
     setContent(notice?.content || "");
   }, [notice]);
+
   const handleSave = () => {
+    // 글자 수 검증
+    if (title.length > TITLE_MAX_LENGTH) {
+      alert(`제목은 ${TITLE_MAX_LENGTH}자를 초과할 수 없습니다.`);
+      return;
+    }
+    if (content.length > CONTENT_MAX_LENGTH) {
+      alert(`내용은 ${CONTENT_MAX_LENGTH}자를 초과할 수 없습니다.`);
+      return;
+    }
     onSave({ title, content, isPinned });
     onClose();
   };
@@ -23,7 +38,9 @@ const NoticeModal = ({ notice, onSave, onClose }) => {
       } else if (event.key === 'Enter' && !event.shiftKey) {
         // Shift+Enter가 아닌 Enter만 처리 (textarea에서 줄바꿈 방지)
         event.preventDefault();
-        handleSave();
+        if (!isSaveDisabled) {
+          handleSave();
+        }
       }
     };
 
@@ -34,34 +51,60 @@ const NoticeModal = ({ notice, onSave, onClose }) => {
       document.removeEventListener('keydown', handleKeyDown, true);
     };
   }, [title, content, isPinned]); // 의존성 배열에 form 데이터 추가
+
+  // 글자 수 초과 여부 확인
+  const isTitleOverflow = title.length > TITLE_MAX_LENGTH;
+  const isContentOverflow = content.length > CONTENT_MAX_LENGTH;
+
+  // 저장 버튼 비활성화 조건
+  const isSaveDisabled = (!notice && !agreePush) || isTitleOverflow || isContentOverflow;
+
   return (
     <Modal isOpen={true} onClose={onClose}>
       <h3 className="text-xl font-bold mb-6">
         {notice ? "공지사항 수정" : "새 공지사항"}
       </h3>
-      <div className="space-y-4">
+      <div className="space-y-6">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            제목
-          </label>
+          <div className="flex justify-between items-center mb-2">
+            <label className="block text-sm font-medium text-gray-700">
+              제목
+            </label>
+            <span className={`text-xs ${isTitleOverflow ? 'text-red-500 font-semibold' : 'text-gray-500'}`}>
+              {title.length}/{TITLE_MAX_LENGTH}
+            </span>
+          </div>
           <input
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="[20자 이내로 작성해주세요]"
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
+            placeholder="[50자 이내로 작성해주세요]"
+            className={`block w-full border rounded-md shadow-sm py-2 px-3 transition-colors duration-200
+              ${isTitleOverflow 
+                ? 'border-red-500 focus:ring-red-500 focus:border-red-500' 
+                : 'border-gray-300 focus:ring-indigo-500 focus:border-indigo-500'
+              }`}
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            내용
-          </label>
+          <div className="flex justify-between items-center mb-2">
+            <label className="block text-sm font-medium text-gray-700">
+              내용
+            </label>
+            <span className={`text-xs ${isContentOverflow ? 'text-red-500 font-semibold' : 'text-gray-500'}`}>
+              {content.length}/{CONTENT_MAX_LENGTH}
+            </span>
+          </div>
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
             rows="6"
-            placeholder="공지 내용을 입력해주세요."
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
+            placeholder="공지 내용을 입력해주세요. (1000자 이내)"
+            className={`block w-full border rounded-md shadow-sm py-2 px-3 transition-colors duration-200
+              ${isContentOverflow 
+                ? 'border-red-500 focus:ring-red-500 focus:border-red-500' 
+                : 'border-gray-300 focus:ring-indigo-500 focus:border-indigo-500'
+              }`}
           />
         </div>
         {!notice && (
@@ -115,12 +158,12 @@ const NoticeModal = ({ notice, onSave, onClose }) => {
           </button>
           <button
             onClick={handleSave}
+            disabled={isSaveDisabled}
             className={`font-bold py-2 px-4 rounded-lg transition-colors duration-200 ${
-              !notice && !agreePush
+              isSaveDisabled
                 ? "bg-gray-300 text-gray-400 cursor-not-allowed"
                 : "bg-gray-800 hover:bg-gray-900 text-white"
             }`}
-            disabled={!notice && !agreePush}
           >
             저장
           </button>
@@ -130,8 +173,7 @@ const NoticeModal = ({ notice, onSave, onClose }) => {
   );
 };
 
-// 공지사항 상세보기 모달
-export const NoticeDetailModal = ({ notice, onClose }) => {
+const NoticeDetailModal = ({ notice, onClose }) => {
   // ESC 키 처리
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -171,4 +213,4 @@ export const NoticeDetailModal = ({ notice, onClose }) => {
   );
 };
 
-export default NoticeModal;
+export { NoticeModal as default, NoticeDetailModal };


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #500 

<br>

## 🛠️ 작업 내용

- 공지사항 제목, 본문 제한을 추가했습니다.

<br>

## 📸 이미지 첨부 

### 변경 전

<img width="539" height="550" alt="스크린샷 2025-08-14 오후 4 31 35" src="https://github.com/user-attachments/assets/1b3dbcc1-f4fc-4076-83fa-97c6ea47aa18" />

### 변경 후
<img width="474" height="507" alt="스크린샷 2025-08-14 오후 4 55 03" src="https://github.com/user-attachments/assets/3455d17b-894f-44ab-b807-331732221184" />

<img width="473" height="508" alt="스크린샷 2025-08-14 오후 4 55 39" src="https://github.com/user-attachments/assets/be285674-89f1-43ec-92da-0d337788acd1" />

<img width="473" height="416" alt="스크린샷 2025-08-14 오후 4 56 34" src="https://github.com/user-attachments/assets/6356865d-84a7-4dcc-9e26-a52e5c33e46b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 공지 작성/수정 시 제목과 내용에 최대 글자 수 제한을 추가하고, 실시간 글자수 카운터를 표시합니다.
  - 제한을 초과하면 입력 필드를 시각적으로 강조하고 경고 메시지를 보여줍니다.
  - 제목/내용이 제한을 초과했거나 새 공지 생성 시 푸시 알림 동의가 없을 경우 “저장” 버튼이 비활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->