### PR TITLE
[AN] 홈 화면에서 일정 확인하기 버튼 클릭 시 일정 화면으로 이동

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -17,7 +17,7 @@ import com.daedan.festabook.presentation.home.adapter.PosterAdapter
 import timber.log.Timber
 
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
-    private val viewModel: HomeViewModel by viewModels { HomeViewModel.Factory }
+    private val viewModel: HomeViewModel by viewModels({ requireActivity() }) { HomeViewModel.Factory }
     private val centerItemMotionEnlarger = CenterItemMotionEnlarger()
 
     private val posterAdapter: PosterAdapter by lazy {
@@ -35,6 +35,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         binding.lifecycleOwner = viewLifecycleOwner
         setupObservers()
         setupAdapters()
+        setupNavigateToScheduleButton()
+    }
+
+    private fun setupNavigateToScheduleButton() {
+        binding.btnNavigateToSchedule.setOnClickListener {
+            viewModel.navigateToScheduleClick()
+        }
     }
 
     private fun setupObservers() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.daedan.festabook.FestaBookApp
 import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.presentation.common.SingleLiveData
 import com.daedan.festabook.presentation.home.adapter.FestivalUiState
 import kotlinx.coroutines.launch
 
@@ -20,6 +21,9 @@ class HomeViewModel(
 
     private val _lineupUiState = MutableLiveData<LineupUiState>()
     val lineupUiState: LiveData<LineupUiState> get() = _lineupUiState
+
+    private val _navigateToScheduleEvent: SingleLiveData<Unit> = SingleLiveData()
+    val navigateToScheduleEvent: LiveData<Unit> get() = _navigateToScheduleEvent
 
     init {
         loadFestival()
@@ -40,7 +44,11 @@ class HomeViewModel(
         }
     }
 
-    fun loadLineup() {
+    fun navigateToScheduleClick() {
+        _navigateToScheduleEvent.setValue(Unit)
+    }
+
+    private fun loadLineup() {
         viewModelScope.launch {
             _lineupUiState.value = LineupUiState.Loading
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.daedan.festabook.presentation.main
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
@@ -23,6 +22,7 @@ import com.daedan.festabook.presentation.common.isGranted
 import com.daedan.festabook.presentation.common.showToast
 import com.daedan.festabook.presentation.common.toLocationPermissionDeniedTextOrNull
 import com.daedan.festabook.presentation.home.HomeFragment
+import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.news.NewsFragment
 import com.daedan.festabook.presentation.placeList.placeMap.PlaceMapFragment
 import com.daedan.festabook.presentation.schedule.ScheduleFragment
@@ -36,7 +36,8 @@ class MainActivity :
     private val binding: ActivityMainBinding by lazy {
         ActivityMainBinding.inflate(layoutInflater)
     }
-    private val viewModel: MainViewModel by viewModels { MainViewModel.Factory }
+    private val mainViewModel: MainViewModel by viewModels { MainViewModel.Factory }
+    private val homeViewModel: HomeViewModel by viewModels { HomeViewModel.Factory }
 
     private val placeMapFragment by lazy {
         PlaceMapFragment().newInstance()
@@ -83,7 +84,7 @@ class MainActivity :
         enableEdgeToEdge()
         setupBinding()
 
-        viewModel.registerDeviceAndFcmToken()
+        mainViewModel.registerDeviceAndFcmToken()
         setupAlarmDialog()
         setupHomeFragment(savedInstanceState)
         setUpBottomNavigation()
@@ -112,10 +113,13 @@ class MainActivity :
     override fun shouldShowPermissionRationale(permission: String): Boolean = shouldShowRequestPermissionRationale(permission)
 
     private fun setupObservers() {
-        viewModel.backPressEvent.observe(this) { event ->
+        mainViewModel.backPressEvent.observe(this) { event ->
             event.getContentIfNotHandled()?.let { isDoublePress ->
                 if (isDoublePress) finish() else showToast(getString(R.string.back_press_exit_message))
             }
+        }
+        homeViewModel.navigateToScheduleEvent.observe(this) {
+            binding.bnvMenu.selectedItemId = R.id.item_menu_schedule
         }
     }
 
@@ -155,7 +159,7 @@ class MainActivity :
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    viewModel.onBackPressed()
+                    mainViewModel.onBackPressed()
                 }
             },
         )
@@ -221,7 +225,7 @@ class MainActivity :
         val dialog =
             MaterialAlertDialogBuilder(this, R.style.MainAlarmDialogTheme)
                 .setView(R.layout.main_alarm_view)
-                .setPositiveButton(R.string.main_alarm_dialog_confirm_button) { dialog, _ ->
+                .setPositiveButton(R.string.main_alarm_dialog_confirm_button) { _, _ ->
                     notificationPermissionManager.requestNotificationPermission(this)
                 }.setNegativeButton(R.string.main_alarm_dialog_cancel_button) { dialog, _ ->
                     dialog.dismiss()

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -67,35 +67,36 @@
             app:dividerColor="@color/gray200"
             app:dividerThickness="1dp"
             app:layout_constraintTop_toBottomOf="@id/tv_home_festival_date" />
-        
+
         <TextView
             android:id="@+id/tv_home_lineup_title"
+            style="@style/PretendardBold18"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/home_lineup_title"
-            style="@style/PretendardBold18"
-            app:layout_constraintTop_toBottomOf="@id/view_divider"
-            android:textColor="@color/gray900"
             android:layout_marginStart="16dp"
             android:layout_marginTop="20dp"
-            app:layout_constraintStart_toStartOf="parent"/>
+            android:text="@string/home_lineup_title"
+            android:textColor="@color/gray900"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_divider" />
 
-<!--        <com.google.android.material.button.MaterialButton-->
-<!--            android:layout_width="wrap_content"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:text="@string/home_check_schedule_text"-->
-<!--            android:textColor="@color/gray400"-->
-<!--            app:icon="@drawable/ic_arrow_forward_right"-->
-<!--            app:iconTint="@color/gray400"-->
-<!--            app:iconGravity="end"-->
-<!--            style="@style/PretendardRegular12"-->
-<!--            app:iconSize="12dp"-->
-<!--            android:background="@color/transparent"-->
-<!--            android:paddingHorizontal="16dp"-->
-<!--            android:paddingVertical="4dp"-->
-<!--            app:layout_constraintTop_toTopOf="@id/tv_home_lineup_title"-->
-<!--            app:layout_constraintBottom_toBottomOf="@id/tv_home_lineup_title"-->
-<!--            app:layout_constraintEnd_toEndOf="parent"/>-->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_navigate_to_schedule"
+            style="@style/PretendardRegular12"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/transparent"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="4dp"
+            android:text="@string/home_check_schedule_text"
+            android:textColor="@color/gray400"
+            app:icon="@drawable/ic_arrow_forward_right"
+            app:iconGravity="end"
+            app:iconSize="12dp"
+            app:iconTint="@color/gray400"
+            app:layout_constraintBottom_toBottomOf="@id/tv_home_lineup_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_home_lineup_title" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_home_lineup"
@@ -106,8 +107,8 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:listitem="@layout/item_home_lineup"
-            app:layout_constraintTop_toBottomOf="@id/tv_home_lineup_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_home_lineup_title"
+            tools:listitem="@layout/item_home_lineup" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <!-- 소식 화면 -->
     <string name="news_title">소식</string>
     <string name="tab_notice">공지</string>
-    <string name="tab_faq">Q&amp;A</string>
+    <string name="tab_faq">FAQ</string>
     <string name="tab_lost_item">분실물</string>
     <string name="tab_faq_question">Q. %1$s</string>
     <string name="modal_lost_item">보관 장소 : %1$s</string>


### PR DESCRIPTION
## #️⃣ 이슈 번호

#599 

<br>

## 🛠️ 작업 내용

- 홈 화면에서 일정 확인하기 버튼 클릭 시 일정 화면으로 이동 기능
- Q&A -> FAQ 로 변경

<br>

## 🙇🏻 중점 리뷰 요청


<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/7e66d4aa-b2cf-4ead-8f9e-8ac97480e981




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 홈 화면에 ‘일정 보기’ 버튼을 추가하여 스케줄 화면으로 즉시 이동할 수 있습니다.
  - 홈에서 스케줄로의 전환 흐름이 더 자연스럽게 동작합니다.
- Style
  - 홈 라인업 제목의 여백을 정돈하고 버튼 아이콘/색상 등 시각 요소를 추가해 레이아웃을 개선했습니다.
  - 뉴스 섹션 탭 텍스트를 “Q&A”에서 “FAQ”로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->