### PR TITLE
[COMMON] Noti Submitted 리뷰어 멘션 삭제

### DIFF
--- a/.github/workflows/common-slack-notify-submitted.yml
+++ b/.github/workflows/common-slack-notify-submitted.yml
@@ -42,7 +42,6 @@ jobs:
           SLACK_REVIEWER_ID=${GITHUB_TO_SLACK[$PR_REVIEWER]:-$PR_REVIEWER}
           SLACK_AUTHOR_ID=${GITHUB_TO_SLACK[$PR_AUTHOR]:-$PR_AUTHOR}
 
-          SLACK_REVIEWER_MENTION="<@$SLACK_REVIEWER_ID>"
           SLACK_AUTHOR_MENTION="<@$SLACK_AUTHOR_ID>"
 
           if [[ "$PR_REVIEWER" == *"[bot]" ]]; then
@@ -57,5 +56,5 @@ jobs:
           esac
 
           curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\": \"${ICON} *리뷰 완료 알림*\n*PR 제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${SLACK_AUTHOR_MENTION}\n*리뷰어:* ${SLACK_REVIEWER_MENTION}\n*상태:* ${REVIEW_STATE}\n*링크:* ${PR_URL}\"}" \
+            --data "{\"text\": \"${ICON} *리뷰 완료 알림*\n*PR 제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${SLACK_AUTHOR_MENTION}\n*상태:* ${REVIEW_STATE}\n*링크:* ${PR_URL}\"}" \
             $SLACK_WEBHOOK_URL


### PR DESCRIPTION
## #️⃣ 이슈 번호

#484

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 제출된 PR에 대한 Slack 알림에서 리뷰어 멘션(언급) 라인을 제거했습니다.
  - 이제 알림에는 PR 제목, 작성자, 상태, 링크만 포함되며, 리뷰어 정보는 표시되지 않습니다.
  - 알림 아이콘과 전송 흐름 등 기존 동작은 변경하지 않았습니다.
  - 팀 채널로 전송되는 메시지 형식이 간소화되어, PR 핵심 정보만 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->