### PR TITLE
[FE] 오늘의 라인업 화면 생성

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,6 +35,8 @@ import AddImageModal from './components/modals/AddImageModal';
 import ConfirmModal from './components/common/ConfirmModal';
 import Modal from './components/common/Modal';
 import { NoticeDetailModal } from './components/modals/NoticeModal';
+import LineupAddModal from './components/modals/LineupAddModal';
+import LineupEditModal from './components/modals/LineupEditModal';
 
 // Common Components
 import Toast from './components/common/Toast';
@@ -88,8 +90,10 @@ function App() {
             case 'placeEdit': return <PlaceEditModal {...allProps} />;
             case 'confirm': return <ConfirmModal {...allProps} onConfirm={() => { props.onConfirm(); closeModal(); }} onCancel={closeModal} />;
             case 'image': return <Modal isOpen={true} onClose={closeModal} maxWidth="max-w-4xl"><div className="relative"><img src={props.src} className="max-w-full max-h-[80vh] rounded-lg mx-auto" alt="상세 이미지" /><button onClick={closeModal} className="absolute top-2 right-2 text-white text-3xl bg-black bg-opacity-50 rounded-full w-8 h-8 flex items-center justify-center">&times;</button></div></Modal>;
-            case 'festival':
-                return <FestivalPage {...allProps} />;
+            case 'festival': return <FestivalPage {...allProps} />;
+            case 'lineup-add': return <LineupAddModal isOpen={true} {...allProps} />;
+            case 'lineup-edit': return <LineupEditModal isOpen={true} {...allProps} />;
+            
             default: return null;
         }
     };

