### PR TITLE
[BE] 콘솔에서는 로그를 텍스트로 출력하도록 변경

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -25,16 +25,17 @@
         </root>
     </springProfile>
 
-    <!-- 로컬 및 테스트 환경: 콘솔 JSON 출력 -->
+    <!-- 로컬 및 테스트 환경: 콘솔 JSON 출력 @formatter:off-->
     <springProfile name="!prod">
-        <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-                <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%cyan(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%-5level) %green(%logger{36}) - %msg%n
+                </pattern>
             </encoder>
         </appender>
 
         <root level="INFO">
-            <appender-ref ref="JSON_CONSOLE"/>
+            <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#597 

<br>

## 🛠️ 작업 내용

- 콘솔에서는 로그를 텍스트로 출력하도록 변경

<br>

## 📸 이미지 첨부 (Optional)

<img width="1220" height="207" alt="image" src="https://github.com/user-attachments/assets/6b5d618f-4ced-4749-8485-7084115bf669" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 비프로덕션 환경의 콘솔 로그를 JSON 출력에서 색상 적용된 사람이 읽기 쉬운 텍스트 출력으로 전환했습니다. 루트 로거가 새 콘솔 포맷을 사용하도록 조정되었습니다. 프로덕션 환경은 영향을 받지 않습니다.
* Style
  * 로그 출력 형식을 개선해 가독성을 높였습니다: 타임스탬프, 스레드, 레벨, 로거, 메시지가 명확한 패턴과 색상 하이라이트로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->