### PR TITLE
[BE] 학생회 페이지에서만 사용하는 api들은 인증이 완료된 사용자만 사용할 수 있도록 인증/인가 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,7 +27,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/daedan/festabook/council/domain/Council.java
+++ b/backend/src/main/java/com/daedan/festabook/council/domain/Council.java
@@ -1,0 +1,33 @@
+package com.daedan.festabook.council.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Council {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private Set<String> roles = new HashSet<>();
+}

--- a/backend/src/main/java/com/daedan/festabook/council/infrastructure/CouncilJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/council/infrastructure/CouncilJpaRepository.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.council.infrastructure;
+
+import com.daedan.festabook.council.domain.Council;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouncilJpaRepository extends JpaRepository<Council, Long> {
+
+    Optional<Council> findByUsername(String username);
+}

--- a/backend/src/main/java/com/daedan/festabook/council/service/CouncilDetailsService.java
+++ b/backend/src/main/java/com/daedan/festabook/council/service/CouncilDetailsService.java
@@ -1,0 +1,34 @@
+package com.daedan.festabook.council.service;
+
+import com.daedan.festabook.council.domain.Council;
+import com.daedan.festabook.council.infrastructure.CouncilJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouncilDetailsService implements UserDetailsService {
+
+    private final CouncilJpaRepository councilJpaRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Council council = councilJpaRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 학생회입니다.", HttpStatus.NOT_FOUND));
+
+        return User.builder()
+                .username(council.getUsername())
+                .password(council.getPassword())
+                .authorities(council.getRoles().stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .toList())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/WebMvcConfig.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -13,19 +12,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final FestivalIdArgumentResolver festivalIdArgumentResolver;
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins(
-                        "http://localhost:5173",
-                        "http://127.0.0.1:5173",
-                        "http://d3tesogs79du0m.cloudfront.net"
-                )
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
-                .allowedHeaders("*")
-                .maxAge(3600);
-    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/backend/src/main/java/com/daedan/festabook/global/security/CorsConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/CorsConfig.java
@@ -1,0 +1,32 @@
+package com.daedan.festabook.global.security;
+
+import java.util.Arrays;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(Arrays.asList(
+                "http://localhost:5173",
+                "http://127.0.0.1:5173",
+                "https://festabook.app",
+                "https://dev.festabook.app"
+        ));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(Arrays.asList("*"));
+        config.setMaxAge(3600L);
+        config.setAllowCredentials(true);
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.daedan.festabook.global.security;
+
+import com.daedan.festabook.council.service.CouncilDetailsService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CouncilDetailsService councilDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            String accessToken = extractTokenFromCookie(request.getCookies());
+
+            if (accessToken != null && jwtProvider.isValidToken(accessToken)) {
+                String username = extractUsernameFromToken(accessToken);
+
+                UserDetails userDetails = councilDetailsService.loadUserByUsername(username);
+
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            SecurityContextHolder.clearContext();
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        String accessToken = null;
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("ACCESS_TOKEN")) {
+                    accessToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        return accessToken;
+    }
+
+    private String extractUsernameFromToken(String accessToken) {
+        Claims claims = jwtProvider.extractBody(accessToken);
+        String username = claims.getSubject();
+        return username;
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/security/JwtProvider.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.daedan.festabook.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    private final Key key;
+    private final Long validityInMilliseconds;
+
+    public JwtProvider(
+            @Value("${secret.jwt-key}") final String secretKey,
+            @Value("${secret.jwt-expiration}") final Long validityInMilliseconds
+    ) {
+        this.validityInMilliseconds = validityInMilliseconds;
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+    }
+
+    public String createToken(String username, Long festivalId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .claim("festivalId", festivalId)
+
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims extractBody(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean isValidToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/SecurityConfig.java
@@ -3,12 +3,14 @@ package com.daedan.festabook.global.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.filter.CorsFilter;
 
 @Configuration
@@ -17,10 +19,41 @@ import org.springframework.web.filter.CorsFilter;
 public class SecurityConfig {
 
     private final CorsFilter corsFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         defaultSecuritySetting(http);
+        http.authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/event-dates",
+                                "/event-dates/*/events",
+                                "/announcements",
+                                "/places",
+                                "/places/*",
+                                "/places/previews",
+                                "/places/geographies",
+                                "/festivals",
+                                "/festivals/geography",
+                                "/lost-items",
+                                "/questions"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.POST,
+                                "/festivals/*/notifications",
+                                "/places/*/favorites"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.DELETE,
+                                "/festivals/notification/*",
+                                "/place/favorites/*"
+                        ).permitAll()
+                        .anyRequest().hasRole("COUNCIL")
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/backend/src/main/java/com/daedan/festabook/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.daedan.festabook.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CorsFilter corsFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        defaultSecuritySetting(http);
+        return http.build();
+    }
+
+    private void defaultSecuritySetting(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS
+                ))
+                .headers(headers -> headers.frameOptions(
+                        HeadersConfigurer.FrameOptionsConfig::disable
+                ))
+                .addFilter(corsFilter);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     include: secret
   lifecycle:
     # WAS 종료 대기 시간 15초로 설정
-    timeout-per-shutdown-phase: 15s 
+    timeout-per-shutdown-phase: 15s
 
 # Swagger
 springdoc:
@@ -30,3 +30,7 @@ firebase:
   adminsdk:
     account:
       path: classpath:firebase/firebase-adminsdk-account.json
+
+secret:
+  jwt-key: asidjiogorepgkpoergkorepgkopergkgopkregopqwrokgro
+  jwt-expiration: 9023859840385093458


### PR DESCRIPTION
## #️⃣ 이슈 번호

#451 

<br>

## 🛠️ 작업 내용

- 인증/인가 처리되지 않은 사용자의 요청에 403으로 응답하도록 기능 추가
- API는 피드백을 한번 받고 추가할 예정입니다.
