### PR TITLE
[BE] cloudFront 경유해 s3를 접근하도록 상대경로 응답 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/storage/dto/StorageUploadResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/dto/StorageUploadResponse.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.storage.dto;
 
 public record StorageUploadResponse(
         String accessUrl,
+        String accessRelativePath,
         String storagePath
 ) {
 }

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
@@ -18,13 +18,13 @@ public class MockStorageManager implements StorageManager {
 
         StorageUploadResponse response = new StorageUploadResponse(
                 MOCK_ACCESS_URL,
-                convertStoragePathToRelativePath(storeFile.getStoragePath()),
+                ensureLeadingSlash(storeFile.getStoragePath()),
                 storeFile.getStoragePath()
         );
         return response;
     }
 
-    private String convertStoragePathToRelativePath(String storagePath) {
+    private String ensureLeadingSlash(String storagePath) {
         if (storagePath.startsWith("/")) {
             return storagePath;
         }

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
@@ -15,6 +15,19 @@ public class MockStorageManager implements StorageManager {
     @Override
     public StorageUploadResponse uploadFile(StorageUploadRequest request) {
         StoreFile storeFile = new StoreFile(request.file(), request.storagePath());
-        return new StorageUploadResponse(MOCK_ACCESS_URL, storeFile.getStoragePath());
+
+        StorageUploadResponse response = new StorageUploadResponse(
+                MOCK_ACCESS_URL,
+                convertStoragePathToRelativePath(storeFile.getStoragePath()),
+                storeFile.getStoragePath()
+        );
+        return response;
+    }
+
+    private String convertStoragePathToRelativePath(String storagePath) {
+        if (storagePath.startsWith("/")) {
+            return storagePath;
+        }
+        return String.format("/%s", storagePath);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/S3StorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/S3StorageManager.java
@@ -47,7 +47,12 @@ public class S3StorageManager implements StorageManager {
             RequestBody requestBody = RequestBody.fromBytes(storeFile.getBytes());
             s3Client.putObject(putObjectRequest, requestBody);
 
-            return new StorageUploadResponse(buildFileUrl(s3Key), s3Key);
+            StorageUploadResponse response = new StorageUploadResponse(
+                    buildFileUrl(s3Key),
+                    convertStoragePathToRelativePath(storeFile.getStoragePath()),
+                    s3Key
+            );
+            return response;
         } catch (S3Exception e) {
             throw new RuntimeException(String.format(
                     "S3 업로드 실패 {%s}:{%s}",
@@ -71,5 +76,12 @@ public class S3StorageManager implements StorageManager {
                 s3Client.serviceClientConfiguration().region().id(),
                 encodedKey
         );
+    }
+
+    private String convertStoragePathToRelativePath(String storagePath) {
+        if (storagePath.startsWith("/")) {
+            return storagePath;
+        }
+        return String.format("/%s", storagePath);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/S3StorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/S3StorageManager.java
@@ -49,7 +49,7 @@ public class S3StorageManager implements StorageManager {
 
             StorageUploadResponse response = new StorageUploadResponse(
                     buildFileUrl(s3Key),
-                    convertStoragePathToRelativePath(storeFile.getStoragePath()),
+                    ensureLeadingSlash(storeFile.getStoragePath()),
                     s3Key
             );
             return response;
@@ -78,7 +78,7 @@ public class S3StorageManager implements StorageManager {
         );
     }
 
-    private String convertStoragePathToRelativePath(String storagePath) {
+    private String ensureLeadingSlash(String storagePath) {
         if (storagePath.startsWith("/")) {
             return storagePath;
         }

--- a/backend/src/main/java/com/daedan/festabook/storage/service/ImageStoreService.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/service/ImageStoreService.java
@@ -44,7 +44,7 @@ public class ImageStoreService {
         StorageUploadRequest request = new StorageUploadRequest(file, storagePath);
 
         StorageUploadResponse response = storageManager.uploadFile(request);
-        return new ImageUploadResponse(response.accessUrl());
+        return new ImageUploadResponse(response.accessRelativePath());
     }
 
     private void validateFile(MultipartFile file) {

--- a/backend/src/test/java/com/daedan/festabook/storage/service/ImageStoreServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/storage/service/ImageStoreServiceTest.java
@@ -56,6 +56,7 @@ class ImageStoreServiceTest {
                     "image/png",
                     new byte[100]
             );
+            String expectedImageUrlPrefix = "/images/";
             String expectedStoragePathPrefix = "images/";
 
             // when
@@ -67,6 +68,7 @@ class ImageStoreServiceTest {
             StorageUploadRequest captureRequest = requestCaptor.getValue();
             assertSoftly(s -> {
                 s.assertThat(response.imageUrl()).isNotBlank();
+                s.assertThat(response.imageUrl()).startsWith(expectedImageUrlPrefix);
                 s.assertThat(captureRequest.storagePath()).startsWith(expectedStoragePathPrefix);
             });
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#587 

<br>

## 🛠️ 작업 내용

/images/ 로 시작하는 상대 경로 응답하도록 변경

<br>

## 📸 이미지 첨부 (Optional)

<img width="1415" height="969" alt="image" src="https://github.com/user-attachments/assets/5fc49cd3-ff26-47e0-9e17-a79f800611b6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 이미지 업로드 후 제공되는 링크가 절대 URL에서 상대 경로로 변경되어 다양한 도메인·프록시 환경에서 일관되게 동작합니다.
  * 제공되는 이미지 경로가 "/images/…" 형태로 통일되어 브라우저·앱 내 표시와 네비게이션이 안정적입니다.
* **버그 수정**
  * 업로드 실패 시 오류 처리 개선으로 실패 원인이 더 명확하게 전달됩니다.
* **테스트**
  * 이미지 경로 형식 검증이 추가되어 동작 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->