### PR TITLE
[AN] 지도 화면에서 뒤로가기가 안먹는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -28,7 +28,11 @@ class ExploreViewModel(
 
     fun onUniversitySelected(university: University) {
         selectedUniversity = university
-        _searchState.value = SearchUiState.Success(selectedUniversity = university)
+        _searchState.value =
+            SearchUiState.Success(
+                universitiesFound = listOf(university),
+//                selectedUniversity = university,
+            )
     }
 
     fun onTextInputChanged() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/explore/SearchUiState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/explore/SearchUiState.kt
@@ -9,7 +9,7 @@ sealed interface SearchUiState {
 
     data class Success(
         val universitiesFound: List<University> = emptyList(),
-        val selectedUniversity: University? = null,
+//        val selectedUniversity: University? = null,
     ) : SearchUiState
 
     data class Error(

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
@@ -22,6 +22,12 @@ class PlaceDetailPreviewSecondaryFragment :
     BaseFragment<FragmentPlaceDetailPreviewSecondaryBinding>(R.layout.fragment_place_detail_preview_secondary),
     OnMenuItemReClickListener {
     private val viewModel by viewModels<PlaceListViewModel>({ requireParentFragment() }) { PlaceListViewModel.Factory }
+    private val backPressedCallback =
+        object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                viewModel.unselectPlace()
+            }
+        }
 
     override fun onViewCreated(
         view: View,
@@ -33,17 +39,15 @@ class PlaceDetailPreviewSecondaryFragment :
     }
 
     override fun onMenuItemReClick() {
-        requireActivity().onBackPressedDispatcher.onBackPressed()
+        viewModel.unselectPlace()
     }
 
     private fun setUpBackPressedCallback() {
-        val callback =
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    viewModel.unselectPlace()
-                }
-            }
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, callback)
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
+    }
+
+    private fun removeBackPressedCallback() {
+        backPressedCallback.remove()
     }
 
     private fun setUpObserver() {
@@ -55,7 +59,7 @@ class PlaceDetailPreviewSecondaryFragment :
                 }
                 is SelectedPlaceUiState.Error -> showErrorSnackBar(selectedPlace.throwable)
                 is SelectedPlaceUiState.Loading -> binding.makeChildInvisible()
-                else -> Unit
+                is SelectedPlaceUiState.Empty -> removeBackPressedCallback()
             }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
@@ -34,8 +34,8 @@ class PlaceDetailPreviewSecondaryFragment :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        setUpBackPressedCallback()
         setUpObserver()
+        setUpBackPressedCallback()
     }
 
     override fun onMenuItemReClick() {
@@ -46,12 +46,9 @@ class PlaceDetailPreviewSecondaryFragment :
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
     }
 
-    private fun removeBackPressedCallback() {
-        backPressedCallback.remove()
-    }
-
     private fun setUpObserver() {
         viewModel.selectedPlace.observe(viewLifecycleOwner) { selectedPlace ->
+            backPressedCallback.isEnabled = true
             when (selectedPlace) {
                 is SelectedPlaceUiState.Success -> {
                     binding.makeChildVisible()
@@ -59,7 +56,7 @@ class PlaceDetailPreviewSecondaryFragment :
                 }
                 is SelectedPlaceUiState.Error -> showErrorSnackBar(selectedPlace.throwable)
                 is SelectedPlaceUiState.Loading -> binding.makeChildInvisible()
-                is SelectedPlaceUiState.Empty -> removeBackPressedCallback()
+                is SelectedPlaceUiState.Empty -> backPressedCallback.isEnabled = false
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 이슈 번호

>https://github.com/woowacourse-teams/2025-festabook/issues/558

<br>

## 🛠️ 작업 내용

- 지도 화면에서 뒤로가기가 안먹는 문제 해결

<br>

## 🙇🏻 중점 리뷰 요청

- 현재 PlaceDetailPreviewFragment에서 선택된 플레이스의 존재 여부에 따라 콜백을 add, remove를 반복하고 있습니다 
확인 결과 성능 상, Fragment를 제거, 생성 하는것보다 훨씬 효율이 좋은 것으로 판단되어 이렇게 구현했어요. 

의견 부탁드립니다

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 장소 상세 미리보기(주요/보조 화면)에서 뒤로가기 및 상단 메뉴 재클릭 시 선택된 장소를 해제하도록 일관되게 처리합니다.
  * 로딩/성공/빈 상태에 따른 레이아웃 가시성 동작을 정리해 깜빡임과 빈 화면 노출을 줄였습니다.

* **개선**
  * 대학교 검색/선택 결과를 리스트 기반으로 통합해 결과 표시와 선택 상태가 더 일관되게 보입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->