### PR TITLE
[AN] 앱 초기 진입 시 분기 처리

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,11 +19,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Festabook"
         tools:targetApi="31">
+
         <activity
             android:name=".presentation.splash.SplashActivity"
             android:exported="true"
             android:theme="@style/Theme.Festabook.Splash">
-
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
 
         <activity
@@ -39,10 +43,7 @@
             android:exported="true"
             android:screenOrientation="portrait"
             tools:ignore="DiscouragedApi, LockedOrientationActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+
         </activity>
         <activity
             android:name=".presentation.placeDetail.PlaceDetailActivity"

--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -7,6 +7,8 @@ import com.daedan.festabook.data.datasource.local.DeviceLocalDataSource
 import com.daedan.festabook.data.datasource.local.DeviceLocalDataSourceImpl
 import com.daedan.festabook.data.datasource.local.FcmDataSource
 import com.daedan.festabook.data.datasource.local.FcmDataSourceImpl
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSourceImpl
 import com.daedan.festabook.data.datasource.local.FestivalNotificationLocalDataSource
 import com.daedan.festabook.data.datasource.local.FestivalNotificationLocalDataSourceImpl
 import com.daedan.festabook.data.datasource.remote.device.DeviceDataSource
@@ -73,6 +75,10 @@ class AppContainer(
 
     private val festivalNotificationLocalDataSource: FestivalNotificationLocalDataSource by lazy {
         FestivalNotificationLocalDataSourceImpl(prefs)
+    }
+
+    val festivalLocalDataSource: FestivalLocalDataSource by lazy {
+        FestivalLocalDataSourceImpl(prefs)
     }
 
     private val scheduleDataSource: ScheduleDataSource by lazy {

--- a/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
+++ b/android/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import com.daedan.festabook.data.service.api.ApiClient
 import com.daedan.festabook.logging.FirebaseAnalyticsTree
 import com.daedan.festabook.service.NotificationHelper
 import com.daedan.festabook.util.CrashlyticsTree
@@ -21,6 +22,7 @@ class FestaBookApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        initializeApiClient()
         setupTimber()
         setupNaverSdk()
         setupNotificationChannel()
@@ -47,7 +49,7 @@ class FestaBookApp : Application() {
         if (BuildConfig.DEBUG) {
             plantDebugTimberTree()
         } else {
-          plantInfoTimberTree()
+            plantInfoTimberTree()
         }
         Timber.plant(CrashlyticsTree())
     }
@@ -75,7 +77,23 @@ class FestaBookApp : Application() {
     }
 
     private fun setGlobalExceptionHandler() {
-        val defaultExceptionHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler(FestabookGlobalExceptionHandler(this, defaultExceptionHandler))
+        val defaultExceptionHandler: Thread.UncaughtExceptionHandler? =
+            Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler(
+            FestabookGlobalExceptionHandler(
+                this,
+                defaultExceptionHandler,
+            ),
+        )
+    }
+
+    private fun initializeApiClient() {
+        runCatching {
+            ApiClient.initialize(this)
+        }.onSuccess {
+            Timber.d("API 클라이언트 초기화 완료")
+        }.onFailure { e ->
+            Timber.e(e, "FestabookApp: API 클라이언트 초기화 실패 ${e.message}")
+        }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.data.datasource.local
+
+interface FestivalLocalDataSource {
+    fun saveFestivalId(festivalId: Long)
+
+    fun getFestivalId(): Long?
+
+    companion object {
+        const val KEY_FESTIVAL_ID = "festival_id"
+        const val DEFAULT_FESTIVAL_ID = -1L
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.daedan.festabook.data.datasource.local
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource.Companion.DEFAULT_FESTIVAL_ID
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource.Companion.KEY_FESTIVAL_ID
+import timber.log.Timber
+
+class FestivalLocalDataSourceImpl(
+    private val prefs: SharedPreferences,
+) : FestivalLocalDataSource {
+    override fun saveFestivalId(festivalId: Long) {
+        Timber.d("festivalLocalDataSource - saveFestivalId: $festivalId")
+        prefs.edit { putLong(KEY_FESTIVAL_ID, festivalId) }
+    }
+
+    override fun getFestivalId(): Long? {
+        val id = prefs.getLong(KEY_FESTIVAL_ID, DEFAULT_FESTIVAL_ID)
+        Timber.d("festivalLocalDataSource - getFestivalId: $id")
+        return if (id == DEFAULT_FESTIVAL_ID) null else id
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/data/service/api/FestaBookAuthInterceptor.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/api/FestaBookAuthInterceptor.kt
@@ -1,19 +1,24 @@
 package com.daedan.festabook.data.service.api
 
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
 import okhttp3.Interceptor
 import okhttp3.Response
+import timber.log.Timber
 
 class FestaBookAuthInterceptor(
-    private val festivalId: String,
+    private val festivalLocalDataSource: FestivalLocalDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        val requestWithHeader =
-            originalRequest
-                .newBuilder()
-                .addHeader("festival", festivalId)
-                .build()
+        val festivalId = festivalLocalDataSource.getFestivalId()
+        val requestBuilder = originalRequest.newBuilder()
 
+        if (festivalId != null) {
+            Timber.d("festivalId : $festivalId")
+            requestBuilder.addHeader("festival", festivalId.toString())
+        }
+
+        val requestWithHeader = requestBuilder.build()
         return chain.proceed(requestWithHeader)
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreActivity.kt
@@ -111,24 +111,16 @@ class ExploreActivity :
         binding.tilSearchInputLayout.setEndIconOnClickListener {
             val query = binding.etSearchText.text.toString()
             val currentState = viewModel.searchState.value
+            viewModel.search(query)
 
             when (currentState) {
-                is SearchUiState.Idle -> {
-                    viewModel.search(query)
-                }
-
-                is SearchUiState.Loading -> {}
+                is SearchUiState.Idle -> Unit
+                is SearchUiState.Loading -> Unit
                 is SearchUiState.Success -> {
                     viewModel.onNavigateIconClicked()
                 }
-
-                is SearchUiState.Error -> {
-                    viewModel.search(query)
-                }
-
-                null -> {
-                    viewModel.search(query)
-                }
+                is SearchUiState.Error -> Unit
+                null -> Unit
             }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
@@ -153,7 +153,7 @@ class PlaceMapFragment :
         childFragments.forEach { fragment ->
             (fragment as? OnMenuItemReClickListener)?.onMenuItemReClick()
         }
-        mapManager.moveToPosition()
+        mapManager?.moveToPosition()
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/NavigationState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/NavigationState.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.splash
+
+sealed interface NavigationState {
+    data object NavigateToExplore : NavigationState
+
+    data class NavigateToMain(
+        val festivalId: Long,
+    ) : NavigationState
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashActivity.kt
@@ -21,7 +21,6 @@ class SplashActivity : AppCompatActivity() {
         setContentView(R.layout.activity_splash)
 
         setupObserver()
-        viewModel.checkFestivalId()
     }
 
     private fun setupObserver() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashActivity.kt
@@ -2,27 +2,45 @@ package com.daedan.festabook.presentation.splash
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.lifecycleScope
 import com.daedan.festabook.R
+import com.daedan.festabook.presentation.explore.ExploreActivity
 import com.daedan.festabook.presentation.main.MainActivity
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 class SplashActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
-        super.onCreate(savedInstanceState)
+    private val viewModel: SplashViewModel by viewModels { SplashViewModel.FACTORY }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen().setKeepOnScreenCondition {
+            !viewModel.isValidationComplete.value!!
+        }
+
+        super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
 
-        lifecycleScope.launch {
-            delay(500)
+        setupObserver()
+        viewModel.checkFestivalId()
+    }
 
-            val intent = Intent(this@SplashActivity, MainActivity::class.java)
-            startActivity(intent)
-            finish()
+    private fun setupObserver() {
+        viewModel.navigationState.observe(this) { state ->
+            when (state) {
+                is NavigationState.NavigateToExplore -> {
+                    // ExploreActivity로 이동
+                    val intent = Intent(this@SplashActivity, ExploreActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                }
+
+                is NavigationState.NavigateToMain -> {
+                    // MainActivity로 이동
+                    val intent = Intent(this@SplashActivity, MainActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashActivity.kt
@@ -14,7 +14,7 @@ class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().setKeepOnScreenCondition {
-            !viewModel.isValidationComplete.value!!
+            viewModel.isValidationComplete.value != true
         }
 
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashViewModel.kt
@@ -4,11 +4,17 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.daedan.festabook.FestaBookApp
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
 import com.daedan.festabook.presentation.common.SingleLiveData
+import timber.log.Timber
 
-class SplashViewModel : ViewModel() {
+class SplashViewModel(
+    private val festivalLocalDataSource: FestivalLocalDataSource,
+) : ViewModel() {
     private val _navigationState = SingleLiveData<NavigationState>()
     val navigationState: LiveData<NavigationState> = _navigationState
 
@@ -16,24 +22,27 @@ class SplashViewModel : ViewModel() {
     val isValidationComplete: LiveData<Boolean> = _isValidationComplete
 
     fun checkFestivalId() {
-        // sharedPreference에서 festivalId 가져오기
-        val festivalId = 1L
+        val festivalId = festivalLocalDataSource.getFestivalId()
+        Timber.d("festival ID : $festivalId")
 
         if (festivalId == null) {
-            _navigationState.postValue(NavigationState.NavigateToExplore)
+            _navigationState.setValue(NavigationState.NavigateToExplore)
         } else {
-            // festival id을 intercepter에 넣어주기
-            _navigationState.postValue(NavigationState.NavigateToMain(festivalId))
+            _navigationState.setValue(NavigationState.NavigateToMain(festivalId))
         }
 
-        _isValidationComplete.postValue(true)
+        _isValidationComplete.value = true
     }
 
     companion object {
         val FACTORY: ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
-                    SplashViewModel()
+                    val festivalLocalDataSource =
+                        (this[APPLICATION_KEY] as FestaBookApp).appContainer.festivalLocalDataSource
+                    SplashViewModel(
+                        festivalLocalDataSource,
+                    )
                 }
             }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,40 @@
+package com.daedan.festabook.presentation.splash
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.daedan.festabook.presentation.common.SingleLiveData
+
+class SplashViewModel : ViewModel() {
+    private val _navigationState = SingleLiveData<NavigationState>()
+    val navigationState: LiveData<NavigationState> = _navigationState
+
+    private val _isValidationComplete = MutableLiveData(false)
+    val isValidationComplete: LiveData<Boolean> = _isValidationComplete
+
+    fun checkFestivalId() {
+        // sharedPreference에서 festivalId 가져오기
+        val festivalId = 1L
+
+        if (festivalId == null) {
+            _navigationState.postValue(NavigationState.NavigateToExplore)
+        } else {
+            // festival id을 intercepter에 넣어주기
+            _navigationState.postValue(NavigationState.NavigateToMain(festivalId))
+        }
+
+        _isValidationComplete.postValue(true)
+    }
+
+    companion object {
+        val FACTORY: ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    SplashViewModel()
+                }
+            }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/SplashViewModel.kt
@@ -21,6 +21,10 @@ class SplashViewModel(
     private val _isValidationComplete = MutableLiveData(false)
     val isValidationComplete: LiveData<Boolean> = _isValidationComplete
 
+    init {
+        checkFestivalId()
+    }
+
     fun checkFestivalId() {
         val festivalId = festivalLocalDataSource.getFestivalId()
         Timber.d("festival ID : $festivalId")


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #495 

<br>

## 🛠️ 작업 내용

- Splash 화면에서 sharedPref에서 festivalId 유무에 따라 앱 초기 화면이 달라지는 분기 처리를 했습니다. 
- 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/04022ea2-a508-4b5a-8065-65c0525c2a79





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 런처가 스플래시로 이동하여 저장된 축제 ID에 따라 메인 또는 탐색 화면으로 분기하는 새로운 스플래시 경험 추가.
  * 로컬 축제 ID 저장소 및 스플래시 기반 검증으로 사용자의 축제 선택 유지.

* **Bug Fixes**
  * 지도 호출에 null 안전성 적용으로 간헐적 크래시 방지.

* **Chores**
  * 앱 시작 시 API 클라이언트 초기화 및 서비스 지연 생성으로 초기 성능 최적화.
  * 인증 헤더는 저장된 축제 ID가 있을 때만 전송되도록 변경.
* **UX**
  * 탐색 화면의 검색 트리거를 일관화하여 검색 동작 중복 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->