### PR TITLE
[BE] dev 환경에서 이미지 저장 기능 확인할 수 있도록 수정

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -100,7 +100,7 @@ jobs:
           LOG_PATH="${DEPLOY_DIRECTORY}/application.log"
           echo "LOG_PATH=${LOG_PATH}"
 
-          sudo nohup java -jar -Duser.timezone=Asia/Seoul "${DEPLOY_JAR_PATH}" --spring.profiles.active=prod --server.port=${WAS_PORT} &
+          sudo nohup java -jar -Duser.timezone=Asia/Seoul "${DEPLOY_JAR_PATH}" --spring.profiles.active=dev --server.port=${WAS_PORT} &
           for i in $(seq 1 30); do
             if sudo lsof -t -i:${WAS_PORT} > /dev/null; then
               echo "WAS has started and is listening on port ${WAS_PORT}."

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -32,12 +32,11 @@ public class LocalStorageManager implements StorageManager {
 
             request.file().transferTo(fileStorePath);
 
-            StorageUploadResponse response = new StorageUploadResponse(
+            return new StorageUploadResponse(
                     ensureLeadingSlash(storeFile.getStoragePath()),
                     ensureLeadingSlash(storeFile.getStoragePath()),
                     request.storagePath()
             );
-            return response;
         } catch (IOException e) {
             throw new BusinessException(
                     String.format("로컬 저장소 파일 저장 실패 %s", e.getMessage()),

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -52,7 +52,7 @@ public class LocalStorageManager implements StorageManager {
     private void createDirectoryIfNotExists(Path directoryPath) throws IOException {
         if (directoryPath != null && !Files.exists(directoryPath)) {
             Files.createDirectories(directoryPath);
-            log.info("디렉토리가 생성되었습니다: {}", directoryPath);
+            log.debug("디렉토리가 생성되었습니다: {}", directoryPath);
         }
     }
 

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -1,0 +1,65 @@
+package com.daedan.festabook.storage.infrastructure;
+
+import com.daedan.festabook.storage.domain.StorageManager;
+import com.daedan.festabook.storage.dto.StorageUploadRequest;
+import com.daedan.festabook.storage.dto.StorageUploadResponse;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("dev")
+public class LocalStorageManager implements StorageManager {
+
+    private final String basePath;
+
+    public LocalStorageManager(
+            @Value("${local.storage.base-path}") String basePath
+    ) {
+        this.basePath = basePath;
+    }
+
+    @Override
+    public StorageUploadResponse uploadFile(StorageUploadRequest request) {
+        StoreFile storeFile = new StoreFile(request.file(), request.storagePath());
+
+        try {
+            Path fileStorePath = Paths.get(basePath, storeFile.getStoragePath());
+            createDirectoryIfNotExists(fileStorePath.getParent());
+
+            request.file().transferTo(fileStorePath);
+
+            StorageUploadResponse response = new StorageUploadResponse(
+                    ensureLeadingSlash(storeFile.getStoragePath()),
+                    ensureLeadingSlash(storeFile.getStoragePath()),
+                    request.storagePath()
+            );
+            return response;
+        } catch (IOException e) {
+            throw new RuntimeException(String.format(
+                    "로컬 저장소 파일 저장 실패 %s",
+                    e.getMessage()
+            ));
+        }
+    }
+
+    private void createDirectoryIfNotExists(Path directoryPath) throws IOException {
+        if (directoryPath != null && !Files.exists(directoryPath)) {
+            Files.createDirectories(directoryPath);
+            log.info("디렉토리가 생성되었습니다: {}", directoryPath);
+        }
+    }
+
+    private String ensureLeadingSlash(String storagePath) {
+        if (storagePath.startsWith("/")) {
+            return storagePath;
+        }
+        return String.format("/%s", storagePath);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -17,13 +17,8 @@ import org.springframework.stereotype.Component;
 @Profile("dev")
 public class LocalStorageManager implements StorageManager {
 
-    private final String basePath;
-
-    public LocalStorageManager(
-            @Value("${local.storage.base-path}") String basePath
-    ) {
-        this.basePath = basePath;
-    }
+    @Value("${local.storage.base-path}")
+    private String basePath;
 
     @Override
     public StorageUploadResponse uploadFile(StorageUploadRequest request) {

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -1,5 +1,6 @@
 package com.daedan.festabook.storage.infrastructure;
 
+import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.storage.domain.StorageManager;
 import com.daedan.festabook.storage.dto.StorageUploadRequest;
 import com.daedan.festabook.storage.dto.StorageUploadResponse;
@@ -10,6 +11,7 @@ import java.nio.file.Paths;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -37,10 +39,10 @@ public class LocalStorageManager implements StorageManager {
             );
             return response;
         } catch (IOException e) {
-            throw new RuntimeException(String.format(
-                    "로컬 저장소 파일 저장 실패 %s",
-                    e.getMessage()
-            ));
+            throw new BusinessException(
+                    String.format("로컬 저장소 파일 저장 실패 %s", e.getMessage()),
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
         }
     }
 

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!prod")
+@Profile("!prod & !dev")
 public class MockStorageManager implements StorageManager {
 
     private static final String MOCK_ACCESS_URL = "https://picsum.photos/200/300";

--- a/backend/src/test/java/com/daedan/festabook/storage/infrastructure/LocalStorageManagerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/storage/infrastructure/LocalStorageManagerTest.java
@@ -18,13 +18,11 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class LocalStorageManagerTest {
 
@@ -35,7 +33,8 @@ class LocalStorageManagerTest {
 
     @BeforeEach
     void setUp() {
-        localStorageManager = new LocalStorageManager(tempDirectory.toString());
+        localStorageManager = new LocalStorageManager();
+        ReflectionTestUtils.setField(localStorageManager, "basePath", tempDirectory.toString());
     }
 
     @Nested

--- a/backend/src/test/java/com/daedan/festabook/storage/infrastructure/LocalStorageManagerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/storage/infrastructure/LocalStorageManagerTest.java
@@ -29,13 +29,13 @@ import org.springframework.web.multipart.MultipartFile;
 class LocalStorageManagerTest {
 
     @TempDir
-    private Path tempDir;
+    private Path tempDirectory;
 
     private LocalStorageManager localStorageManager;
 
     @BeforeEach
     void setUp() {
-        localStorageManager = new LocalStorageManager(tempDir.toString());
+        localStorageManager = new LocalStorageManager(tempDirectory.toString());
     }
 
     @Nested
@@ -65,7 +65,7 @@ class LocalStorageManagerTest {
                 s.assertThat(response.accessRelativePath()).startsWith(expectedRelativePath);
                 s.assertThat(response.storagePath()).isEqualTo(storagePath);
             });
-            Path expectedFilePath = tempDir.resolve(response.storagePath());
+            Path expectedFilePath = tempDirectory.resolve(response.storagePath());
             assertThat(Files.exists(expectedFilePath)).isTrue();
         }
 

--- a/backend/src/test/java/com/daedan/festabook/storage/infrastructure/LocalStorageManagerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/storage/infrastructure/LocalStorageManagerTest.java
@@ -1,0 +1,91 @@
+package com.daedan.festabook.storage.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+
+import com.daedan.festabook.storage.dto.StorageUploadRequest;
+import com.daedan.festabook.storage.dto.StorageUploadRequestFixture;
+import com.daedan.festabook.storage.dto.StorageUploadResponse;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LocalStorageManagerTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private LocalStorageManager localStorageManager;
+
+    @BeforeEach
+    void setUp() {
+        localStorageManager = new LocalStorageManager(tempDir.toString());
+    }
+
+    @Nested
+    class uploadFile {
+
+        @Test
+        void 성공() {
+            // given
+            String fileName = "sample.png";
+            MockMultipartFile mockFile = new MockMultipartFile(
+                    "file",
+                    fileName,
+                    "image/png",
+                    new byte[10]
+            );
+            String storagePath = "images/" + fileName;
+            String expectedAccessUrl = "/" + storagePath;
+            String expectedRelativePath = "/" + storagePath;
+            StorageUploadRequest request = StorageUploadRequestFixture.create(mockFile, storagePath);
+
+            // when
+            StorageUploadResponse response = localStorageManager.uploadFile(request);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(response.accessUrl()).isEqualTo(expectedAccessUrl);
+                s.assertThat(response.accessRelativePath()).startsWith(expectedRelativePath);
+                s.assertThat(response.storagePath()).isEqualTo(storagePath);
+            });
+            Path expectedFilePath = tempDir.resolve(response.storagePath());
+            assertThat(Files.exists(expectedFilePath)).isTrue();
+        }
+
+        @Test
+        void 예외_파일_저장_실패시_RuntimeException_변환() throws IOException {
+            // given
+            // 파일 데이터를 비워서 IOException을 발생시킴
+            MultipartFile mockFile = mock(MultipartFile.class);
+            willThrow(IOException.class)
+                    .given(mockFile)
+                    .transferTo(any(Path.class));
+
+            String storagePath = "images/sample.png";
+            StorageUploadRequest request = new StorageUploadRequest(mockFile, storagePath);
+
+            // when & then
+            // RuntimeException이 발생하는지 검증
+            assertThatThrownBy(() -> localStorageManager.uploadFile(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("로컬 저장소 파일 저장 실패");
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/storage/infrastructure/S3StorageManagerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/storage/infrastructure/S3StorageManagerTest.java
@@ -68,17 +68,19 @@ class S3StorageManagerTest {
                     mockRegion,
                     BASE_PATH
             );
+            String expectedRelativePath = "/" + fileName;
             String expectedS3Key = String.format("%s/%s", BASE_PATH, fileName);
 
             StorageUploadRequest request = StorageUploadRequestFixture.create(mockFile, fileName);
 
             // when
-            StorageUploadResponse result = s3StorageManager.uploadFile(request);
+            StorageUploadResponse response = s3StorageManager.uploadFile(request);
 
             // then
             assertSoftly(s -> {
-                s.assertThat(result.accessUrl()).isEqualTo(expectedFileUrl);
-                s.assertThat(result.storagePath()).isEqualTo(expectedS3Key);
+                s.assertThat(response.accessUrl()).isEqualTo(expectedFileUrl);
+                s.assertThat(response.accessRelativePath()).isEqualTo(expectedRelativePath);
+                s.assertThat(response.storagePath()).isEqualTo(expectedS3Key);
             });
             then(s3Client).should()
                     .putObject(any(PutObjectRequest.class), any(RequestBody.class));


### PR DESCRIPTION
## #️⃣ 이슈 번호

#596 

<br>

## 🛠️ 작업 내용

- dev 환경에서 이미지 저장 기능을 위한 StorageManager 추가

<br>

## 📸 이미지 첨부 (Optional)

dev 서버도 이미지 업로드 후 EC2 내부에 파일이 생성되어 조회가 가능합니다.

<img width="518" height="494" alt="image" src="https://github.com/user-attachments/assets/9eee0117-f63b-4bf1-b6bb-eaeff72093fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 개발 환경에서 로컬 파일 업로드를 지원합니다.
  - 업로드 응답에 상대 경로(accessRelativePath)가 포함되어 접근 경로 일관성이 향상되었습니다.
- Tests
  - 로컬 저장소 업로드의 정상 동작 및 저장 실패 시 예외 전환을 검증하는 테스트를 추가했습니다.
  - 클라우드 저장소 업로드 응답의 상대 경로 검증을 보강했습니다.
- Chores
  - 비프로덕션 빈 활성화 조건을 명확히 조정(개발 환경 제외 포함)하고, 배포 파이프라인의 실행 프로필을 개발(dev)으로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->