--- a/frontend/src/components/modals/LineupAddModal.jsx
+++ b/frontend/src/components/modals/LineupAddModal.jsx
@@ -1,0 +1,285 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Modal from '../common/Modal';
+import { lineupAPI } from '../../utils/api';
+
+const LineupAddModal = ({ isOpen, onClose, showToast, onUpdate }) => {
+    const [formData, setFormData] = useState({
+        name: '',
+        imageUrl: '',
+        performanceAt: ''
+    });
+    const [selectedFile, setSelectedFile] = useState(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // ESC 키 이벤트 리스너
+    useEffect(() => {
+        const handleEscKey = (event) => {
+            if (event.key === 'Escape' && !isUploading) {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleEscKey);
+
+        return () => {
+            document.removeEventListener('keydown', handleEscKey);
+        };
+    }, [onClose, isUploading]);
+
+    // 모달이 닫힐 때 상태 초기화
+    useEffect(() => {
+        if (!isOpen) {
+            setFormData({
+                name: '',
+                imageUrl: '',
+                performanceAt: ''
+            });
+            setSelectedFile(null);
+            setIsDragging(false);
+            setIsUploading(false);
+        }
+    }, [isOpen]);
+
+    const validateFile = (file) => {
+        const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
+        const maxSize = 5 * 1024 * 1024; // 5MB
+
+        if (!allowedTypes.includes(file.type)) {
+            showToast('PNG, JPG, JPEG 파일만 업로드 가능합니다.');
+            return false;
+        }
+
+        if (file.size > maxSize) {
+            showToast('파일 크기는 5MB 이하여야 합니다.');
+            return false;
+        }
+
+        return true;
+    };
+
+    const handleFileSelect = (file) => {
+        if (validateFile(file)) {
+            setSelectedFile(file);
+        }
+    };
+
+    const handleFileInputChange = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+            handleFileSelect(file);
+        }
+    };
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+    };
+
+    const handleDrop = (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+        
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            handleFileSelect(files[0]);
+        }
+    };
+
+    const handleUploadClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        
+        if (!formData.name.trim()) {
+            showToast('아티스트명을 입력해주세요.');
+            return;
+        }
+
+        if (!selectedFile) {
+            showToast('이미지를 선택해주세요.');
+            return;
+        }
+
+        if (!formData.performanceAt) {
+            showToast('공연 일시를 입력해주세요.');
+            return;
+        }
+        
+        setIsUploading(true);
+        
+        try {
+            // 파일을 base64로 변환
+            const reader = new FileReader();
+            const imageUrl = await new Promise((resolve, reject) => {
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = reject;
+                reader.readAsDataURL(selectedFile);
+            });
+
+            const response = await lineupAPI.addLineup({
+                name: formData.name,
+                imageUrl: imageUrl,
+                performanceAt: formData.performanceAt
+            });
+            
+            // 상태 업데이트
+            if (onUpdate) {
+                onUpdate(prev => [...prev, response]);
+            }
+            
+            showToast('라인업이 성공적으로 추가되었습니다.');
+            onClose();
+        } catch (error) {
+            console.error('Lineup add error:', error);
+            showToast('라인업 추가에 실패했습니다.');
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({
+            ...prev,
+            [name]: value
+        }));
+    };
+
+    const handleClose = () => {
+        if (!isUploading) {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose} maxWidth="max-w-md">
+            <form onSubmit={handleSubmit}>
+                <h2 className="text-2xl font-bold mb-6 text-center">라인업 추가</h2>
+                
+                <div className="space-y-4">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            아티스트명
+                        </label>
+                        <input
+                            type="text"
+                            name="name"
+                            value={formData.name}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            placeholder="아티스트명을 입력하세요"
+                            required
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            이미지 선택
+                        </label>
+                        <div
+                            className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
+                                isDragging 
+                                    ? 'border-blue-500 bg-blue-50' 
+                                    : selectedFile 
+                                        ? 'border-green-500 bg-green-50' 
+                                        : 'border-gray-300 hover:border-gray-400'
+                            }`}
+                            onClick={handleUploadClick}
+                            onDragOver={handleDragOver}
+                            onDragLeave={handleDragLeave}
+                            onDrop={handleDrop}
+                        >
+                            {selectedFile ? (
+                                <div>
+                                    <div className="w-12 h-12 mx-auto mb-3 bg-green-100 rounded-full flex items-center justify-center">
+                                        <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                        </svg>
+                                    </div>
+                                    <p className="text-green-700 font-medium mb-1">{selectedFile.name}</p>
+                                    <p className="text-green-600 text-sm">
+                                        {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                                    </p>
+                                    <p className="text-gray-500 text-xs mt-2">클릭하여 다른 파일 선택</p>
+                                </div>
+                            ) : (
+                                <div>
+                                    <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-full flex items-center justify-center">
+                                        <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                                        </svg>
+                                    </div>
+                                    <p className="text-gray-700 font-medium mb-1">클릭하여 이미지 선택</p>
+                                    <p className="text-gray-500 text-sm">PNG, JPG, JPEG (최대 5MB)</p>
+                                    <p className="text-gray-400 text-xs mt-2">또는 파일을 여기에 드래그하세요</p>
+                                </div>
+                            )}
+                        </div>
+                        
+                        {/* 숨겨진 파일 입력 */}
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/png,image/jpeg,image/jpg"
+                            onChange={handleFileInputChange}
+                            className="hidden"
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            공연 일시
+                        </label>
+                        <input
+                            type="datetime-local"
+                            name="performanceAt"
+                            value={formData.performanceAt}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            required
+                        />
+                    </div>
+                </div>
+                
+                <div className="flex space-x-3 mt-6">
+                    <button
+                        type="button"
+                        onClick={handleClose}
+                        disabled={isUploading}
+                        className="flex-1 bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-400 transition-colors duration-200 disabled:opacity-50"
+                    >
+                        취소
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isUploading}
+                        className="flex-1 bg-black text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-800 transition-colors duration-200 disabled:opacity-50 flex items-center justify-center"
+                    >
+                        {isUploading ? (
+                            <>
+                                <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                추가 중...
+                            </>
+                        ) : (
+                            '추가'
+                        )}
+                    </button>
+                </div>
+            </form>
+        </Modal>
+    );
+};
+
+export default LineupAddModal;

--- a/frontend/src/components/modals/LineupEditModal.jsx
+++ b/frontend/src/components/modals/LineupEditModal.jsx
@@ -1,0 +1,342 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Modal from '../common/Modal';
+import { lineupAPI } from '../../utils/api';
+
+const LineupEditModal = ({ isOpen, onClose, lineup, showToast, onUpdate }) => {
+    const [formData, setFormData] = useState({
+        name: lineup?.name || '',
+        imageUrl: lineup?.imageUrl || '',
+        performanceAt: lineup?.performanceAt ? lineup.performanceAt.slice(0, 16) : ''
+    });
+    const [selectedFile, setSelectedFile] = useState(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // lineup이 변경될 때마다 폼 데이터 업데이트
+    useEffect(() => {
+        if (lineup) {
+            setFormData({
+                name: lineup.name || '',
+                imageUrl: lineup.imageUrl || '',
+                performanceAt: lineup.performanceAt ? lineup.performanceAt.slice(0, 16) : ''
+            });
+        }
+    }, [lineup]);
+
+    // ESC 키 이벤트 리스너
+    useEffect(() => {
+        const handleEscKey = (event) => {
+            if (event.key === 'Escape' && !isUploading) {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleEscKey);
+
+        return () => {
+            document.removeEventListener('keydown', handleEscKey);
+        };
+    }, [onClose, isUploading]);
+
+    // 모달이 닫힐 때 상태 초기화
+    useEffect(() => {
+        if (!isOpen) {
+            setSelectedFile(null);
+            setIsDragging(false);
+            setIsUploading(false);
+        }
+    }, [isOpen]);
+
+    const validateFile = (file) => {
+        const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
+        const maxSize = 5 * 1024 * 1024; // 5MB
+
+        if (!allowedTypes.includes(file.type)) {
+            showToast('PNG, JPG, JPEG 파일만 업로드 가능합니다.');
+            return false;
+        }
+
+        if (file.size > maxSize) {
+            showToast('파일 크기는 5MB 이하여야 합니다.');
+            return false;
+        }
+
+        return true;
+    };
+
+    const handleFileSelect = (file) => {
+        if (validateFile(file)) {
+            setSelectedFile(file);
+        }
+    };
+
+    const handleFileInputChange = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+            handleFileSelect(file);
+        }
+    };
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+    };
+
+    const handleDrop = (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+        
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            handleFileSelect(files[0]);
+        }
+    };
+
+    const handleUploadClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        
+        if (!formData.name.trim()) {
+            showToast('아티스트명을 입력해주세요.');
+            return;
+        }
+
+        if (!selectedFile && !lineup?.imageUrl) {
+            showToast('이미지를 선택해주세요.');
+            return;
+        }
+
+        if (!formData.performanceAt) {
+            showToast('공연 일시를 입력해주세요.');
+            return;
+        }
+        
+        setIsUploading(true);
+        
+        try {
+            let finalImageUrl = lineup?.imageUrl || '';
+            
+            if (selectedFile) {
+                // 파일을 base64로 변환
+                const reader = new FileReader();
+                finalImageUrl = await new Promise((resolve, reject) => {
+                    reader.onload = () => resolve(reader.result);
+                    reader.onerror = reject;
+                    reader.readAsDataURL(selectedFile);
+                });
+            }
+
+            const response = await lineupAPI.updateLineup(lineup.lineupId, {
+                name: formData.name,
+                imageUrl: finalImageUrl,
+                performanceAt: formData.performanceAt
+            });
+            
+            // 상태 업데이트
+            if (onUpdate) {
+                onUpdate(prev => prev.map(item => 
+                    item.lineupId === lineup.lineupId ? response : item
+                ));
+            }
+            
+            showToast('라인업이 성공적으로 수정되었습니다.');
+            onClose();
+        } catch (error) {
+            console.error('Lineup update error:', error);
+            showToast('라인업 수정에 실패했습니다.');
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({
+            ...prev,
+            [name]: value
+        }));
+    };
+
+    const handleDelete = async () => {
+        if (window.confirm(`${lineup?.name} 라인업을 삭제하시겠습니까?`)) {
+            try {
+                await lineupAPI.deleteLineup(lineup.lineupId);
+                
+                // 상태 업데이트
+                if (onUpdate) {
+                    onUpdate(prev => prev.filter(item => item.lineupId !== lineup.lineupId));
+                }
+                
+                showToast('라인업이 성공적으로 삭제되었습니다.');
+                onClose();
+            } catch (error) {
+                console.error('Lineup delete error:', error);
+                showToast('라인업 삭제에 실패했습니다.');
+            }
+        }
+    };
+
+    const handleClose = () => {
+        if (!isUploading) {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose} maxWidth="max-w-md">
+            <form onSubmit={handleSubmit}>
+                <h2 className="text-2xl font-bold mb-6 text-center">라인업 수정</h2>
+                
+                <div className="space-y-4">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            아티스트명
+                        </label>
+                        <input
+                            type="text"
+                            name="name"
+                            value={formData.name}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            placeholder="아티스트명을 입력하세요"
+                            required
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            이미지 선택
+                        </label>
+                        <div
+                            className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
+                                isDragging 
+                                    ? 'border-blue-500 bg-blue-50' 
+                                    : selectedFile 
+                                        ? 'border-green-500 bg-green-50' 
+                                        : lineup?.imageUrl
+                                            ? 'border-green-500 bg-green-50'
+                                            : 'border-gray-300 hover:border-gray-400'
+                            }`}
+                            onClick={handleUploadClick}
+                            onDragOver={handleDragOver}
+                            onDragLeave={handleDragLeave}
+                            onDrop={handleDrop}
+                        >
+                            {selectedFile ? (
+                                <div>
+                                    <div className="w-12 h-12 mx-auto mb-3 bg-green-100 rounded-full flex items-center justify-center">
+                                        <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                        </svg>
+                                    </div>
+                                    <p className="text-green-700 font-medium mb-1">{selectedFile.name}</p>
+                                    <p className="text-green-600 text-sm">
+                                        {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                                    </p>
+                                    <p className="text-gray-500 text-xs mt-2">클릭하여 다른 파일 선택</p>
+                                </div>
+                            ) : lineup?.imageUrl ? (
+                                <div>
+                                    <div className="w-12 h-12 mx-auto mb-3 bg-green-100 rounded-full flex items-center justify-center">
+                                        <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                        </svg>
+                                    </div>
+                                    <p className="text-green-700 font-medium mb-1">기존 이미지</p>
+                                    <p className="text-green-600 text-sm">이미지가 선택되어 있습니다</p>
+                                    <p className="text-gray-500 text-xs mt-2">클릭하여 다른 파일 선택</p>
+                                </div>
+                            ) : (
+                                <div>
+                                    <div className="w-12 h-12 mx-auto mb-3 bg-gray-100 rounded-full flex items-center justify-center">
+                                        <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                                        </svg>
+                                    </div>
+                                    <p className="text-gray-700 font-medium mb-1">클릭하여 이미지 선택</p>
+                                    <p className="text-gray-500 text-sm">PNG, JPG, JPEG (최대 5MB)</p>
+                                    <p className="text-gray-400 text-xs mt-2">또는 파일을 여기에 드래그하세요</p>
+                                </div>
+                            )}
+                        </div>
+                        
+                        {/* 숨겨진 파일 입력 */}
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/png,image/jpeg,image/jpg"
+                            onChange={handleFileInputChange}
+                            className="hidden"
+                        />
+                    </div>
+                    
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                            공연 일시
+                        </label>
+                        <input
+                            type="datetime-local"
+                            name="performanceAt"
+                            value={formData.performanceAt}
+                            onChange={handleChange}
+                            className="block w-full border border-gray-300 rounded-lg shadow-sm py-2 px-3 focus:ring-black focus:border-black"
+                            required
+                        />
+                    </div>
+                </div>
+                
+                <div className="space-y-3 mt-6">
+                    {/* 삭제 버튼 */}
+                    <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={isUploading}
+                        className="w-full bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition-colors duration-200 disabled:opacity-50"
+                    >
+                        라인업 삭제
+                    </button>
+                    
+                    {/* 취소/수정 버튼 */}
+                    <div className="flex space-x-3">
+                        <button
+                            type="button"
+                            onClick={handleClose}
+                            disabled={isUploading}
+                            className="flex-1 bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-400 transition-colors duration-200 disabled:opacity-50"
+                        >
+                            취소
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isUploading}
+                            className="flex-1 bg-black text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-800 transition-colors duration-200 disabled:opacity-50 flex items-center justify-center"
+                        >
+                            {isUploading ? (
+                                <>
+                                    <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                    </svg>
+                                    수정 중...
+                                </>
+                            ) : (
+                                '수정'
+                            )}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </Modal>
+    );
+};
+
+export default LineupEditModal;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -222,29 +222,28 @@ const HomePage = () => {
                         onMouseUp={handleMouseUp}
                         onMouseLeave={handleMouseLeave}
                     >
-                        <div className="flex space-x-6 w-max select-none">
+                        <div className="flex space-x-6 w-max select-none py-2">
                             {lineups.map((lineup, index) => (
                                 <div
                                     key={lineup.lineupId}
-                                    className="relative flex-shrink-0 text-center cursor-pointer hover:opacity-80 transition-opacity duration-200"
+                                    className="relative flex-shrink-0 text-center cursor-pointer hover:scale-105 transition-transform duration-300 ease-out"
                                     onClick={() => openModal('lineup-edit', { 
                                         lineup, 
                                         onUpdate: setLineups 
                                     })}
                                 >
-                                    {/* 개선된 프로필 이미지 - 오른쪽 하단 장식 효과 */}
-                                    <div className="relative w-24 h-24 mb-3">
-                                        <div className="w-full h-full bg-gray-200 overflow-hidden relative border-3 border-gray-300" style={{borderRadius: '50% 50% 50% 15%'}}>
+                                    {/* 개선된 프로필 이미지 - 축제 분위기 */}
+                                    <div className="relative w-24 h-24 mb-3 mt-2">
+                                        {/* 회색 테두리로 복구 */}
+                                        <div className="w-full h-full bg-white overflow-hidden relative border-2 border-gray-300 shadow-2xl hover:shadow-black transition-shadow duration-300" style={{borderRadius: '50% 50% 50% 15%', boxShadow: '0 10px 25px rgba(0, 0, 0, 0.3), 0 6px 10px rgba(0, 0, 0, 0.2)'}}>
                                             <img
                                                 src={lineup.imageUrl}
                                                 alt={lineup.name}
                                                 className="w-full h-full object-cover"
                                             />
-
                                         </div>
                                     </div>
-                                    <p className="text-sm font-medium text-gray-900 mb-1">{lineup.name}</p>
-                                    <p className="text-xs text-gray-500">{formatDateTime(lineup.performanceAt)}</p>
+                                    <p className="text-sm font-medium text-gray-900">{lineup.name}</p>
                                 </div>
                             ))}
                         </div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useModal } from '../hooks/useModal';
