### PR TITLE
[BE] 플레이스 공지사항 생성, 수정, 삭제 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
@@ -12,6 +12,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +38,17 @@ public class PlaceAnnouncementController {
             @RequestBody PlaceAnnouncementRequest request
     ) {
         return placeAnnouncementService.createPlaceAnnouncement(placeId, request);
+    }
+
+    @DeleteMapping("/announcements/{placeAnnouncementId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 플레이스의 공지 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
+    })
+    public void deleteByPlaceAnnouncementId(
+            @PathVariable Long placeAnnouncementId
+    ) {
+        placeAnnouncementService.deleteByPlaceAnnouncementId(placeAnnouncementId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
@@ -2,6 +2,8 @@ package com.daedan.festabook.place.controller;
 
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
+import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateResponse;
 import com.daedan.festabook.place.service.PlaceAnnouncementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,6 +17,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,6 +44,19 @@ public class PlaceAnnouncementController {
             @RequestBody PlaceAnnouncementRequest request
     ) {
         return placeAnnouncementService.createPlaceAnnouncement(placeId, request);
+    }
+
+    @PatchMapping("/announcements/{placeAnnouncementId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제에 대한 플레이스 공지사항 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public PlaceAnnouncementUpdateResponse updatePlaceAnnouncement(
+            @PathVariable Long placeAnnouncementId,
+            @RequestBody PlaceAnnouncementUpdateRequest request
+    ) {
+        return placeAnnouncementService.updatePlaceAnnouncement(placeAnnouncementId, request);
     }
 
     @DeleteMapping("/announcements/{placeAnnouncementId}")

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.place.controller;
+
+import com.daedan.festabook.place.service.PlaceAnnouncementService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/places")
+@Tag(name = "플레이스 공지", description = "플레이스 공지 관련 API")
+public class PlaceAnnouncementController {
+
+    private final PlaceAnnouncementService placeAnnouncementService;
+}

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceAnnouncementController.java
@@ -1,9 +1,19 @@
 package com.daedan.festabook.place.controller;
 
+import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
 import com.daedan.festabook.place.service.PlaceAnnouncementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,4 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlaceAnnouncementController {
 
     private final PlaceAnnouncementService placeAnnouncementService;
+
+    @PostMapping("/{placeId}/announcements")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "특정 축제에 대한 플레이스 공지 생성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+    })
+    public PlaceAnnouncementResponse createPlaceAnnouncement(
+            @PathVariable("placeId") Long placeId,
+            @RequestBody PlaceAnnouncementRequest request
+    ) {
+        return placeAnnouncementService.createPlaceAnnouncement(placeId, request);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceAnnouncement.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceAnnouncement.java
@@ -46,7 +46,8 @@ public class PlaceAnnouncement {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public PlaceAnnouncement(
+    protected PlaceAnnouncement(
+            Long id,
             Place place,
             String title,
             String content
@@ -54,9 +55,23 @@ public class PlaceAnnouncement {
         validateTitle(title);
         validateContent(content);
 
+        this.id = id;
         this.place = place;
         this.title = title;
         this.content = content;
+    }
+
+    public PlaceAnnouncement(
+            Place place,
+            String title,
+            String content
+    ) {
+        this(
+                null,
+                place,
+                title,
+                content
+        );
     }
 
     private void validateTitle(String title) {

--- a/backend/src/main/java/com/daedan/festabook/place/domain/PlaceAnnouncement.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/PlaceAnnouncement.java
@@ -74,6 +74,14 @@ public class PlaceAnnouncement {
         );
     }
 
+    public void updatePlaceAnnouncement(String title, String content) {
+        validateTitle(title);
+        validateContent(content);
+
+        this.title = title;
+        this.content = content;
+    }
+
     private void validateTitle(String title) {
         if (!StringUtils.hasText(title)) {
             throw new BusinessException("플레이스 공지의 제목은 비어있을 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequest.java
@@ -1,5 +1,7 @@
 package com.daedan.festabook.place.dto;
 
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record PlaceAnnouncementRequest(
@@ -10,4 +12,12 @@ public record PlaceAnnouncementRequest(
         @Schema(description = "공지 내용", example = "우산을 챙겨주세요.")
         String content
 ) {
+
+    public PlaceAnnouncement toEntity(Place place) {
+        return new PlaceAnnouncement(
+                place,
+                title,
+                content
+        );
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequest.java
@@ -1,0 +1,13 @@
+package com.daedan.festabook.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceAnnouncementRequest(
+
+        @Schema(description = "공지 제목", example = "폭우가 내립니다.")
+        String title,
+
+        @Schema(description = "공지 내용", example = "우산을 챙겨주세요.")
+        String content
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.daedan.festabook.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceAnnouncementUpdateRequest(
+
+        @Schema(description = "플레이스 공지사항 제목", example = "긴급! 재료가 소진되었습니다.")
+        String title,
+
+        @Schema(description = "플레이스 공지사항 내용", example = "새우가 모두 소진되어 새우볶음밥은 판매하지 않습니다.")
+        String content
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.place.dto;
+
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+
+public record PlaceAnnouncementUpdateResponse(
+        String title,
+        String content
+) {
+
+    public static PlaceAnnouncementUpdateResponse from(PlaceAnnouncement placeAnnouncement) {
+        return new PlaceAnnouncementUpdateResponse(
+                placeAnnouncement.getTitle(),
+                placeAnnouncement.getContent()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateResponse.java
@@ -3,12 +3,14 @@ package com.daedan.festabook.place.dto;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 
 public record PlaceAnnouncementUpdateResponse(
+        Long id,
         String title,
         String content
 ) {
 
     public static PlaceAnnouncementUpdateResponse from(PlaceAnnouncement placeAnnouncement) {
         return new PlaceAnnouncementUpdateResponse(
+                placeAnnouncement.getId(),
                 placeAnnouncement.getTitle(),
                 placeAnnouncement.getContent()
         );

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceAnnouncementJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceAnnouncementJpaRepository.java
@@ -1,5 +1,6 @@
 package com.daedan.festabook.place.infrastructure;
 
+import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlaceAnnouncementJpaRepository extends JpaRepository<PlaceAnnouncement, Long> {
 
     List<PlaceAnnouncement> findAllByPlaceId(Long placeId);
+
+    Integer countByPlace(Place place);
 
     void deleteAllByPlaceId(Long placeId);
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -22,8 +22,7 @@ public class PlaceAnnouncementService {
 
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
-
-    @Transactional
+    
     public PlaceAnnouncementResponse createPlaceAnnouncement(Long placeId, PlaceAnnouncementRequest request) {
         Place place = getPlaceById(placeId);
 

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -5,11 +5,16 @@ import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateResponse;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +36,33 @@ public class PlaceAnnouncementService {
         return PlaceAnnouncementResponse.from(savedPlaceAnnouncement);
     }
 
+    @Transactional
+    public PlaceAnnouncementUpdateResponse updatePlaceAnnouncement(
+            Long placeAnnouncementId,
+            PlaceAnnouncementUpdateRequest request
+    ) {
+        PlaceAnnouncement placeAnnouncement = getPlaceAnnouncementById(placeAnnouncementId);
+
+        placeAnnouncement.updatePlaceAnnouncement(request.title(), request.content());
+
+        return PlaceAnnouncementUpdateResponse.from(placeAnnouncement);
+    }
+
+
+    public void deleteByPlaceAnnouncementId(Long placeAnnouncementId) {
+        placeAnnouncementJpaRepository.deleteById(placeAnnouncementId);
+    }
+
+    private Place getPlaceById(Long placeId) {
+        return placeJpaRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private PlaceAnnouncement getPlaceAnnouncementById(Long placeAnnouncementId) {
+        return placeAnnouncementJpaRepository.findById(placeAnnouncementId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스 공지입니다.", HttpStatus.NOT_FOUND));
+    }
+
     private void validatePlaceAnnouncementMaxCount(Place place) {
         Integer placeAnnouncementCount = placeAnnouncementJpaRepository.countByPlace(place);
         if (placeAnnouncementCount >= PLACE_ANNOUNCEMENT_MAX_COUNT) {
@@ -39,15 +71,5 @@ public class PlaceAnnouncementService {
                     HttpStatus.BAD_REQUEST
             );
         }
-    }
-
-    private Place getPlaceById(Long placeId) {
-        return placeJpaRepository.findById(placeId)
-                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
-    }
-
-
-    public void deleteByPlaceAnnouncementId(Long placeAnnouncementId) {
-        placeAnnouncementJpaRepository.deleteById(placeAnnouncementId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -45,4 +45,9 @@ public class PlaceAnnouncementService {
         return placeJpaRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
     }
+
+
+    public void deleteByPlaceAnnouncementId(Long placeAnnouncementId) {
+        placeAnnouncementJpaRepository.deleteById(placeAnnouncementId);
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -1,14 +1,48 @@
 package com.daedan.festabook.place.service;
 
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceAnnouncementService {
 
+    private static final int PLACE_ANNOUNCEMENT_MAX_COUNT = 3;
+
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
+
+    public PlaceAnnouncementResponse createPlaceAnnouncement(Long placeId, PlaceAnnouncementRequest request) {
+        Place place = getPlaceById(placeId);
+
+        validatePlaceAnnouncementMaxCount(place);
+
+        PlaceAnnouncement placeAnnouncement = new PlaceAnnouncement(place, request.title(), request.content());
+        PlaceAnnouncement savedPlaceAnnouncement = placeAnnouncementJpaRepository.save(placeAnnouncement);
+
+        return PlaceAnnouncementResponse.from(savedPlaceAnnouncement);
+    }
+
+    private void validatePlaceAnnouncementMaxCount(Place place) {
+        Integer placeAnnouncementCount = placeAnnouncementJpaRepository.countByPlace(place);
+        if (placeAnnouncementCount >= PLACE_ANNOUNCEMENT_MAX_COUNT) {
+            throw new BusinessException(
+                    String.format("플레이스 공지사항은 %d개까지 작성이 가능합니다.", PLACE_ANNOUNCEMENT_MAX_COUNT),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+    }
+
+    private Place getPlaceById(Long placeId) {
+        return placeJpaRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 플레이스입니다.", HttpStatus.NOT_FOUND));
+    }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -5,8 +5,6 @@ import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
-import com.daedan.festabook.global.exception.BusinessException;
-import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateResponse;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
@@ -25,6 +23,7 @@ public class PlaceAnnouncementService {
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
 
+    @Transactional
     public PlaceAnnouncementResponse createPlaceAnnouncement(Long placeId, PlaceAnnouncementRequest request) {
         Place place = getPlaceById(placeId);
 
@@ -47,7 +46,6 @@ public class PlaceAnnouncementService {
 
         return PlaceAnnouncementUpdateResponse.from(placeAnnouncement);
     }
-
 
     public void deleteByPlaceAnnouncementId(Long placeAnnouncementId) {
         placeAnnouncementJpaRepository.deleteById(placeAnnouncementId);

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -1,0 +1,14 @@
+package com.daedan.festabook.place.service;
+
+import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceAnnouncementService {
+
+    private final PlaceJpaRepository placeJpaRepository;
+    private final PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
+}

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceAnnouncementService.java
@@ -29,7 +29,7 @@ public class PlaceAnnouncementService {
 
         validatePlaceAnnouncementMaxCount(place);
 
-        PlaceAnnouncement placeAnnouncement = new PlaceAnnouncement(place, request.title(), request.content());
+        PlaceAnnouncement placeAnnouncement = request.toEntity(place);
         PlaceAnnouncement savedPlaceAnnouncement = placeAnnouncementJpaRepository.save(placeAnnouncement);
 
         return PlaceAnnouncementResponse.from(savedPlaceAnnouncement);

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -1,31 +1,18 @@
 package com.daedan.festabook.place.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.daedan.festabook.festival.domain.Festival;
-import com.daedan.festabook.festival.domain.FestivalFixture;
-import static org.hamcrest.Matchers.equalTo;
-
-import com.daedan.festabook.festival.domain.Festival;
-import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
 import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequestFixture;
-import com.daedan.festabook.place.domain.Place;
-import com.daedan.festabook.place.domain.PlaceAnnouncement;
-import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
-import com.daedan.festabook.place.domain.PlaceFixture;
-import com.daedan.festabook.place.domain.Place;
-import com.daedan.festabook.place.domain.PlaceAnnouncement;
-import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
-import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
@@ -76,7 +63,12 @@ class PlaceAnnouncementControllerTest {
             Place place = PlaceFixture.create(festival);
             placeJpaRepository.save(place);
 
-            PlaceAnnouncementRequest request = PlaceAnnouncementRequestFixture.create();
+            String expectedTitle = "공지입니다.";
+            String expectedContent = "공지내용입니다.";
+            PlaceAnnouncementRequest request = PlaceAnnouncementRequestFixture.create(
+                    expectedTitle,
+                    expectedContent
+            );
 
             int expectedFieldSize = 4;
 
@@ -90,8 +82,8 @@ class PlaceAnnouncementControllerTest {
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
                     .body("id", notNullValue())
-                    .body("title", equalTo(request.title()))
-                    .body("content", equalTo(request.content()))
+                    .body("title", equalTo(expectedTitle))
+                    .body("content", equalTo(expectedContent))
                     .body("createdAt", notNullValue());
         }
     }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -1,0 +1,35 @@
+package com.daedan.festabook.place.controller;
+
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlaceAnnouncementControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Autowired
+    private PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -1,16 +1,28 @@
 package com.daedan.festabook.place.controller;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
-import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -22,14 +34,43 @@ class PlaceAnnouncementControllerTest {
     @Autowired
     private PlaceJpaRepository placeJpaRepository;
 
-    @Autowired
-    private PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
-
     @LocalServerPort
     private int port;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+    }
+
+    @Nested
+    class createPlaceAnnouncement {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceAnnouncementRequest request = PlaceAnnouncementRequestFixture.create();
+
+            int expectedFieldSize = 4;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .post("/places/{placeId}/announcements", place.getId())
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("id", notNullValue())
+                    .body("title", equalTo(request.title()))
+                    .body("content", equalTo(request.content()))
+                    .body("createdAt", notNullValue());
+        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -9,6 +9,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceFixture;
@@ -18,6 +22,12 @@ import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
 import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
 import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequestFixture;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import io.restassured.RestAssured;
@@ -83,6 +93,39 @@ class PlaceAnnouncementControllerTest {
                     .body("title", equalTo(request.title()))
                     .body("content", equalTo(request.content()))
                     .body("createdAt", notNullValue());
+        }
+    }
+
+    @Nested
+    class updatePlaceAnnouncement {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Place place = PlaceFixture.create(festival);
+            placeJpaRepository.save(place);
+
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create(place);
+            placeAnnouncementJpaRepository.save(placeAnnouncement);
+
+            int expectedFieldSize = 2;
+
+            PlaceAnnouncementUpdateRequest request = PlaceAnnouncementUpdateRequestFixture.create("수정된 공지", "수정된 내용");
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .patch("/places/announcements/{placeAnnouncementId}", placeAnnouncement.getId())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("title", equalTo(request.title()))
+                    .body("content", equalTo(request.content()));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceAnnouncementControllerTest.java
@@ -103,7 +103,7 @@ class PlaceAnnouncementControllerTest {
             PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create(place);
             placeAnnouncementJpaRepository.save(placeAnnouncement);
 
-            int expectedFieldSize = 2;
+            int expectedFieldSize = 3;
 
             PlaceAnnouncementUpdateRequest request = PlaceAnnouncementUpdateRequestFixture.create("수정된 공지", "수정된 내용");
 
@@ -116,6 +116,7 @@ class PlaceAnnouncementControllerTest {
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("size()", equalTo(expectedFieldSize))
+                    .body("id", notNullValue())
                     .body("title", equalTo(request.title()))
                     .body("content", equalTo(request.content()));
         }

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementFixture.java
@@ -14,6 +14,15 @@ public class PlaceAnnouncementFixture {
         );
     }
 
+    public static PlaceAnnouncement create(Long id) {
+        return new PlaceAnnouncement(
+                id,
+                DEFAULT_PLACE,
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT
+        );
+    }
+
     public static PlaceAnnouncement create(
             Place place
     ) {

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -47,12 +48,11 @@ class PlaceAnnouncementTest {
                     .doesNotThrowAnyException();
         }
 
-        @Test
-        void 예외_플레이스_공지_제목_null() {
-            // given
-            String title = null;
-
-            // when & then
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "    ")
+        void 예외_플레이스_공지_제목_null_공백(String title) {
+            // given & when & then
             assertThatThrownBy(() -> PlaceAnnouncementFixture.createWithTitle(title))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("플레이스 공지의 제목은 비어있을 수 없습니다.");
@@ -67,17 +67,6 @@ class PlaceAnnouncementTest {
             assertThatThrownBy(() -> PlaceAnnouncementFixture.createWithTitle(title))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("플레이스 공지 제목의 길이는 %d자를 초과할 수 없습니다.", MAX_TITLE_LENGTH);
-        }
-
-        @Test
-        void 예외_플레이스_공지_제목_공백() {
-            // given
-            String title = " ";
-
-            // when & then
-            assertThatThrownBy(() -> PlaceAnnouncementFixture.createWithTitle(title))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("플레이스 공지의 제목은 비어있을 수 없습니다.");
         }
     }
 
@@ -154,36 +143,21 @@ class PlaceAnnouncementTest {
                     .doesNotThrowAnyException();
         }
 
-        @Test
-        void 예외_플레이스_공지_제목_null() {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "    ")
+        void 예외_플레이스_공지_제목_null_공백(String invalidTitle) {
             // given
             PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
 
             String content = "수정된 내용";
-
-            String invalidTitle = null;
 
             // when & then
             assertThatThrownBy(() -> placeAnnouncement.updatePlaceAnnouncement(invalidTitle, content))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("플레이스 공지의 제목은 비어있을 수 없습니다.");
         }
-
-        @Test
-        void 예외_플레이스_공지_제목_공백() {
-            // given
-            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
-
-            String content = "수정된 내용";
-
-            String invalidTitle = " ";
-
-            // when & then
-            assertThatThrownBy(() -> placeAnnouncement.updatePlaceAnnouncement(invalidTitle, content))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("플레이스 공지의 제목은 비어있을 수 없습니다.");
-        }
-
+        
         @ParameterizedTest
         @ValueSource(ints = {1, 100, 200, MAX_CONTENT_LENGTH})
         void 성공_플레이스_공지_내용_경계값(int length) {

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceAnnouncementTest.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.place.domain;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -112,6 +113,118 @@ class PlaceAnnouncementTest {
 
             // when & then
             assertThatThrownBy(() -> PlaceAnnouncementFixture.createWithContent(content))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("플레이스 공지 내용의 길이는 %d자를 초과할 수 없습니다.", MAX_CONTENT_LENGTH);
+        }
+    }
+
+    @Nested
+    class updatePlaceAnnouncement {
+
+        @Test
+        void 성공() {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String title = "수정된 공지";
+            String content = "수정된 내용";
+
+            // when
+            placeAnnouncement.updatePlaceAnnouncement(title, content);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(placeAnnouncement.getTitle()).isEqualTo(title);
+                s.assertThat(placeAnnouncement.getContent()).isEqualTo(content);
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 5, 10, MAX_TITLE_LENGTH})
+        void 성공_플레이스_공지_제목_경계값(int length) {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String content = "수정된 내용";
+
+            String title = "m".repeat(length);
+
+            // when & then
+            assertThatCode(() -> placeAnnouncement.updatePlaceAnnouncement(title, content))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 예외_플레이스_공지_제목_null() {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String content = "수정된 내용";
+
+            String invalidTitle = null;
+
+            // when & then
+            assertThatThrownBy(() -> placeAnnouncement.updatePlaceAnnouncement(invalidTitle, content))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("플레이스 공지의 제목은 비어있을 수 없습니다.");
+        }
+
+        @Test
+        void 예외_플레이스_공지_제목_공백() {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String content = "수정된 내용";
+
+            String invalidTitle = " ";
+
+            // when & then
+            assertThatThrownBy(() -> placeAnnouncement.updatePlaceAnnouncement(invalidTitle, content))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("플레이스 공지의 제목은 비어있을 수 없습니다.");
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 100, 200, MAX_CONTENT_LENGTH})
+        void 성공_플레이스_공지_내용_경계값(int length) {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String title = "수정된 공지";
+
+            String content = "m".repeat(length);
+
+            // when & then
+            assertThatCode(() -> placeAnnouncement.updatePlaceAnnouncement(title, content))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 예외_플레이스_공지_내용_최대_null() {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String title = "수정된 공지";
+
+            String invalidContent = null;
+
+            // when & then
+            assertThatThrownBy(() -> placeAnnouncement.updatePlaceAnnouncement(title, invalidContent))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("플레이스 공지 내용은 null일 수 없습니다.", MAX_CONTENT_LENGTH);
+        }
+
+        @Test
+        void 예외_플레이스_공지_내용_최대_길이_초과() {
+            // given
+            PlaceAnnouncement placeAnnouncement = PlaceAnnouncementFixture.create();
+
+            String title = "수정된 공지";
+
+            String invalidContent = "m".repeat(MAX_CONTENT_LENGTH + 1);
+
+            // when & then
+            assertThatThrownBy(() -> placeAnnouncement.updatePlaceAnnouncement(title, invalidContent))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("플레이스 공지 내용의 길이는 %d자를 초과할 수 없습니다.", MAX_CONTENT_LENGTH);
         }

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequestFixture.java
@@ -1,0 +1,14 @@
+package com.daedan.festabook.place.dto;
+
+public class PlaceAnnouncementRequestFixture {
+
+    private static final String DEFAULT_TITLE = "공지 제목입니다. 확인해주세요.";
+    private static final String DEFAULT_CONTENT = "공지 내용입니다.";
+
+    public static PlaceAnnouncementRequest create() {
+        return new PlaceAnnouncementRequest(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceAnnouncementRequestFixture.java
@@ -11,4 +11,14 @@ public class PlaceAnnouncementRequestFixture {
                 DEFAULT_CONTENT
         );
     }
+
+    public static PlaceAnnouncementRequest create(
+            String title,
+            String content
+    ) {
+        return new PlaceAnnouncementRequest(
+                title,
+                content
+        );
+    }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/place/dto/PlaceAnnouncementUpdateRequestFixture.java
@@ -1,0 +1,14 @@
+package com.daedan.festabook.place.dto;
+
+public class PlaceAnnouncementUpdateRequestFixture {
+
+    public static PlaceAnnouncementUpdateRequest create(
+            String title,
+            String content
+    ) {
+        return new PlaceAnnouncementUpdateRequest(
+                title,
+                content
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
@@ -12,6 +12,8 @@ import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequestFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
+import static org.mockito.BDDMockito.then;
+
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
 import java.util.Optional;
@@ -84,6 +86,23 @@ class PlaceAnnouncementServiceTest {
             assertThatThrownBy(() -> placeAnnouncementService.createPlaceAnnouncement(place.getId(), request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(String.format("플레이스 공지사항은 %d개까지 작성이 가능합니다.", PLACE_ANNOUNCEMENT_MAX_COUNT));
+        }
+    }
+
+    @Nested
+    class deleteByPlaceAnnouncementId {
+
+        @Test
+        void 성공() {
+            // given
+            Long placeAnnouncementId = 1L;
+
+            // when
+            placeAnnouncementService.deleteByPlaceAnnouncementId(placeAnnouncementId);
+
+            // then
+            then(placeAnnouncementJpaRepository).should()
+                    .deleteById(placeAnnouncementId);
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
@@ -1,0 +1,24 @@
+package com.daedan.festabook.place.service;
+
+import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
+import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlaceAnnouncementServiceTest {
+
+    @Mock
+    private PlaceJpaRepository placeJpaRepository;
+
+    @Mock
+    private PlaceAnnouncementJpaRepository placeAnnouncementJpaRepository;
+
+    @InjectMocks
+    private PlaceAnnouncementService placeAnnouncementService;
+}

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
@@ -1,9 +1,24 @@
 package com.daedan.festabook.place.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.domain.PlaceFixture;
+import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
+import com.daedan.festabook.place.dto.PlaceAnnouncementRequestFixture;
+import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
 import com.daedan.festabook.place.infrastructure.PlaceAnnouncementJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -13,6 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PlaceAnnouncementServiceTest {
 
+    private static final int PLACE_ANNOUNCEMENT_MAX_COUNT = 3;
+
     @Mock
     private PlaceJpaRepository placeJpaRepository;
 
@@ -21,4 +38,52 @@ class PlaceAnnouncementServiceTest {
 
     @InjectMocks
     private PlaceAnnouncementService placeAnnouncementService;
+
+    @Nested
+    class createPlaceAnnouncement {
+
+        @Test
+        void 성공() {
+            // given
+            Place place = PlaceFixture.create();
+
+            PlaceAnnouncementRequest request = PlaceAnnouncementRequestFixture.create();
+
+            PlaceAnnouncement placeAnnouncement = new PlaceAnnouncement(place, request.title(), request.content());
+
+            given(placeJpaRepository.findById(place.getId()))
+                    .willReturn(Optional.of(place));
+            given(placeAnnouncementJpaRepository.countByPlace(place))
+                    .willReturn(0);
+            given(placeAnnouncementJpaRepository.save(any()))
+                    .willReturn(placeAnnouncement);
+
+            // when
+            PlaceAnnouncementResponse result = placeAnnouncementService.createPlaceAnnouncement(place.getId(), request);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.title()).isEqualTo(request.title());
+                s.assertThat(result.content()).isEqualTo(request.content());
+            });
+        }
+
+        @Test
+        void 예외_공지_최대_개수_초과() {
+            // given
+            Place place = PlaceFixture.create();
+
+            PlaceAnnouncementRequest request = PlaceAnnouncementRequestFixture.create();
+
+            given(placeJpaRepository.findById(place.getId()))
+                    .willReturn(Optional.of(place));
+            given(placeAnnouncementJpaRepository.countByPlace(place))
+                    .willReturn(PLACE_ANNOUNCEMENT_MAX_COUNT);
+
+            // when & then
+            assertThatThrownBy(() -> placeAnnouncementService.createPlaceAnnouncement(place.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(String.format("플레이스 공지사항은 %d개까지 작성이 가능합니다.", PLACE_ANNOUNCEMENT_MAX_COUNT));
+        }
+    }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceAnnouncementServiceTest.java
@@ -4,23 +4,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
 import com.daedan.festabook.place.domain.PlaceFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementRequestFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementResponse;
-import static org.mockito.BDDMockito.then;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.BDDMockito.given;
-
-import com.daedan.festabook.global.exception.BusinessException;
-import com.daedan.festabook.place.domain.PlaceAnnouncement;
-import com.daedan.festabook.place.domain.PlaceAnnouncementFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequest;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateRequestFixture;
 import com.daedan.festabook.place.dto.PlaceAnnouncementUpdateResponse;
@@ -161,6 +154,19 @@ class PlaceAnnouncementServiceTest {
             // then
             then(placeAnnouncementJpaRepository).should()
                     .deleteById(placeAnnouncementId);
+        }
+
+        @Test
+        void 성공_존재하지_않는_플레이스_공지() {
+            // given
+            Long invalidPlaceAnnouncementId = 0L;
+
+            // when
+            placeAnnouncementService.deleteByPlaceAnnouncementId(invalidPlaceAnnouncementId);
+
+            // then
+            then(placeAnnouncementJpaRepository).should()
+                    .deleteById(invalidPlaceAnnouncementId);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#463 

<br>

## 🛠️ 작업 내용

- 플레이스 공지사항 생성 API
- 플레이스 공지사항 수정 API
- 플레이스 공지사항 삭제 API

<br>

## 🙇🏻 중점 리뷰 요청

- 리뷰를 한번씩 했던 부분이라, 가볍게 보시면 될 것 같습니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1389" height="234" alt="image" src="https://github.com/user-attachments/assets/17ef4a1b-4db7-4624-b52a-5dfed0389ce2" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 장소 공지사항 생성·수정·삭제 API를 추가했습니다 (POST /places/{placeId}/announcements, PATCH/DELETE /places/announcements/{id}).
  - 공지 생성·수정 기능과 엔티티 변환을 지원하며, 장소별 공지 최대 3개 제약을 적용합니다.
- 문서
  - Swagger/OpenAPI 주석과 예시 값을 추가해 엔드포인트 설명을 보강했습니다.
- 테스트
  - 컨트롤러·서비스의 단위 및 통합 테스트와 테스트 픽스처를 추가해 흐름 및 경계·예외 케이스를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->