### PR TITLE
[AN] 홈화면 라인업 뷰 UI 구현 (New)

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -3,8 +3,11 @@ package com.daedan.festabook.data.repository
 import com.daedan.festabook.data.datasource.remote.festival.FestivalDataSource
 import com.daedan.festabook.data.model.response.festival.toDomain
 import com.daedan.festabook.data.util.toResult
+import com.daedan.festabook.domain.model.LineupItem
 import com.daedan.festabook.domain.model.Organization
 import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.presentation.home.LineupItemUiModel
+import com.daedan.festabook.presentation.home.toUiModel
 
 class FestivalRepositoryImpl(
     private val festivalDataSource: FestivalDataSource,
@@ -12,5 +15,27 @@ class FestivalRepositoryImpl(
     override suspend fun getFestivalInfo(): Result<Organization> {
         val response = festivalDataSource.fetchFestival().toResult()
         return response.mapCatching { it.toDomain() }
+    }
+
+    override suspend fun getLineup(): Result<List<LineupItemUiModel>> {
+        val dummyData =
+            listOf(
+                LineupItem(
+                    id = 1,
+                    imageUrl = "https://images.unsplash.com/photo-1754951661102-341dfb58bd26?q=80&w=1335&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                    name = "실리카겔",
+                ),
+                LineupItem(
+                    id = 2,
+                    imageUrl = "https://images.unsplash.com/photo-1754951661102-341dfb58bd26?q=80&w=1335&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                    name = "요네즈 켄시",
+                ),
+                LineupItem(
+                    id = 3,
+                    imageUrl = "https://images.unsplash.com/photo-1754951661102-341dfb58bd26?q=80&w=1335&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                    name = "하츠네 미쿠",
+                ),
+            )
+        return Result.success(dummyData.map { it.toUiModel() })
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -6,8 +6,6 @@ import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.model.LineupItem
 import com.daedan.festabook.domain.model.Organization
 import com.daedan.festabook.domain.repository.FestivalRepository
-import com.daedan.festabook.presentation.home.LineupItemUiModel
-import com.daedan.festabook.presentation.home.toUiModel
 
 class FestivalRepositoryImpl(
     private val festivalDataSource: FestivalDataSource,
@@ -17,7 +15,7 @@ class FestivalRepositoryImpl(
         return response.mapCatching { it.toDomain() }
     }
 
-    override suspend fun getLineup(): Result<List<LineupItemUiModel>> {
+    override suspend fun getLineup(): Result<List<LineupItem>> {
         val dummyData =
             listOf(
                 LineupItem(
@@ -36,6 +34,6 @@ class FestivalRepositoryImpl(
                     name = "하츠네 미쿠",
                 ),
             )
-        return Result.success(dummyData.map { it.toUiModel() })
+        return Result.success(dummyData)
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/LineupItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/LineupItem.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.domain.model
+
+data class LineupItem(
+    val id: Long,
+    val imageUrl: String,
+    val name: String,
+)

--- a/android/app/src/main/java/com/daedan/festabook/domain/repository/FestivalRepository.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/repository/FestivalRepository.kt
@@ -1,7 +1,10 @@
 package com.daedan.festabook.domain.repository
 
 import com.daedan.festabook.domain.model.Organization
+import com.daedan.festabook.presentation.home.LineupItemUiModel
 
 interface FestivalRepository {
     suspend fun getFestivalInfo(): Result<Organization>
+
+    suspend fun getLineup(): Result<List<LineupItemUiModel>>
 }

--- a/android/app/src/main/java/com/daedan/festabook/domain/repository/FestivalRepository.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/repository/FestivalRepository.kt
@@ -1,10 +1,10 @@
 package com.daedan.festabook.domain.repository
 
+import com.daedan.festabook.domain.model.LineupItem
 import com.daedan.festabook.domain.model.Organization
-import com.daedan.festabook.presentation.home.LineupItemUiModel
 
 interface FestivalRepository {
     suspend fun getFestivalInfo(): Result<Organization>
 
-    suspend fun getLineup(): Result<List<LineupItemUiModel>>
+    suspend fun getLineup(): Result<List<LineupItem>>
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -12,6 +12,7 @@ import com.daedan.festabook.presentation.common.formatFestivalPeriod
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.home.adapter.CenterItemMotionEnlarger
 import com.daedan.festabook.presentation.home.adapter.FestivalUiState
+import com.daedan.festabook.presentation.home.adapter.LineupAdapter
 import com.daedan.festabook.presentation.home.adapter.PosterAdapter
 import timber.log.Timber
 
@@ -19,7 +20,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private val viewModel: HomeViewModel by viewModels { HomeViewModel.Factory }
     private val centerItemMotionEnlarger = CenterItemMotionEnlarger()
 
-    private lateinit var adapter: PosterAdapter
+    private lateinit var posterAdapter: PosterAdapter
+    private lateinit var lineupAdapter: LineupAdapter
 
     override fun onViewCreated(
         view: View,
@@ -41,6 +43,16 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                 }
             }
         }
+        viewModel.lineupUiState.observe(viewLifecycleOwner) { lineupUiState ->
+            when (lineupUiState) {
+                is LineupUiState.Loading -> {}
+                is LineupUiState.Success -> setupLineupAdapter(lineupUiState.lineups)
+                is LineupUiState.Error -> {
+                    showErrorSnackBar(lineupUiState.throwable)
+                    Timber.w(lineupUiState.throwable, "HomeFragment: ${lineupUiState.throwable.message}")
+                }
+            }
+        }
     }
 
     private fun handleSuccessState(festivalUiState: FestivalUiState.Success) {
@@ -58,16 +70,21 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             festivalUiState.organization.festival.festivalImages
                 .sortedBy { it.sequence }
                 .map { it.imageUrl }
-        setupAdapter(posterUrls)
+        setupPosterAdapter(posterUrls)
     }
 
-    private fun setupAdapter(posters: List<String> = emptyList()) {
-        adapter = PosterAdapter(posters)
-        binding.rvHomePoster.adapter = adapter
+    private fun setupPosterAdapter(posters: List<String> = emptyList()) {
+        posterAdapter = PosterAdapter(posters)
+        binding.rvHomePoster.adapter = posterAdapter
 
         attachSnapHelper()
         scrollToInitialPosition(posters.size)
         addScrollEffectListener()
+    }
+
+    private fun setupLineupAdapter(lineups: List<LineupItemUiModel> = emptyList()) {
+        lineupAdapter = LineupAdapter(lineups)
+        binding.rvHomeLineup.adapter = lineupAdapter
     }
 
     private fun attachSnapHelper() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
@@ -47,7 +47,7 @@ class HomeViewModel(
             val result = festivalRepository.getLineup()
             result
                 .onSuccess { lineups ->
-                    _lineupUiState.value = LineupUiState.Success(lineups)
+                    _lineupUiState.value = LineupUiState.Success(lineups.map { it.toUiModel() })
                 }.onFailure {
                     _lineupUiState.value = LineupUiState.Error(it)
                 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
@@ -18,8 +18,12 @@ class HomeViewModel(
     private val _festivalUiState = MutableLiveData<FestivalUiState>()
     val festivalUiState: LiveData<FestivalUiState> get() = _festivalUiState
 
+    private val _lineupUiState = MutableLiveData<LineupUiState>()
+    val lineupUiState: LiveData<LineupUiState> get() = _lineupUiState
+
     init {
         loadFestival()
+        loadLineup()
     }
 
     fun loadFestival() {
@@ -32,6 +36,20 @@ class HomeViewModel(
                     _festivalUiState.value = FestivalUiState.Success(festival)
                 }.onFailure {
                     _festivalUiState.value = FestivalUiState.Error(it)
+                }
+        }
+    }
+
+    fun loadLineup() {
+        viewModelScope.launch {
+            _lineupUiState.value = LineupUiState.Loading
+
+            val result = festivalRepository.getLineup()
+            result
+                .onSuccess { lineups ->
+                    _lineupUiState.value = LineupUiState.Success(lineups)
+                }.onFailure {
+                    _lineupUiState.value = LineupUiState.Error(it)
                 }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/LineupItemUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/LineupItemUiModel.kt
@@ -1,15 +1,12 @@
 package com.daedan.festabook.presentation.home
 
-import android.os.Parcelable
 import com.daedan.festabook.domain.model.LineupItem
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 data class LineupItemUiModel(
     val id: Long,
     val imageUrl: String,
     val name: String,
-) : Parcelable
+)
 
 fun LineupItem.toUiModel(): LineupItemUiModel =
     LineupItemUiModel(

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/LineupItemUiModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/LineupItemUiModel.kt
@@ -1,0 +1,19 @@
+package com.daedan.festabook.presentation.home
+
+import android.os.Parcelable
+import com.daedan.festabook.domain.model.LineupItem
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class LineupItemUiModel(
+    val id: Long,
+    val imageUrl: String,
+    val name: String,
+) : Parcelable
+
+fun LineupItem.toUiModel(): LineupItemUiModel =
+    LineupItemUiModel(
+        id = id,
+        imageUrl = imageUrl,
+        name = name,
+    )

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/LineupUiState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/LineupUiState.kt
@@ -1,0 +1,13 @@
+package com.daedan.festabook.presentation.home
+
+sealed interface LineupUiState {
+    data object Loading : LineupUiState
+
+    data class Success(
+        val lineups: List<LineupItemUiModel>,
+    ) : LineupUiState
+
+    data class Error(
+        val throwable: Throwable,
+    ) : LineupUiState
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/LineupAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/LineupAdapter.kt
@@ -1,0 +1,23 @@
+package com.daedan.festabook.presentation.home.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.daedan.festabook.presentation.home.LineupItemUiModel
+
+class LineupAdapter(
+    private val lineupItems: List<LineupItemUiModel>,
+) : RecyclerView.Adapter<LineupItemViewHolder>() {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): LineupItemViewHolder = LineupItemViewHolder.from(parent)
+
+    override fun onBindViewHolder(
+        holder: LineupItemViewHolder,
+        position: Int,
+    ) {
+        holder.bind(lineupItems[position])
+    }
+
+    override fun getItemCount(): Int = lineupItems.size
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/LineupAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/LineupAdapter.kt
@@ -1,12 +1,11 @@
 package com.daedan.festabook.presentation.home.adapter
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.daedan.festabook.presentation.home.LineupItemUiModel
 
-class LineupAdapter(
-    private val lineupItems: List<LineupItemUiModel>,
-) : RecyclerView.Adapter<LineupItemViewHolder>() {
+class LineupAdapter : ListAdapter<LineupItemUiModel, LineupItemViewHolder>(lineupItemDiffUtil) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -16,8 +15,21 @@ class LineupAdapter(
         holder: LineupItemViewHolder,
         position: Int,
     ) {
-        holder.bind(lineupItems[position])
+        holder.bind(currentList[position])
     }
 
-    override fun getItemCount(): Int = lineupItems.size
+    companion object {
+        private val lineupItemDiffUtil =
+            object : DiffUtil.ItemCallback<LineupItemUiModel>() {
+                override fun areItemsTheSame(
+                    oldItem: LineupItemUiModel,
+                    newItem: LineupItemUiModel,
+                ): Boolean = oldItem.id == newItem.id
+
+                override fun areContentsTheSame(
+                    oldItem: LineupItemUiModel,
+                    newItem: LineupItemUiModel,
+                ): Boolean = oldItem == newItem
+            }
+    }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/LineupItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/LineupItemViewHolder.kt
@@ -1,0 +1,33 @@
+package com.daedan.festabook.presentation.home.adapter
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.graphics.drawable.toDrawable
+import androidx.recyclerview.widget.RecyclerView
+import coil3.load
+import coil3.request.CachePolicy
+import coil3.request.placeholder
+import com.daedan.festabook.databinding.ItemHomeLineupBinding
+import com.daedan.festabook.presentation.home.LineupItemUiModel
+import timber.log.Timber
+
+class LineupItemViewHolder(
+    val binding: ItemHomeLineupBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(lineupItemUiModel: LineupItemUiModel) {
+        Timber.d("lineupItemUiModel: $lineupItemUiModel")
+        binding.itemLineupImage.load(lineupItemUiModel.imageUrl) {
+            placeholder(Color.LTGRAY.toDrawable())
+            memoryCachePolicy(CachePolicy.ENABLED)
+        }
+        binding.tvLineupName.text = lineupItemUiModel.name
+    }
+
+    companion object {
+        fun from(parent: ViewGroup): LineupItemViewHolder {
+            val binding = ItemHomeLineupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            return LineupItemViewHolder(binding)
+        }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterAdapter.kt
@@ -1,11 +1,10 @@
 package com.daedan.festabook.presentation.home.adapter
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 
-class PosterAdapter(
-    private val posters: List<String>,
-) : RecyclerView.Adapter<PosterItemViewHolder>() {
+class PosterAdapter : ListAdapter<String, PosterItemViewHolder>(posterDiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -15,11 +14,27 @@ class PosterAdapter(
         holder: PosterItemViewHolder,
         position: Int,
     ) {
-        if (posters.isEmpty()) return
+        val posterList = currentList
+        if (posterList.isEmpty()) return
 
-        val actualIndex = position % posters.size
-        holder.bind(posters[actualIndex])
+        val actualIndex = position % posterList.size
+        holder.bind(posterList[actualIndex])
     }
 
     override fun getItemCount(): Int = Int.MAX_VALUE
+
+    companion object {
+        private val posterDiffCallback =
+            object : DiffUtil.ItemCallback<String>() {
+                override fun areItemsTheSame(
+                    oldItem: String,
+                    newItem: String,
+                ): Boolean = oldItem == newItem
+
+                override fun areContentsTheSame(
+                    oldItem: String,
+                    newItem: String,
+                ): Boolean = oldItem == newItem
+            }
+    }
 }

--- a/android/app/src/main/res/drawable/bg_stroke_gray300_radius50dp.xml
+++ b/android/app/src/main/res/drawable/bg_stroke_gray300_radius50dp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:bottomLeftRadius="5dp"
+        android:bottomRightRadius="50dp"
+        android:topLeftRadius="50dp"
+        android:topRightRadius="50dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray300" />
+</shape>

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -70,7 +70,7 @@
         
         <TextView
             android:id="@+id/tv_home_lineup_title"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/home_lineup_title"
             style="@style/PretendardBold18"
@@ -80,22 +80,22 @@
             android:layout_marginTop="20dp"
             app:layout_constraintStart_toStartOf="parent"/>
 
-        <com.google.android.material.button.MaterialButton
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/home_check_schedule_text"
-            android:textColor="@color/gray400"
-            app:icon="@drawable/ic_arrow_forward_right"
-            app:iconTint="@color/gray400"
-            app:iconGravity="end"
-            style="@style/PretendardRegular12"
-            app:iconSize="12dp"
-            android:background="@color/transparent"
-            android:paddingHorizontal="16dp"
-            android:paddingVertical="4dp"
-            app:layout_constraintTop_toTopOf="@id/tv_home_lineup_title"
-            app:layout_constraintBottom_toBottomOf="@id/tv_home_lineup_title"
-            app:layout_constraintEnd_toEndOf="parent"/>
+<!--        <com.google.android.material.button.MaterialButton-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:text="@string/home_check_schedule_text"-->
+<!--            android:textColor="@color/gray400"-->
+<!--            app:icon="@drawable/ic_arrow_forward_right"-->
+<!--            app:iconTint="@color/gray400"-->
+<!--            app:iconGravity="end"-->
+<!--            style="@style/PretendardRegular12"-->
+<!--            app:iconSize="12dp"-->
+<!--            android:background="@color/transparent"-->
+<!--            android:paddingHorizontal="16dp"-->
+<!--            android:paddingVertical="4dp"-->
+<!--            app:layout_constraintTop_toTopOf="@id/tv_home_lineup_title"-->
+<!--            app:layout_constraintBottom_toBottomOf="@id/tv_home_lineup_title"-->
+<!--            app:layout_constraintEnd_toEndOf="parent"/>-->
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_home_lineup"

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -67,6 +67,47 @@
             app:dividerColor="@color/gray200"
             app:dividerThickness="1dp"
             app:layout_constraintTop_toBottomOf="@id/tv_home_festival_date" />
+        
+        <TextView
+            android:id="@+id/tv_home_lineup_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/home_lineup_title"
+            style="@style/PretendardBold18"
+            app:layout_constraintTop_toBottomOf="@id/view_divider"
+            android:textColor="@color/gray900"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="20dp"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/home_check_schedule_text"
+            android:textColor="@color/gray400"
+            app:icon="@drawable/ic_arrow_forward_right"
+            app:iconTint="@color/gray400"
+            app:iconGravity="end"
+            style="@style/PretendardRegular12"
+            app:iconSize="12dp"
+            android:background="@color/transparent"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="4dp"
+            app:layout_constraintTop_toTopOf="@id/tv_home_lineup_title"
+            app:layout_constraintBottom_toBottomOf="@id/tv_home_lineup_title"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_home_lineup"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:listitem="@layout/item_home_lineup"
+            app:layout_constraintTop_toBottomOf="@id/tv_home_lineup_title" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/item_home_lineup.xml
+++ b/android/app/src/main/res/layout/item_home_lineup.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="68dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp">
+
+        <ImageView
+            android:id="@+id/item_lineup_image"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_stroke_gray300_radius50dp"
+            android:clipToOutline="true"
+            android:contentDescription="@string/item_lineup_image"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/sample_poster" />
+
+        <TextView
+            android:id="@+id/tv_lineup_name"
+            style="@style/PretendardBold12"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/gray600"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/item_lineup_image"
+            tools:text="실리카겔" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_home_poster.xml
+++ b/android/app/src/main/res/layout/item_home_poster.xml
@@ -19,7 +19,7 @@
             android:layout_height="match_parent"
             android:contentDescription="@string/home_poster_image"
             android:scaleType="centerCrop"
-            android:src="@drawable/sample_poster"
+            tools:src="@drawable/sample_poster"
             app:layout_constraintDimensionRatio="3:4"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -106,6 +106,9 @@
     <string name="notification_permission_message">새로운 소식 및 중요한 정보를 받기 위해 알림 권한이 필요합니다.</string>
     <string name="confirm">확인</string>
     <string name="cancel">취소</string>
+    <string name="item_lineup_image">item_lineup_image</string>
+    <string name="home_check_schedule_text">일정 확인하기</string>
+    <string name="home_lineup_title">축제 라인업</string>
 
     <!--토스트 메시지-->
     <string name="back_press_exit_message">뒤로가기를 한 번 더 누르면 종료됩니다.</string>

--- a/android/app/src/test/java/com/daedan/festabook/home/HomeTestFixture.kt
+++ b/android/app/src/test/java/com/daedan/festabook/home/HomeTestFixture.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.home
 
 import com.daedan.festabook.domain.model.Festival
+import com.daedan.festabook.domain.model.LineupItem
 import com.daedan.festabook.domain.model.Organization
 import com.daedan.festabook.domain.model.Poster
 import java.time.LocalDate
@@ -23,4 +24,13 @@ val FAKE_ORGANIZATION =
                 startDate = LocalDate.of(2025, 1, 1),
                 endDate = LocalDate.of(2025, 1, 3),
             ),
+    )
+
+val FAKE_LINEUP =
+    listOf(
+        LineupItem(
+            id = 1L,
+            imageUrl = "aa.com",
+            name = "SINGER",
+        ),
     )

--- a/android/app/src/test/java/com/daedan/festabook/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daedan/festabook/home/HomeViewModelTest.kt
@@ -35,6 +35,8 @@ class HomeViewModelTest {
         Dispatchers.setMain(testDispatcher)
         festivalRepository = mockk()
         coEvery { festivalRepository.getFestivalInfo() } returns Result.success(FAKE_ORGANIZATION)
+        coEvery { festivalRepository.getLineup() } returns Result.success(FAKE_LINEUP)
+
         homeViewModel = HomeViewModel(festivalRepository)
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

>  #542 

<br>

## 🛠️ 작업 내용

- #545
위의 PR에서 작업한 내용 중에 버그가 생겨, 해당 코드를 제외한 부분만 피알을 다시 올립니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 홈 화면에 ‘축제 라인업’ 섹션 추가: 가로 스크롤 리스트로 아티스트 이미지와 이름 표시, 로딩/성공/오류 상태 반영 및 스낵바 알림 지원.
- Refactor
  - 포스터 리스트를 ListAdapter로 전환해 더 부드러운 갱신과 스크롤 성능 개선.
- UI
  - 라인업 아이템 전용 레이아웃과 회색 테두리 배경 추가, 홈 레이아웃에 섹션 타이틀 및 리스트 구성.
  - 미리보기 리소스 정리 및 문자열 리소스 추가(섹션 제목 등).
- Tests
  - 라인업 테스트 픽스처 및 저장소 목 추가로 뷰모델 테스트 보강.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->