### PR TITLE
[AN]안드로이드 디렉토리 변경 시에만 CI 빌드 트리거되도록 yml 설정 변경

### DIFF
--- a/.github/workflows/android-ci-pr-test.yml
+++ b/.github/workflows/android-ci-pr-test.yml
@@ -2,9 +2,13 @@ name: Android CI Pull-Request Gradle Test
 
 on:
   pull_request:
+    # 'main' 또는 'android' 브랜치로 PR이 병합될 때 트리거
     branches:
       - main
       - android
+      # 'android' 디렉토리 내의 파일이 변경되었을 때만 워크플로우를 실행
+    path:
+      - 'android/**'
 
 jobs:
   Run-PR-Test:


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #582 

<br>

## 🛠️ 작업 내용

- 안드로이드 디렉토리 변경 시에만 CI 빌드 트리거되도록 android-ci-pr-test.yml 파일에서 path를 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 작업(Chores)
  - PR CI 워크플로가 android/ 경로 변경에만 실행되도록 경로 필터를 추가했습니다. 불필요한 빌드와 검사 실행을 줄여 PR 처리 속도와 리소스 효율을 개선합니다. 사용자 기능 변화는 없습니다.
- 문서화(Documentation)
  - PR 트리거 섹션에 안내 주석을 추가해 워크플로 동작과 조건을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->