### PR TITLE
[BE] 로그를 JSON 형태로 구조화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Logging
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+
     // Dev Tools
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
@@ -1,5 +1,9 @@
 package com.daedan.festabook.global.logging;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import com.daedan.festabook.global.logging.dto.MethodCallMessage;
+import com.daedan.festabook.global.logging.dto.MethodEndMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -25,10 +29,8 @@ public class LoggingAspect {
         String className = joinPoint.getSignature().getDeclaringTypeName();
         String methodName = joinPoint.getSignature().getName();
 
-        log.info("[Method Call] | Class: {} | Method: {}",
-                className,
-                methodName
-        );
+        MethodCallMessage methodCallMessage = MethodCallMessage.from(className, methodName);
+        log.info("", kv("event", methodCallMessage));
 
         Object result = null;
         try {
@@ -37,11 +39,8 @@ public class LoggingAspect {
             long end = System.currentTimeMillis();
             long executionTime = end - start;
 
-            log.info("[Method End] | Class: {} | Method: {} | Execution Time: {}ms",
-                    className,
-                    methodName,
-                    executionTime
-            );
+            MethodEndMessage methodEndMessage = MethodEndMessage.from(className, methodName, executionTime);
+            log.info("", kv("event", methodEndMessage));
         }
 
         return result;

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiCallMessage.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiCallMessage.java
@@ -1,0 +1,22 @@
+package com.daedan.festabook.global.logging.dto;
+
+public record ApiCallMessage(
+        String type,
+        String httpMethod,
+        String queryString,
+        String uri
+) {
+
+    public static ApiCallMessage from(
+            String httpMethod,
+            String queryString,
+            String uri
+    ) {
+        return new ApiCallMessage(
+                "API Call",
+                httpMethod,
+                queryString,
+                uri
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiEndMessage.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiEndMessage.java
@@ -3,13 +3,13 @@ package com.daedan.festabook.global.logging.dto;
 public record ApiEndMessage(
         String type,
         int httpStatusCode,
-        String requestBody,
+        Object requestBody,
         long executionTime
 ) {
 
     public static ApiEndMessage from(
             int httpStatusCode,
-            String requestBody,
+            Object requestBody,
             long executionTime
     ) {
         return new ApiEndMessage(

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiEndMessage.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiEndMessage.java
@@ -1,0 +1,22 @@
+package com.daedan.festabook.global.logging.dto;
+
+public record ApiEndMessage(
+        String type,
+        int httpStatusCode,
+        String requestBody,
+        long executionTime
+) {
+
+    public static ApiEndMessage from(
+            int httpStatusCode,
+            String requestBody,
+            long executionTime
+    ) {
+        return new ApiEndMessage(
+                "API End",
+                httpStatusCode,
+                requestBody,
+                executionTime
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/MethodCallMessage.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/MethodCallMessage.java
@@ -1,0 +1,16 @@
+package com.daedan.festabook.global.logging.dto;
+
+public record MethodCallMessage(
+        String type,
+        String className,
+        String methodName
+) {
+
+    public static MethodCallMessage from(String className, String methodName) {
+        return new MethodCallMessage(
+                "Method Call",
+                className,
+                methodName
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/MethodEndMessage.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/MethodEndMessage.java
@@ -1,0 +1,18 @@
+package com.daedan.festabook.global.logging.dto;
+
+public record MethodEndMessage(
+        String type,
+        String className,
+        String methodName,
+        long executionTime
+) {
+
+    public static MethodEndMessage from(String className, String methodName, long executionTime) {
+        return new MethodEndMessage(
+                "Method End",
+                className,
+                methodName,
+                executionTime
+        );
+    }
+}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -23,7 +23,9 @@
     <!-- 로컬 및 테스트 환경: 콘솔 JSON 출력 -->
     <springProfile name="!prod">
         <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+            </encoder>
         </appender>
 
         <root level="INFO">

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,43 +1,33 @@
 <configuration>
 
-    <!-- 공통 로그 패턴 -->
-    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId}] - %msg%n"/>
-
-    <!-- PROD 전용: 로그를 파일에 기록 -->
+    <!-- PROD 전용: 파일 로그를 JSON 형식으로 기록 -->
     <springProfile name="prod">
         <property name="LOG_FILE_PATH" value="/home/ubuntu/2025-festabook/spring-logs"/>
 
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOG_FILE_PATH}/application.log</file>
+        <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_FILE_PATH}/application.json</file>
 
             <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOG_FILE_PATH}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <fileNamePattern>${LOG_FILE_PATH}/application.%d{yyyy-MM-dd}.json</fileNamePattern>
                 <maxHistory>7</maxHistory>
             </rollingPolicy>
 
-            <encoder>
-                <pattern>${LOG_PATTERN}</pattern>
-            </encoder>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         </appender>
 
         <root level="INFO">
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="JSON_FILE"/>
         </root>
     </springProfile>
 
-    <!-- 로컬 및 테스트 환경용: 콘솔 출력 @formatter:off-->
+    <!-- 로컬 및 테스트 환경: 콘솔 JSON 출력 -->
     <springProfile name="!prod">
-        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder>
-                <pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %green([%thread]) %cyan(%logger{36}) [%X{traceId}] - %msg%n
-                </pattern>
-            </encoder>
+        <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         </appender>
 
-
         <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="JSON_CONSOLE"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #이슈번호, #이슈번호

<br>

## 🛠️ 작업 내용

- 로그를 JSON으로 구조화
- logstash logback encoder 의존성 추가: 로그를 JSON으로 인코딩
- 로그 메시지 객체를 추가
- requestBody도 json으로 구조화하여 응답

<br>

## 🙇🏻 중점 리뷰 요청

- 로그 메시지를 json으로 작성하기 위해서, 클래스를 정의해주었는데 패키지 명을 dto로 네이밍하였습니다. logger에게 정보를 전달하는 dto라고 생각하고 네이밍을 했는데, 일반적인 dto와 달라서 고민이 됩니다. 의견 부탁드립니다.
- 지금 console 로그도 json으로 출력되고 있는데 이게 보기 편한지 기존이 편한지 잘 모르겠습니다. 사진으로 추가해두었으니, 확인하고 의견 부탁드립니다.

<br>

## 📸 로그 형태

**PlaceAnnouncement 생성 로그**
```json
[
  {
    "timestamp": "2025-08-17T15:46:08.448386+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "API Call",
      "httpMethod": "POST",
      "queryString": null,
      "uri": "/announcements"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.459451+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method Call",
      "className": "org.springframework.data.repository.CrudRepository",
      "methodName": "existsById"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.493704+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method End",
      "className": "org.springframework.data.repository.CrudRepository",
      "methodName": "existsById",
      "executionTime": 34
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.514303+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method Call",
      "className": "com.daedan.festabook.announcement.controller.AnnouncementController",
      "methodName": "createAnnouncement"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.514664+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method Call",
      "className": "com.daedan.festabook.announcement.service.AnnouncementService",
      "methodName": "createAnnouncement"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.515125+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method Call",
      "className": "com.daedan.festabook.announcement.infrastructure.AnnouncementJpaRepository",
      "methodName": "countByFestivalIdAndIsPinnedTrue"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.524924+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method End",
      "className": "com.daedan.festabook.announcement.infrastructure.AnnouncementJpaRepository",
      "methodName": "countByFestivalIdAndIsPinnedTrue",
      "executionTime": 9
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.525386+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method Call",
      "className": "org.springframework.data.repository.CrudRepository",
      "methodName": "findById"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.535156+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method End",
      "className": "org.springframework.data.repository.CrudRepository",
      "methodName": "findById",
      "executionTime": 10
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.535455+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method Call",
      "className": "org.springframework.data.repository.CrudRepository",
      "methodName": "save"
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.545185+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method End",
      "className": "org.springframework.data.repository.CrudRepository",
      "methodName": "save",
      "executionTime": 10
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.546018+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method End",
      "className": "com.daedan.festabook.announcement.service.AnnouncementService",
      "methodName": "createAnnouncement",
      "executionTime": 32
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.546576+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "Method End",
      "className": "com.daedan.festabook.announcement.controller.AnnouncementController",
      "methodName": "createAnnouncement",
      "executionTime": 32
    },
    "thread_name": "http-nio-auto-1-exec-1"
  },
  {
    "timestamp": "2025-08-17T15:46:08.556591+09:00",
    "traceId": "c6588097-0245-406f-8bf1-81aa27722cd0",
    "event": {
      "type": "API End",
      "httpStatusCode": 201,
      "requestBody": {
        "title": "폭우가 내립니다.",
        "content": "우산을 챙겨주세요.",
        "isPinned": true
      },
      "executionTime": 106
    },
    "thread_name": "http-nio-auto-1-exec-1"
  }
]
```

## 콘솔 JSON 로그

<img width="1121" height="847" alt="image" src="https://github.com/user-attachments/assets/13d9cb41-50ea-46e7-9e45-f1d5325ce334" />
