### PR TITLE
[BE] 플레이스 지리 정보에 title 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponse.java
@@ -7,14 +7,16 @@ import com.daedan.festabook.place.domain.PlaceCategory;
 public record PlaceGeographyResponse(
         Long placeId,
         PlaceCategory category,
-        FestivalCoordinateResponse markerCoordinate
+        FestivalCoordinateResponse markerCoordinate,
+        String title
 ) {
 
     public static PlaceGeographyResponse from(Place place) {
         return new PlaceGeographyResponse(
                 place.getId(),
                 place.getCategory(),
-                FestivalCoordinateResponse.from(place.getCoordinate())
+                FestivalCoordinateResponse.from(place.getCoordinate()),
+                place.getTitle()
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/controller/PlaceGeographyControllerTest.java
@@ -75,7 +75,7 @@ class PlaceGeographyControllerTest {
             placeJpaRepository.saveAll(List.of(place));
 
             int expectedSize = 1;
-            int expectedFieldSize = 3;
+            int expectedFieldSize = 4;
             int expectedMarkerFieldSize = 2;
 
             // when & then
@@ -92,7 +92,8 @@ class PlaceGeographyControllerTest {
                     .body("[0].category", equalTo(place.getCategory().name()))
                     .body("[0].markerCoordinate.size()", equalTo(expectedMarkerFieldSize))
                     .body("[0].markerCoordinate.latitude", equalTo(place.getCoordinate().getLatitude()))
-                    .body("[0].markerCoordinate.longitude", equalTo(place.getCoordinate().getLongitude()));
+                    .body("[0].markerCoordinate.longitude", equalTo(place.getCoordinate().getLongitude()))
+                    .body("[0].title", equalTo(place.getTitle()));
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 이슈 번호

#521 

<br>

## 🛠️ 작업 내용

- 지리정조 보회할 때, title도 같이 조회하도록 추가
- #550 에서 변경한 프리뷰 조회 대신, 지리정보를 조회하면서 같이 조회하도록 변경

<br>

## 📸 이미지 첨부 (Optional)

<img width="1613" height="808" alt="image" src="https://github.com/user-attachments/assets/2d834284-0e3d-4716-9fa0-2c557792e7df" />

