### PR TITLE
[AN] 알림 기능 문제 해결 및 권한 거부 시 추가 기능 구현

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
+++ b/android/app/src/main/java/com/daedan/festabook/AppContainer.kt
@@ -140,6 +140,7 @@ class AppContainer(
             festivalNotificationDataSource,
             deviceLocalDataSource,
             festivalNotificationLocalDataSource,
+            festivalLocalDataSource,
         )
     }
     val festivalRepository: FestivalRepository by lazy {

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationDataSource.kt
@@ -5,7 +5,7 @@ import com.daedan.festabook.data.model.response.festival.FestivalNotificationRes
 
 interface FestivalNotificationDataSource {
     suspend fun saveFestivalNotification(
-        festivalNotificationId: Long,
+        festivalId: Long,
         deviceId: Long,
     ): ApiResult<FestivalNotificationResponse>
 

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationDataSourceImpl.kt
@@ -9,12 +9,12 @@ class FestivalNotificationDataSourceImpl(
     private val festivalNotificationService: FestivalNotificationService,
 ) : FestivalNotificationDataSource {
     override suspend fun saveFestivalNotification(
-        festivalNotificationId: Long,
+        festivalId: Long,
         deviceId: Long,
     ): ApiResult<FestivalNotificationResponse> =
         ApiResult.toApiResult {
             festivalNotificationService.saveFestivalNotification(
-                festivalNotificationId,
+                festivalId,
                 FestivalNotificationRequest(deviceId = deviceId),
             )
         }

--- a/android/app/src/main/java/com/daedan/festabook/data/service/FestivalNotificationService.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/FestivalNotificationService.kt
@@ -9,13 +9,13 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface FestivalNotificationService {
-    @POST("/festivals/{festivalId}/notifications")
+    @POST("festivals/{festivalId}/notifications")
     suspend fun saveFestivalNotification(
         @Path("festivalId") id: Long,
         @Body request: FestivalNotificationRequest,
     ): Response<FestivalNotificationResponse>
 
-    @DELETE("/festivals/notifications/{festivalNotificationId}")
+    @DELETE("festivals/notifications/{festivalNotificationId}")
     suspend fun deleteFestivalNotification(
         @Path("festivalNotificationId") id: Long,
     ): Response<Unit>

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/PermissionUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/PermissionUtil.kt
@@ -2,7 +2,12 @@ package com.daedan.festabook.presentation.common
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import android.view.View
 import com.daedan.festabook.R
+import com.google.android.material.snackbar.Snackbar
 
 fun Int.isGranted(): Boolean = this == 0
 
@@ -14,3 +19,22 @@ fun Context.toLocationPermissionDeniedTextOrNull(rawText: String) =
 
         else -> null
     }
+
+fun showNotificationDeniedSnackbar(
+    view: View,
+    context: Context,
+) {
+    Snackbar
+        .make(
+            view,
+            context.getString(R.string.notification_permission_denied_message),
+            Snackbar.LENGTH_LONG,
+        ).setAction(context.getString(R.string.move_to_setting_text)) {
+            val intent =
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            context.startActivity(intent)
+        }.show()
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -19,6 +19,7 @@ import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.isGranted
+import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
 import com.daedan.festabook.presentation.common.showToast
 import com.daedan.festabook.presentation.common.toLocationPermissionDeniedTextOrNull
 import com.daedan.festabook.presentation.home.HomeFragment
@@ -60,7 +61,11 @@ class MainActivity :
     }
 
     private val notificationPermissionManager by lazy {
-        NotificationPermissionManager(this)
+        NotificationPermissionManager(
+            requester = this,
+            onPermissionGranted = { onPermissionGranted() },
+            onPermissionDenied = { onPermissionDenied() },
+        )
     }
 
     override val permissionLauncher: ActivityResultLauncher<String> =
@@ -69,9 +74,10 @@ class MainActivity :
         ) { isGranted: Boolean ->
             if (isGranted) {
                 Timber.d("Notification permission granted")
+                mainViewModel.saveNotificationId()
             } else {
                 Timber.d("Notification permission denied")
-                // 사용자에게 알림 권한이 필요한 이유를 설명하거나, 설정 화면으로 유도
+                showNotificationDeniedSnackbar(binding.main, this)
             }
         }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -42,7 +42,9 @@ class SettingFragment :
             }
         }
 
-    override fun onPermissionGranted() = Unit
+    override fun onPermissionGranted() {
+        viewModel.saveNotificationId()
+    }
 
     override fun onPermissionDenied() {
         binding.btnNoticeAllow.isChecked = false

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -14,6 +14,7 @@ import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.showErrorSnackBar
+import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
 import timber.log.Timber
 
 class SettingFragment :
@@ -26,6 +27,7 @@ class SettingFragment :
     private val notificationPermissionManager by lazy {
         NotificationPermissionManager(
             requester = this,
+            onPermissionGranted = { onPermissionGranted() },
             onPermissionDenied = { onPermissionDenied() },
         )
     }
@@ -38,19 +40,16 @@ class SettingFragment :
                 Timber.d("Notification permission granted")
             } else {
                 Timber.d("Notification permission denied")
-                // 사용자에게 알림 권한이 필요한 이유를 설명하거나, 설정 화면으로 유도
+                showNotificationDeniedSnackbar(binding.root, requireContext())
+                binding.btnNoticeAllow.isChecked = false
+                viewModel.updateNotificationIsAllowed(false)
+                viewModel.saveNotificationIsAllowed(false)
             }
         }
 
