### PR TITLE
[AN] 설정 화면 변경 사항 적용

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -93,6 +93,12 @@ android {
             "NAVER_MAP_STYLE_ID",
             naverMapStyleId,
         )
+
+        buildConfigField(
+            "String",
+            "VERSION_NAME",
+            "\"${versionName}\"",
+        )
     }
 
     buildTypes {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -1,13 +1,13 @@
 package com.daedan.festabook.presentation.setting
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
+import com.daedan.festabook.BuildConfig
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentSettingBinding
 import com.daedan.festabook.presentation.NotificationPermissionManager
@@ -55,12 +55,19 @@ class SettingFragment :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        binding.btnNoticeAllow.isChecked = viewModel.isAllowed
+        setupBindings()
+
         setupNoticeAllowButtonClickListener()
         setupServicePolicyClickListener()
         setupContactUsButtonClickListener()
 
         setupObservers()
+    }
+
+    private fun setupBindings() {
+        binding.btnNoticeAllow.isChecked = viewModel.isAllowed
+        val versionName = BuildConfig.VERSION_NAME
+        binding.tvSettingAppVersionName.text = versionName
     }
 
     override fun shouldShowPermissionRationale(permission: String): Boolean = shouldShowRequestPermissionRationale(permission)
@@ -91,12 +98,7 @@ class SettingFragment :
 
     private fun setupContactUsButtonClickListener() {
         binding.tvSettingContactUs.setOnClickListener {
-            val emailAddress = getString(R.string.setting_contact_us_email)
-            val subject = R.string.setting_contact_us_email_subject
-
-            val uri = "mailto:$emailAddress?subject=${Uri.encode(subject.toString())}".toUri()
-            val intent = Intent(Intent.ACTION_SENDTO, uri)
-
+            val intent = Intent(Intent.ACTION_VIEW, CONTACT_US_URL.toUri())
             startActivity(intent)
         }
     }
@@ -110,5 +112,8 @@ class SettingFragment :
     companion object {
         private const val POLICY_URL: String =
             "https://www.notion.so/244a540dc0b780638e56e31c4bdb3c9f"
+
+        private const val CONTACT_US_URL =
+            "https://forms.gle/XjqJFfQrTPgkZzGZ9"
     }
 }

--- a/android/app/src/main/res/layout/fragment_news.xml
+++ b/android/app/src/main/res/layout/fragment_news.xml
@@ -21,6 +21,7 @@
             android:layout_marginTop="40dp"
             android:layout_marginBottom="8dp"
             android:text="@string/news_title"
+            android:textColor="@color/gray900"
             app:layout_constraintBottom_toTopOf="@id/tl_news"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/android/app/src/main/res/layout/fragment_setting.xml
+++ b/android/app/src/main/res/layout/fragment_setting.xml
@@ -37,7 +37,7 @@
 
         <TextView
             android:id="@+id/tv_setting_current_university_notice"
-            style="@style/PretendardMedium18"
+            style="@style/PretendardMedium16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
@@ -59,7 +59,7 @@
 
         <TextView
             android:id="@+id/tv_setting_notice_detail"
-            style="@style/PretendardMedium18"
+            style="@style/PretendardMedium16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
@@ -90,7 +90,7 @@
 
         <TextView
             android:id="@+id/tv_setting_app_version_text"
-            style="@style/PretendardMedium18"
+            style="@style/PretendardMedium16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
@@ -100,7 +100,7 @@
             app:layout_constraintTop_toBottomOf="@id/tv_setting_app_info_title" />
 
         <TextView
-            android:id="@+id/tv_setting_app_version_number"
+            android:id="@+id/tv_setting_app_version_name"
             style="@style/PretendardRegular14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -111,7 +111,7 @@
 
         <TextView
             android:id="@+id/tv_setting_service_policy"
-            style="@style/PretendardMedium18"
+            style="@style/PretendardMedium16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
@@ -132,7 +132,7 @@
 
         <TextView
             android:id="@+id/tv_setting_contact_us"
-            style="@style/PretendardMedium18"
+            style="@style/PretendardMedium16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!--grayscale-->
-    <color name="gray900">#FF000000</color>
+    <color name="gray900">#FF17171B</color>
     <color name="gray800">#FF1F1F1F</color>
     <color name="gray700">#FF333333</color>
     <color name="gray600">#FF474747</color>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #562 

<br>

## 🛠️ 작업 내용

- gray/900 색상코드를 변경했어요.
- 소식 화면에 title 색상을 지정했어요.
- 설정화면의 메뉴 텍스트 크기를 변경했어요.
- 설정화면에서 개발자 문의하기 버튼을 클릭하면 구글폼으로 연결되도록 변경했어요.

<br>

## 📸 이미지 첨부 (Optional)
<img width="406" height="904" alt="스크린샷 2025-08-20 오전 11 57 21" src="https://github.com/user-attachments/assets/91f64b15-877b-4f7f-91b0-8309518a826a" />

