### PR TITLE
[FE] 이미지 업로드 api 연동/ Q&A 표현 FAQ로 변경

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,12 +16,12 @@ import BoothsPage from './pages/BoothsPage';
 import MapSettingsPage from './pages/MapSettingsPage';
 import NoticesPage from './pages/NoticesPage';
 import LostFoundPage from './pages/LostFoundPage';
-import QnaPage from './pages/QnaPage';
+import FaqPage from './pages/FaqPage';
 
 // Modals
 import NoticeModal from './components/modals/NoticeModal';
 import LostItemModal from './components/modals/LostItemModal';
-import QnaModal from './components/modals/QnaModal';
+import FaqModal from './components/modals/FaqModal';
 import ScheduleModal from './components/modals/ScheduleModal';
 import DatePromptModal from './components/modals/DatePromptModal';
 import BoothModal from './components/modals/BoothModal';
@@ -68,7 +68,7 @@ function App() {
             case 'map-settings': return <MapSettingsPage />;
             case 'notices': return <NoticesPage />;
             case 'lost-found': return <LostFoundPage />;
-            case 'qna': return <QnaPage />;
+            case 'faq': return <FaqPage />;
             default: return <HomePage />;
         }
     };
@@ -80,7 +80,7 @@ function App() {
             case 'notice': return <NoticeModal {...allProps} isPlaceNotice={props.isPlaceNotice} />;
             case 'notice-detail': return <NoticeDetailModal {...allProps} />;
             case 'lostItem': return <LostItemModal {...allProps} />;
-            case 'qna': return <QnaModal {...allProps} />;
+            case 'faq': return <FaqModal {...allProps} />;
             case 'schedule': return <ScheduleModal {...allProps} />;
             case 'datePrompt': return <DatePromptModal {...allProps} />;
             case 'booth': return <BoothModal {...allProps} />;

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -173,7 +173,7 @@ const Sidebar = ({ open, setOpen }) => {
                 <NavLink target="home" icon="fa-home" open={open}>홈</NavLink>
                 <NavLink target="schedule" icon="fa-calendar-alt" open={open}>일정</NavLink>
                 <SubMenu icon="fa-map-marked-alt" title="지도" links={[{ target: 'booths', title: '플레이스 관리' }, { target: 'map-settings', title: '지도 설정' }]} open={openMenus[0]} onToggle={() => handleSubMenuToggle(0)} sidebarOpen={open} />
-                <SubMenu icon="fa-bullhorn" title="소식" links={[{ target: 'notices', title: '공지 사항' }, { target: 'qna', title: 'QnA' }, { target: 'lost-found', title: '분실물' }]} open={openMenus[1]} onToggle={() => handleSubMenuToggle(1)} sidebarOpen={open} />
+                <SubMenu icon="fa-bullhorn" title="소식" links={[{ target: 'notices', title: '공지 사항' }, { target: 'faq', title: 'FAQ' }, { target: 'lost-found', title: '분실물' }]} open={openMenus[1]} onToggle={() => handleSubMenuToggle(1)} sidebarOpen={open} />
             </nav>
             
             {/* 로그아웃 버튼 - 사이드바 하단에 배치 */}

--- a/frontend/src/components/modals/AddImageModal.jsx
+++ b/frontend/src/components/modals/AddImageModal.jsx
@@ -1,14 +1,128 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Modal from '../common/Modal';
-import { festivalAPI, placeAPI } from '../../utils/api';
+import { festivalAPI, placeAPI, imageAPI } from '../../utils/api';
+import { validateImageFile } from '../../utils/imageUpload';
 
-const AddImageModal = ({ isOpen, onClose, showToast, onImageAdded, placeId, isPlaceImage = false }) => {
+const AddImageModal = ({ 
+    isOpen, 
+    onClose, 
+    showToast, 
+    onImageAdded, 
+    placeId, 
+    isPlaceImage = false, 
+    isImageOnly = false, // 이미지만 업로드하고 URL만 반환할지 여부
+    onImageUploaded // 이미지 URL만 필요한 경우 사용할 콜백
+}) => {
     // showToast가 없을 경우 기본 함수 사용
     const handleToast = showToast || ((message) => console.log(message));
-    const [selectedFile, setSelectedFile] = useState(null);
-    const [isDragging, setIsDragging] = useState(false);
-    const [isUploading, setIsUploading] = useState(false);
     const fileInputRef = useRef(null);
+
+    // 상태 관리
+    const [selectedFile, setSelectedFile] = useState(null);
+    const [isUploading, setIsUploading] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
+
+    // 파일 검증 함수
+    const validateFile = (file) => {
+        const validation = validateImageFile(file);
+        if (!validation.isValid) {
+            handleToast(validation.message);
+            return false;
+        }
+        return true;
+    };
+
+    // 파일 업로드 함수
+    const uploadFile = async () => {
+        if (!selectedFile) return;
+
+        setIsUploading(true);
+        try {
+            // 1단계: 이미지 업로드
+            const response = await imageAPI.uploadImage(selectedFile);
+            const imageUrl = response.imageUrl;
+
+            // 이미지만 업로드하고 URL만 반환하는 경우
+            if (isImageOnly && onImageUploaded) {
+                onImageUploaded(imageUrl);
+                handleToast('이미지가 성공적으로 업로드되었습니다.');
+                onClose();
+                return;
+            }
+            
+            // 2단계: 반환된 URL을 목적별 API에 전송
+            let apiResponse;
+            if (isPlaceImage && placeId) {
+                // 플레이스 이미지인 경우
+                apiResponse = await placeAPI.createPlaceImage(placeId, {
+                    imageUrl: imageUrl
+                });
+            } else {
+                // 축제 이미지인 경우
+                apiResponse = await festivalAPI.addFestivalImage({
+                    imageUrl: imageUrl
+                });
+            }
+            
+            handleToast('이미지가 성공적으로 업로드되었습니다.');
+            
+            // 새로 추가된 이미지를 부모 컴포넌트에 전달
+            if (onImageAdded && apiResponse) {
+                onImageAdded(apiResponse);
+            } else {
+                onClose();
+            }
+        } catch (error) {
+            console.error('Image upload error:', error);
+            handleToast(error.message || '이미지 업로드에 실패했습니다.');
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    // 상태 초기화
+    const reset = () => {
+        setSelectedFile(null);
+        setIsUploading(false);
+        setIsDragging(false);
+    };
+
+    // 드래그 이벤트 핸들러
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+    };
+
+    const handleDrop = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            const file = files[0];
+            if (validateFile(file)) {
+                setSelectedFile(file);
+            }
+        }
+    };
+
+    // 파일 입력 변경 핸들러
+    const handleFileInputChange = (e) => {
+        const file = e.target.files[0];
+        if (file && validateFile(file)) {
+            setSelectedFile(file);
+        }
+        // input value 초기화 (같은 파일 다시 선택 가능하게)
+        e.target.value = '';
+    };
 
     // ESC 키 이벤트 리스너
     useEffect(() => {
@@ -32,9 +146,7 @@ const AddImageModal = ({ isOpen, onClose, showToast, onImageAdded, placeId, isPl
     // 모달이 닫힐 때 상태 초기화
     useEffect(() => {
         if (!isOpen) {
-            setSelectedFile(null);
-            setIsDragging(false);
-            setIsUploading(false);
+            reset();
         }
     }, [isOpen]);
 
@@ -44,97 +156,12 @@ const AddImageModal = ({ isOpen, onClose, showToast, onImageAdded, placeId, isPl
         }
     };
 
-    const validateFile = (file) => {
-        const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
-        const maxSize = 5 * 1024 * 1024; // 5MB
-
-        if (!allowedTypes.includes(file.type)) {
-            handleToast('PNG, JPG, JPEG 파일만 업로드 가능합니다.');
-            return false;
-        }
-
-        if (file.size > maxSize) {
-            handleToast('파일 크기는 5MB 이하여야 합니다.');
-            return false;
-        }
-
-        return true;
-    };
-
-    const handleFileSelect = (file) => {
-        if (validateFile(file)) {
-            setSelectedFile(file);
-        }
-    };
-
-    const handleFileInputChange = (e) => {
-        const file = e.target.files[0];
-        if (file) {
-            handleFileSelect(file);
-        }
-    };
-
-    const handleDragOver = (e) => {
-        e.preventDefault();
-        setIsDragging(true);
-    };
-
-    const handleDragLeave = (e) => {
-        e.preventDefault();
-        setIsDragging(false);
-    };
-
-    const handleDrop = (e) => {
-        e.preventDefault();
-        setIsDragging(false);
-        
-        const files = e.dataTransfer.files;
-        if (files.length > 0) {
-            handleFileSelect(files[0]);
-        }
-    };
-
     const handleUploadClick = () => {
         fileInputRef.current?.click();
     };
 
     const handleUpload = async () => {
-        if (!selectedFile) {
-            handleToast('업로드할 이미지를 선택해주세요.');
-            return;
-        }
-
-        setIsUploading(true);
-        
-        try {
-            const imageUrl = URL.createObjectURL(selectedFile);
-            
-            let response;
-            if (isPlaceImage && placeId) {
-                // 플레이스 이미지인 경우
-                response = await placeAPI.createPlaceImage(placeId, {
-                    imageUrl: imageUrl
-                });
-            } else {
-                // 축제 이미지인 경우
-                response = await festivalAPI.addFestivalImage({
-                    imageUrl: imageUrl
-                });
-            }
-            
-            handleToast('이미지가 성공적으로 업로드되었습니다.');
-            
-            // 새로 추가된 이미지를 부모 컴포넌트에 전달
-            if (onImageAdded && response) {
-                onImageAdded(response);
-            } else {
-                onClose();
-            }
-        } catch (error) {
-            handleToast('이미지 업로드에 실패했습니다.');
-        } finally {
-            setIsUploading(false);
-        }
+        await uploadFile();
     };
 
     return (
@@ -229,4 +256,4 @@ const AddImageModal = ({ isOpen, onClose, showToast, onImageAdded, placeId, isPl
     );
 };
 
-export default AddImageModal; 
+export default AddImageModal;

--- a/frontend/src/components/modals/FaqModal.jsx
+++ b/frontend/src/components/modals/FaqModal.jsx
@@ -1,14 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Modal from '../common/Modal';
 
-const QnaModal = ({ qna, onSave, onClose }) => {
+const FaqModal = ({ faq, onSave, onClose }) => {
     const [question, setQuestion] = useState('');
     const [answer, setAnswer] = useState('');
     useEffect(() => {
-        setQuestion(qna?.question || '');
-        setAnswer(qna?.answer || '');
-    }, [qna]);
-    const handleSave = () => { onSave({ question, answer }); onClose(); };
+        setQuestion(faq?.question || '');
+        setAnswer(faq?.answer || '');
+    }, [faq]);
+    
+    const handleSave = useCallback(() => { 
+        onSave({ question, answer }); 
+        onClose(); 
+    }, [question, answer, onSave, onClose]);
     
     useEffect(() => {
         const handleKeyPress = (e) => {
@@ -25,11 +29,11 @@ const QnaModal = ({ qna, onSave, onClose }) => {
         return () => {
             document.removeEventListener('keydown', handleKeyPress);
         };
-    }, [question, answer, onClose]);
+    }, [question, answer, onClose, handleSave]);
 
     return (
         <Modal isOpen={true} onClose={onClose}>
-            <h3 className="text-xl font-bold mb-6">{qna ? 'QnA 수정' : '새 QnA 등록'}</h3>
+            <h3 className="text-xl font-bold mb-6">{faq ? 'FAQ 수정' : '새 FAQ 등록'}</h3>
             <div className="space-y-4">
                 <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">질문</label>
@@ -62,4 +66,4 @@ const QnaModal = ({ qna, onSave, onClose }) => {
     );
 };
 
-export default QnaModal;
+export default FaqModal;

--- a/frontend/src/components/modals/FestivalImagesModal.jsx
+++ b/frontend/src/components/modals/FestivalImagesModal.jsx
@@ -12,15 +12,6 @@ const FestivalImagesModal = ({ isOpen, onClose, festival, showToast, onUpdate })
     const [selectedImageToDelete, setSelectedImageToDelete] = useState(null);
     const [showAddImageModal, setShowAddImageModal] = useState(false);
 
-    // 이미지 데이터 정규화 함수
-    const normalizeImageData = useCallback((imageData) => {
-        return imageData.map(image => ({
-            ...image,
-            id: image.festivalImageId || image.id,
-            festivalImageId: image.festivalImageId || image.id
-        }));
-    }, []);
-
     const handleCancelMode = useCallback(() => {
         setIsReorderMode(false);
         setIsDeleteMode(false);
@@ -63,8 +54,7 @@ const FestivalImagesModal = ({ isOpen, onClose, festival, showToast, onUpdate })
     useEffect(() => {
         if (isOpen) {
             if (festival?.festivalImages) {
-                const normalizedImages = normalizeImageData(festival.festivalImages);
-                setImages(normalizedImages);
+                setImages([...festival.festivalImages]);
             }
         } else {
             // 모달이 닫힐 때 모든 상태 초기화
@@ -75,7 +65,7 @@ const FestivalImagesModal = ({ isOpen, onClose, festival, showToast, onUpdate })
             setSelectedImageToDelete(null);
             setShowAddImageModal(false);
         }
-    }, [festival, isOpen, normalizeImageData]);
+    }, [festival, isOpen]);
 
     const handleImageClick = (image) => {
         if (!isReorderMode && !isDeleteMode) {
@@ -150,12 +140,11 @@ const FestivalImagesModal = ({ isOpen, onClose, festival, showToast, onUpdate })
             
             // 상태 업데이트
             if (onUpdate && response) {
-                const normalizedResponseImages = normalizeImageData(response);
                 onUpdate(prev => ({
                     ...prev,
-                    festivalImages: normalizedResponseImages
+                    festivalImages: response
                 }));
-                setImages(normalizedResponseImages);
+                setImages(response);
             }
             
             showToast('이미지 순서가 저장되었습니다.');
@@ -397,7 +386,7 @@ const FestivalImagesModal = ({ isOpen, onClose, festival, showToast, onUpdate })
                     try {
                         // 서버에서 최신 축제 데이터를 다시 가져와서 업데이트
                         const updatedFestival = await festivalAPI.getFestival();
-                        const updatedImages = normalizeImageData(updatedFestival.festivalImages || []);
+                        const updatedImages = updatedFestival.festivalImages || [];
                         setImages(updatedImages);
                         
                         // 부모 컴포넌트에 업데이트 전달

--- a/frontend/src/components/modals/LineupAddModal.jsx
+++ b/frontend/src/components/modals/LineupAddModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Modal from '../common/Modal';
-import { lineupAPI } from '../../utils/api';
+import { lineupAPI, imageAPI } from '../../utils/api';
 
 const LineupAddModal = ({ isOpen, onClose, showToast, onUpdate }) => {
     const [formData, setFormData] = useState({
@@ -117,14 +117,11 @@ const LineupAddModal = ({ isOpen, onClose, showToast, onUpdate }) => {
         setIsUploading(true);
         
         try {
-            // 파일을 base64로 변환
-            const reader = new FileReader();
-            const imageUrl = await new Promise((resolve, reject) => {
-                reader.onload = () => resolve(reader.result);
-                reader.onerror = reject;
-                reader.readAsDataURL(selectedFile);
-            });
+            // 1단계: 이미지 파일을 백엔드 이미지 업로드 API로 전송
+            const uploadResponse = await imageAPI.uploadImage(selectedFile);
+            const imageUrl = uploadResponse.imageUrl;
 
+            // 2단계: 라인업 API에 이미지 URL과 함께 데이터 전송
             const response = await lineupAPI.addLineup({
                 name: formData.name,
                 imageUrl: imageUrl,
@@ -140,7 +137,7 @@ const LineupAddModal = ({ isOpen, onClose, showToast, onUpdate }) => {
             onClose();
         } catch (error) {
             console.error('Lineup add error:', error);
-            showToast('라인업 추가에 실패했습니다.');
+            showToast(error.message || '라인업 추가에 실패했습니다.');
         } finally {
             setIsUploading(false);
         }

--- a/frontend/src/contexts/DataProvider.jsx
+++ b/frontend/src/contexts/DataProvider.jsx
@@ -41,19 +41,19 @@ export const DataProvider = ({ children }) => {
         }
     };
 
-    const fetchQnaItems = async () => {
+    const fetchFaqItems = async () => {
         try {
             setIsLoadingQna(true);
             const questions = await qnaAPI.getQuestions();
             setData(prev => ({
                 ...prev,
-                qnaItems: questions
+                faqItems: questions
             }));
         } catch {
             // 초기 로드 실패 시 빈 배열로 설정
             setData(prev => ({
                 ...prev,
-                qnaItems: []
+                faqItems: []
             }));
         } finally {
             setIsLoadingQna(false);
@@ -79,10 +79,10 @@ export const DataProvider = ({ children }) => {
         }
     };
     
-    // 컴포넌트 마운트 시 축제 날짜 목록, QnA, 분실물 조회
+    // 컴포넌트 마운트 시 축제 날짜 목록, FAQ, 분실물 조회
     useEffect(() => {
         fetchEventDates();
-        fetchQnaItems();
+        fetchFaqItems();
         fetchLostItems();
     }, []);
 
@@ -175,76 +175,76 @@ export const DataProvider = ({ children }) => {
                 throw error;
             }
         },
-        // QnA 관련 액션들 (서버 연동)
-        addQnaItem: async (item, showToast) => {
+        // FAQ 관련 액션들 (서버 연동)
+        addFaqItem: async (item, showToast) => {
             try {
                 setIsLoadingQna(true);
                 await qnaAPI.createQuestion(item);
                 
-                // 서버에서 전체 QnA 목록을 다시 조회하여 최신 상태로 업데이트
+                // 서버에서 전체 FAQ 목록을 다시 조회하여 최신 상태로 업데이트
                 const questions = await qnaAPI.getQuestions();
                 
                 setData(prev => ({
                     ...prev,
-                    qnaItems: questions
+                    faqItems: questions
                 }));
-                showToast('새 QnA가 등록되었습니다.');
+                showToast('새 FAQ가 등록되었습니다.');
             } catch (error) {
-                showToast(error.message || 'QnA 추가에 실패했습니다.');
+                showToast(error.message || 'FAQ 추가에 실패했습니다.');
             } finally {
                 setIsLoadingQna(false);
             }
         },
         
-        updateQnaItem: async (id, updated, showToast) => {
+        updateFaqItem: async (id, updated, showToast) => {
             try {
                 setIsLoadingQna(true);
                 await qnaAPI.updateQuestion(id, updated);
                 
-                // 서버에서 전체 QnA 목록을 다시 조회하여 최신 상태로 업데이트
+                // 서버에서 전체 FAQ 목록을 다시 조회하여 최신 상태로 업데이트
                 const questions = await qnaAPI.getQuestions();
                 
                 setData(prev => ({
                     ...prev,
-                    qnaItems: questions
+                    faqItems: questions
                 }));
-                showToast('QnA가 수정되었습니다.');
+                showToast('FAQ가 수정되었습니다.');
             } catch (error) {
-                showToast(error.message || 'QnA 수정에 실패했습니다.');
+                showToast(error.message || 'FAQ 수정에 실패했습니다.');
             } finally {
                 setIsLoadingQna(false);
             }
         },
         
-        deleteQnaItem: async (questionId, showToast) => {
+        deleteFaqItem: async (questionId, showToast) => {
             try {
                 setIsLoadingQna(true);
                 await qnaAPI.deleteQuestion(questionId);
                 setData(prev => ({
                     ...prev,
-                    qnaItems: prev.qnaItems.filter(q => q.questionId !== questionId)
+                    faqItems: prev.faqItems.filter(q => q.questionId !== questionId)
                 }));
-                showToast('QnA가 삭제되었습니다.');
+                showToast('FAQ가 삭제되었습니다.');
             } catch (error) {
-                showToast(error.message || 'QnA 삭제에 실패했습니다.');
+                showToast(error.message || 'FAQ 삭제에 실패했습니다.');
             } finally {
                 setIsLoadingQna(false);
             }
         },
 
-        updateQnaSequences: async (sequences, showToast) => {
+        updateFaqSequences: async (sequences, showToast) => {
             try {
                 setIsLoadingQna(true);
                 await qnaAPI.updateQuestionSequences(sequences);
-                // 서버에서 전체 QnA 목록을 다시 조회하여 최신 상태로 업데이트
+                // 서버에서 전체 FAQ 목록을 다시 조회하여 최신 상태로 업데이트
                 const questions = await qnaAPI.getQuestions();
                 setData(prev => ({
                     ...prev,
-                    qnaItems: questions
+                    faqItems: questions
                 }));
-                showToast('QnA 순서가 저장되었습니다.');
+                showToast('FAQ 순서가 저장되었습니다.');
             } catch (error) {
-                showToast(error.message || 'QnA 순서 변경에 실패했습니다.');
+                showToast(error.message || 'FAQ 순서 변경에 실패했습니다.');
             } finally {
                 setIsLoadingQna(false);
             }
@@ -490,7 +490,7 @@ export const DataProvider = ({ children }) => {
         
         // 새로운 상태 제공
         fetchEventDates,
-        fetchQnaItems,
+        fetchFaqItems,
         fetchLostItems,
         isLoadingDates,
         isLoadingEvents,

--- a/frontend/src/pages/FaqPage.jsx
+++ b/frontend/src/pages/FaqPage.jsx
@@ -3,32 +3,32 @@ import FlipMove from 'react-flip-move';
 import { useData } from '../hooks/useData';
 import { useModal } from '../hooks/useModal';
 
-const QnaPage = () => {
-    const { qnaItems, addQnaItem, updateQnaItem, deleteQnaItem, updateQnaSequences, fetchQnaItems } = useData();
+const FaqPage = () => {
+    const { faqItems, addFaqItem, updateFaqItem, deleteFaqItem, updateFaqSequences, fetchFaqItems } = useData();
     const { openModal, showToast } = useModal();
     const [isEditingOrder, setIsEditingOrder] = useState(false);
-    const [tempItems, setTempItems] = useState(qnaItems || []);
+    const [tempItems, setTempItems] = useState(faqItems || []);
 
-    // qnaItems가 변경될 때 tempItems도 업데이트
+    // faqItems가 변경될 때 tempItems도 업데이트
     useEffect(() => {
-        setTempItems(qnaItems || []);
-    }, [qnaItems]);
+        setTempItems(faqItems || []);
+    }, [faqItems]);
 
-    // 컴포넌트 마운트 시 QnA 데이터 새로 조회
+    // 컴포넌트 마운트 시 FAQ 데이터 새로 조회
     useEffect(() => {
-        fetchQnaItems();
-    }, []);
+        fetchFaqItems();
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleSave = async (id, data) => {
         if (!data.question || !data.answer) { showToast('질문과 답변을 모두 입력해주세요.'); return; }
         try {
             if (id) {
-                await updateQnaItem(id, data, showToast);
+                await updateFaqItem(id, data, showToast);
             } else {
-                await addQnaItem(data, showToast);
+                await addFaqItem(data, showToast);
             }
-        } catch (error) {
-            showToast('QnA 저장 중 오류가 발생했습니다.');
+        } catch {
+            showToast('FAQ 저장 중 오류가 발생했습니다.');
         }
     };
 
@@ -45,19 +45,19 @@ const QnaPage = () => {
             questionId: item.questionId,
             sequence: index + 1
         }));
-        await updateQnaSequences(sequences, showToast);
+        await updateFaqSequences(sequences, showToast);
         setIsEditingOrder(false);
     };
 
     const handleCancelOrder = () => {
-        setTempItems(qnaItems || []);
+        setTempItems(faqItems || []);
         setIsEditingOrder(false);
     };
 
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
-                <h2 className="text-3xl font-bold">QnA 관리</h2>
+                <h2 className="text-3xl font-bold">FAQ 관리</h2>
                 <div className="flex items-center space-x-2">
                     {isEditingOrder ? (
                         <>
@@ -67,13 +67,13 @@ const QnaPage = () => {
                     ) : (
                         <>
                             <button onClick={() => setIsEditingOrder(true)} className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg">순서 변경</button>
-                            <button onClick={() => openModal('qna', { onSave: (data) => handleSave(null, data) })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center"><i className="fas fa-plus mr-2"></i> QnA 등록</button>
+                            <button onClick={() => openModal('faq', { onSave: (data) => handleSave(null, data) })} className="bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded-lg flex items-center"><i className="fas fa-plus mr-2"></i> FAQ 등록</button>
                         </>
                     )}
                 </div>
             </div>
             <FlipMove className="space-y-4">
-                {(isEditingOrder ? tempItems : qnaItems || []).map((item, index) => (
+                {(isEditingOrder ? tempItems : faqItems || []).map((item, index) => (
                     <div key={item.questionId} data-id={item.questionId} className="bg-white rounded-lg shadow-sm border border-gray-200 p-5">
                         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
                             <p className="font-semibold flex-1 truncate" title={item.question}><span className="text-blue-600 mr-2">Q.</span>{item.question}</p>
@@ -85,13 +85,13 @@ const QnaPage = () => {
                                     </>
                                 ) : (
                                     <>
-                                        <button onClick={() => openModal('qna', { qna: item, onSave: (data) => handleSave(item.questionId, data) })} className="text-blue-600 hover:text-blue-800 font-bold">수정</button>
+                                        <button onClick={() => openModal('faq', { faq: item, onSave: (data) => handleSave(item.questionId, data) })} className="text-blue-600 hover:text-blue-800 font-bold">수정</button>
                                         <button onClick={() => {
                                             openModal('confirm', {
-                                                title: 'QnA 삭제 확인',
+                                                title: 'FAQ 삭제 확인',
                                                 message: `정말로 삭제하시겠습니까?`,
                                                 onConfirm: async () => {
-                                                    await deleteQnaItem(item.questionId, showToast);
+                                                    await deleteFaqItem(item.questionId, showToast);
                                                 }
                                             });
                                         }} className="text-red-600 hover:text-red-800 font-bold">삭제</button>
@@ -103,16 +103,16 @@ const QnaPage = () => {
                     </div>
                 ))}
                 
-                {/* QnA가 없을 때 */}
-                {(!isEditingOrder && (!qnaItems || qnaItems.length === 0)) && (
+                {/* FAQ가 없을 때 */}
+                {(!isEditingOrder && (!faqItems || faqItems.length === 0)) && (
                     <div className="text-center py-12">
                         <i className="fas fa-question-circle text-4xl text-gray-400 mb-4"></i>
-                        <p className="text-gray-500 mb-4">등록된 QnA가 없습니다</p>
+                        <p className="text-gray-500 mb-4">등록된 FAQ가 없습니다</p>
                         <button
-                            onClick={() => openModal('qna', { onSave: (data) => handleSave(null, data) })}
+                            onClick={() => openModal('faq', { onSave: (data) => handleSave(null, data) })}
                             className="bg-gray-800 hover:bg-gray-900 text-white px-4 py-2 rounded-lg transition-colors"
                         >
-                            첫 번째 QnA 등록
+                            첫 번째 FAQ 등록
                         </button>
                     </div>
                 )}
@@ -121,4 +121,4 @@ const QnaPage = () => {
     );
 };
 
-export default QnaPage;
+export default FaqPage;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -9,7 +9,28 @@ const api = axios.create({
   },
 });
 
+// 파일 업로드용 별도 인스턴스
+const fileApi = axios.create({
+  baseURL: API_HOST,
+  headers: {
+    'Content-Type': 'multipart/form-data',
+  },
+});
+
 api.interceptors.request.use((config) => {
+  const festivalId = localStorage.getItem('festivalId');
+  if (festivalId) {
+    config.headers['festival'] = festivalId;
+  }
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 파일 업로드용 인터셉터
+fileApi.interceptors.request.use((config) => {
   const festivalId = localStorage.getItem('festivalId');
   if (festivalId) {
     config.headers['festival'] = festivalId;
@@ -30,11 +51,47 @@ api.interceptors.response.use(
       try {
         localStorage.clear();
         window.location.replace('/');
-      } catch (_) {}
+      } catch (error) {
+        // 에러 처리 시 로그만 출력
+        console.error('Error during logout redirect:', error);
+      }
     }
     return Promise.reject(error);
   }
 );
+
+fileApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status;
+    if (status === 401 || status === 403) {
+      try {
+        localStorage.clear();
+        window.location.replace('/');
+      } catch (error) {
+        console.error('Error during logout redirect:', error);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+// 공통 이미지 업로드 API
+export const imageAPI = {
+  // 이미지 파일 업로드
+  uploadImage: async (file) => {
+    try {
+      const formData = new FormData();
+      formData.append('image', file);
+      
+      const response = await fileApi.post('/images', formData);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to upload image:', error);
+      throw new Error('이미지 업로드에 실패했습니다.');
+    }
+  }
+};
 
 // 축제 관련 API
 export const festivalAPI = {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -441,60 +441,60 @@ export const scheduleAPI = {
     }
 };
 
-// QnA 관련 API
+// FAQ 관련 API
 export const qnaAPI = {
-  // 모든 QnA 조회
+  // 모든 FAQ 조회
   getQuestions: async () => {
     try {
       const response = await api.get('/questions');
       return response.data;
     } catch (error) {
       console.error('Failed to fetch questions:', error);
-      throw new Error('QnA 조회에 실패했습니다.');
+      throw new Error('FAQ 조회에 실패했습니다.');
     }
   },
 
-  // 새 QnA 추가
+  // 새 FAQ 추가
   createQuestion: async (questionData) => {
     try {
       const response = await api.post('/questions', questionData);
       return response.data;
     } catch (error) {
       console.error('Failed to create question:', error);
-      throw new Error('QnA 추가에 실패했습니다.');
+      throw new Error('FAQ 추가에 실패했습니다.');
     }
   },
 
-  // QnA 수정
+  // FAQ 수정
   updateQuestion: async (questionId, questionData) => {
     try {
       const response = await api.patch(`/questions/${questionId}`, questionData);
       return response.data;
     } catch (error) {
       console.error('Failed to update question:', error);
-      throw new Error('QnA 수정에 실패했습니다.');
+      throw new Error('FAQ 수정에 실패했습니다.');
     }
   },
 
-  // QnA 삭제
+  // FAQ 삭제
   deleteQuestion: async (questionId) => {
     try {
       await api.delete(`/questions/${questionId}`);
       // 성공 시 204 응답, body 없음
     } catch (error) {
       console.error('Failed to delete question:', error);
-      throw new Error('QnA 삭제에 실패했습니다.');
+      throw new Error('FAQ 삭제에 실패했습니다.');
     }
   },
 
-  // QnA 순서 변경
+  // FAQ 순서 변경
   updateQuestionSequences: async (sequences) => {
     try {
       const response = await api.patch('/questions/sequences', sequences);
       return response.data;
     } catch (error) {
       console.error('Failed to update question sequences:', error);
-      throw new Error('QnA 순서 변경에 실패했습니다.');
+      throw new Error('FAQ 순서 변경에 실패했습니다.');
     }
   }
 };

--- a/frontend/src/utils/imageUpload.js
+++ b/frontend/src/utils/imageUpload.js
@@ -1,0 +1,30 @@
+// src/utils/imageUpload.js
+
+/**
+ * 파일 유효성을 검사하는 함수
+ * @param {File} file - 검사할 파일
+ * @returns {Object} - { isValid: boolean, message: string }
+ */
+export const validateImageFile = (file) => {
+  const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
+  const maxSize = 10 * 1024 * 1024; // 10MB
+
+  if (!allowedTypes.includes(file.type)) {
+    return {
+      isValid: false,
+      message: 'PNG, JPG, JPEG 파일만 업로드 가능합니다.'
+    };
+  }
+
+  if (file.size > maxSize) {
+    return {
+      isValid: false,
+      message: '파일 크기는 10MB 이하여야 합니다.'
+    };
+  }
+
+  return {
+    isValid: true,
+    message: ''
+  };
+};


### PR DESCRIPTION
## #️⃣ 이슈 번호

#533 

<br>

## 🛠️ 작업 내용

이미지 업로드 기능 실제 서버 API 연동
- 축제 이미지 관리
- 플레이스 이미지 관리
- 분실물 등록/수정
- 라인업 추가
 Q&A 표현 FAQ로 변경




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - QnA가 FAQ로 전환되었습니다: 사이드바, 페이지, 모달, 알림 문구 등 전반 업데이트.
  - 이미지 업로드 개선: 서버 업로드 방식 도입, 드래그 앤 드롭 지원, 이미지 URL만 반환하는 모드 추가, 오류 메시지 강화.
  - 라인업/축제/장소 이미지 관리 향상: 업로드 후 서버 데이터로 즉시 새로고침, 순서/삭제 작업 안정성 개선.

- Refactor
  - 이미지 검증 유틸 추가(형식·용량 체크).
  - 전용 파일 업로드 API 도입으로 업로드 흐름 일원화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->