-    override fun onPermissionGranted() {
-        viewModel.saveNotificationId()
-    }
+    override fun onPermissionGranted() = Unit
 
-    override fun onPermissionDenied() {
-        binding.btnNoticeAllow.isChecked = false
-        viewModel.updateNotificationIsAllowed(false)
-        viewModel.saveNotificationIsAllowed(false)
-    }
+    override fun onPermissionDenied() = Unit
 
     override fun onViewCreated(
         view: View,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -40,7 +40,7 @@ class SettingViewModel(
         isAllowed = allowed
     }
 
-    private fun saveNotificationId() {
+    fun saveNotificationId() {
         viewModelScope.launch {
             val result =
                 festivalNotificationRepository.saveFestivalNotification()
@@ -50,7 +50,7 @@ class SettingViewModel(
                     saveNotificationIsAllowed(isAllowed)
                 }.onFailure {
                     _error.value = Event(it)
-                    Timber.e(it, "${::SettingViewModel.name} NotificationId 저장 실패")
+                    Timber.e(it, "${::SettingViewModel.javaClass.simpleName} NotificationId 저장 실패")
                 }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -29,6 +29,7 @@ class SettingViewModel(
     fun notificationAllowClick() {
         updateNotificationIsAllowed(!isAllowed)
         _allowClickEvent.value = Event(Unit)
+        Timber.d("$isAllowed")
         if (isAllowed) saveNotificationId() else deleteNotificationId()
     }
 
@@ -40,7 +41,7 @@ class SettingViewModel(
         isAllowed = allowed
     }
 
-    fun saveNotificationId() {
+    private fun saveNotificationId() {
         viewModelScope.launch {
             val result =
                 festivalNotificationRepository.saveFestivalNotification()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -116,6 +116,9 @@
 
     <!--토스트 메시지-->
     <string name="back_press_exit_message">뒤로가기를 한 번 더 누르면 종료됩니다.</string>
+    <!--알림 권한-->
+    <string name="notification_permission_denied_message">알림이 비활성화되어 있습니다 [설정]에서 다시 켤 수 있어요.</string>
+    <string name="move_to_setting_text">설정으로 이동</string>
 
 
 </resources>

--- a/android/app/src/test/java/com/daedan/festabook/main/MainViewModelTest.kt
+++ b/android/app/src/test/java/com/daedan/festabook/main/MainViewModelTest.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.main
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.daedan.festabook.domain.repository.DeviceRepository
+import com.daedan.festabook.domain.repository.FestivalNotificationRepository
 import com.daedan.festabook.presentation.main.MainViewModel
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -29,12 +30,14 @@ class MainViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var deviceRepository: DeviceRepository
     private lateinit var mainViewModel: MainViewModel
+    private lateinit var festivalNotificationRepository: FestivalNotificationRepository
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         deviceRepository = mockk()
-        mainViewModel = MainViewModel(deviceRepository)
+        festivalNotificationRepository = mockk()
+        mainViewModel = MainViewModel(deviceRepository, festivalNotificationRepository)
 
         coEvery {
             deviceRepository.registerDevice(


### PR DESCRIPTION
## #️⃣ 이슈 번호

#616 

<br>

## 🛠️ 작업 내용

- 알림 권한 거부 시 설정화면으로 이동할 수 있는 스낵바 구현
- 알림 기능 문제 해결

<br>

## 🙇🏻 중점 리뷰 요청

- 다이어로그 메시지, 스위치 버튼, 시스템 권한 등 분기처리 할 부분이 생각보다 너어무 많아서 제가 놓친 부분이 있을 가능성이 높아요... 그래도 최대한 꼼꼼하게 보긴했습니다..🥲(+ 피곤이슈로 심신미약)

- 이 함수들은 나중에 쓸 일이 있을 것 같아서 일단 그냥 둘게용.
```kotlin
override fun onPermissionGranted() = Unit
override fun onPermissionDenied() = Unit
```

<br>

## 📸 이미지 첨부 (Optional)

### 권한 거부 시 설정 화면 이동 
https://github.com/user-attachments/assets/f43800c5-ab5a-460e-91b4-0737e9b657c6

### 알림 기능 fix
https://github.com/user-attachments/assets/cbce1fbe-fb17-4ce9-baab-11981d416dcb




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 알림 권한 거부 시 스낵바로 안내하고 ‘설정으로 이동’ 액션 제공.
  - 권한 허용 시 즉시 알림 등록을 시도하고 허용 상태를 저장.

- 리팩터
  - 메인/설정 화면 권한 요청 흐름을 콜백 기반으로 정리해 거부·허용 처리와 UI(체크 상태, 안내 메시지)를 명확히 정리.
  - 알림 등록/삭제 통신 경로 및 관련 흐름을 정비해 안정성 향상.

- 기타
  - 알림 관련 문자열 리소스 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->