### PR TITLE
[BE] 로그 파일을 날짜 기준이 아닌 크기 기준으로 변경

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -7,10 +7,15 @@
         <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_FILE_PATH}/application.json</file>
 
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOG_FILE_PATH}/application.%d{yyyy-MM-dd}.json</fileNamePattern>
-                <maxHistory>7</maxHistory>
+            <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                <fileNamePattern>${LOG_FILE_PATH}/application.%i.json</fileNamePattern>
+                <minIndex>1</minIndex>
+                <maxIndex>10</maxIndex> <!-- 100MB * 10개 = 최대 1GB 보관 -->
             </rollingPolicy>
+
+            <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                <maxFileSize>100MB</maxFileSize> <!-- 100MB 단위 롤링 -->
+            </triggeringPolicy>
 
             <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         </appender>


### PR DESCRIPTION
## #️⃣ 이슈 번호

#546 

<br>

## 🛠️ 작업 내용

- 현재 날짜 기반으로 일주일치의 로그 파일을 보관하고 있습니다.
- 날짜보다는 용량 기반으로, 특정 크기가 되면 삭제하도록 하는게 EC2의 스토리지 제한을 넘기지 않고 안전하게 저장할 수 있다고 판단하였습니다.
- 따로, 용량의 감이 없어서 1GB로 설정하였고 100MB 단위로 롤링합니다. 의견 부탁드립니다.
- 모든 로그 정보들은 CloudWatch에 저장되기 때문에 괜찮다고 판단하였습니다.

이슈에도 내용 작성되어 있습니다.