### PR TITLE
[AN] 학교로 돌아가기 버튼 로직 수정

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapManager.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapManager.kt
@@ -133,7 +133,10 @@ class MapManager(
     private fun isExceededMaxLength(): Boolean {
         val currentPosition = map.cameraPosition.target
         val zoomWeight = map.cameraPosition.zoom.zoomWeight()
-        return currentPosition.distanceTo(initialCenter) > maxLength * zoomWeight
+        return currentPosition.distanceTo(initialCenter) >
+            (maxLength * zoomWeight).coerceAtLeast(
+                maxLength,
+            )
     }
 
     fun clearMapManager() {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/515

<br>

## 🛠️ 작업 내용

- 학교로 돌아가기 버튼의 로직을 수정하였습니다 

<br>

## 🙇🏻 중점 리뷰 요청

- UT에서 사용자의 줌 배율을 확인한 결과, 생각보다 확대해서 보는 경향이 강했습니다. 
하지만 기존 학교로 돌아가기 버튼은 줌 배율에 따라 가중치를 두어, 너무 확대를 하게 된다면 
사용자가 학교 위치 내부에 있음에도 버튼이 뜨는 문제가 발생했습니다 

줌 배율에 따른 가중치를 사용하되, Math.max()을 사용하여
최소 특정 거리까지 거리를 넘겨야 학교로 돌아가기 버튼을 넣도록 하는 방향으로 구현해보았습니다

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