-import { festivalAPI } from '../utils/api';
+import { festivalAPI, lineupAPI } from '../utils/api';
 
 const HomePage = () => {
     const { openModal, showToast } = useModal();
     const [festival, setFestival] = useState(null);
+    const [lineups, setLineups] = useState([]);
     const [loading, setLoading] = useState(true);
     const [isDragging, setIsDragging] = useState(false);
     const scrollContainerRef = useRef(null);
@@ -12,10 +13,10 @@ const HomePage = () => {
     const scrollLeftRef = useRef(null);
 
     useEffect(() => {
-        fetchFestivalData();
+        fetchData();
     }, []);
 
-    const fetchFestivalData = async () => {
+    const fetchData = async () => {
         try {
             setLoading(true);
             const festivalId = localStorage.getItem('festivalId');
@@ -23,8 +24,15 @@ const HomePage = () => {
                 showToast('Festival ID가 설정되지 않았습니다.');
                 return;
             }
-            const festivalData = await festivalAPI.getFestival();
+            
+            // 축제 정보와 라인업 정보를 병렬로 가져오기
+            const [festivalData, lineupsData] = await Promise.all([
+                festivalAPI.getFestival(),
+                lineupAPI.getLineups()
+            ]);
+            
             setFestival(festivalData);
+            setLineups(lineupsData);
         } catch (error) {
             if (error.response?.status === 404) {
                 showToast('축제 정보를 찾을 수 없습니다. Festival ID를 확인해주세요.');
@@ -46,6 +54,15 @@ const HomePage = () => {
         const month = String(date.getMonth() + 1).padStart(2, '0');
         const day = String(date.getDate()).padStart(2, '0');
         return `${year}년 ${month}월 ${day}일`;
+    };
+
+    const formatDateTime = (dateTimeString) => {
+        const date = new Date(dateTimeString);
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${month}.${day} ${hours}:${minutes}`;
     };
 
     const handleMouseDown = (e) => {
@@ -83,7 +100,7 @@ const HomePage = () => {
             <div className="text-center py-12">
                 <p className="text-gray-600 mb-4">축제 정보를 불러올 수 없습니다.</p>
                 <button 
-                    onClick={fetchFestivalData}
+                    onClick={fetchData}
                     className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
                 >
                     다시 시도
@@ -179,6 +196,71 @@ const HomePage = () => {
                             className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
                         >
                             첫 번째 이미지 추가
+                        </button>
+                    </div>
+                )}
+            </div>
+
+            {/* 축제 라인업 */}
+            <div className="bg-white rounded-xl shadow-lg p-6 mb-8">
+                <div className="flex justify-between items-center mb-6">
+                    <h3 className="text-lg font-semibold text-gray-900">축제 라인업</h3>
+                    <button 
+                        onClick={() => openModal('lineup-add', { onUpdate: setLineups })}
+                        className="text-black hover:text-gray-700 text-sm font-medium"
+                    >
+                        추가
+                    </button>
+                </div>
+                
+                {lineups.length > 0 ? (
+                    <div 
+                        ref={scrollContainerRef}
+                        className={`overflow-x-auto ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+                        onMouseDown={handleMouseDown}
+                        onMouseMove={handleMouseMove}
+                        onMouseUp={handleMouseUp}
+                        onMouseLeave={handleMouseLeave}
+                    >
+                        <div className="flex space-x-6 w-max select-none">
+                            {lineups.map((lineup, index) => (
+                                <div
+                                    key={lineup.lineupId}
+                                    className="relative flex-shrink-0 text-center cursor-pointer hover:opacity-80 transition-opacity duration-200"
+                                    onClick={() => openModal('lineup-edit', { 
+                                        lineup, 
+                                        onUpdate: setLineups 
+                                    })}
+                                >
+                                    {/* 개선된 프로필 이미지 - 오른쪽 하단 장식 효과 */}
+                                    <div className="relative w-24 h-24 mb-3">
+                                        <div className="w-full h-full bg-gray-200 overflow-hidden relative border-3 border-gray-300" style={{borderRadius: '50% 50% 50% 15%'}}>
+                                            <img
+                                                src={lineup.imageUrl}
+                                                alt={lineup.name}
+                                                className="w-full h-full object-cover"
+                                            />
+
+                                        </div>
+                                    </div>
+                                    <p className="text-sm font-medium text-gray-900 mb-1">{lineup.name}</p>
+                                    <p className="text-xs text-gray-500">{formatDateTime(lineup.performanceAt)}</p>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="text-center py-12">
+                        <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+                        </svg>
+                        <p className="text-gray-500 mb-4">등록된 라인업이 없습니다</p>
+                        <button
+                            onClick={() => openModal('lineup-add', { onUpdate: setLineups })}
+                            className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                        >
+                            첫 번째 라인업 추가
                         </button>
                     </div>
                 )}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -504,4 +504,50 @@ export const lostItemAPI = {
     }
 };
 
+// 라인업 관련 API
+export const lineupAPI = {
+  // 특정 축제의 모든 라인업 조회
+  getLineups: async () => {
+    try {
+      const response = await api.get('/lineups');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch lineups:', error);
+      throw new Error('라인업 조회에 실패했습니다.');
+    }
+  },
+
+  // 라인업 추가
+  addLineup: async (lineupData) => {
+    try {
+      const response = await api.post('/lineups', lineupData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to add lineup:', error);
+      throw new Error('라인업 추가에 실패했습니다.');
+    }
+  },
+
+  // 라인업 수정
+  updateLineup: async (lineupId, lineupData) => {
+    try {
+      const response = await api.patch(`/lineups/${lineupId}`, lineupData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to update lineup:', error);
+      throw new Error('라인업 수정에 실패했습니다.');
+    }
+  },
+
+  // 라인업 삭제
+  deleteLineup: async (lineupId) => {
+    try {
+      await api.delete(`/lineups/${lineupId}`);
+    } catch (error) {
+      console.error('Failed to delete lineup:', error);
+      throw new Error('라인업 삭제에 실패했습니다.');
+    }
+  }
+};
+
 export default api;


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #607 

<br>

## 🛠️ 작업 내용

- 축제 라인업 조회, 추가, 수정, 삭제 기능 추가했습니다.

## 📸 이미지 첨부 (Optional)

<img width="3316" height="2010" alt="스크린샷 2025-08-21 오후 12 41 08" src="https://github.com/user-attachments/assets/4470e6fc-e30d-4270-9d1f-b5d55974a30e" />

<img width="862" height="1192" alt="스크린샷 2025-08-21 오후 12 41 13" src="https://github.com/user-attachments/assets/586fb8b2-1feb-42a5-930f-efd2073b5f45" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 홈에 “축제 라인업” 섹션 추가: 가로 드래그 스크롤 카드로 이미지·이름·공연시간 표시, 카드 클릭 시 편집 모달 오픈.
  - 라인업 추가/편집 모달 도입: 드래그앤드롭·클릭 이미지 업로드(형식·용량 검증), 날짜·시간 입력, 삭제 지원, 성공 시 목록 즉시 갱신, 업로드 중 로딩·ESC 종료 제어.
  - 모달 라우터에 라인업 추가/편집 케이스 추가.
- 개선
  - 초기 로딩 시 페스티벌·라인업 데이터를 병렬로 로드해 응답 속도 향상.
  - 401·네트워크 등 오류 상황별 토스트 안내 강화 및 에러 처리 개선.
- 버그픽스
  - API 그룹 추가 중 중복 정의가 포함되어 있어 정리 필요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->