### PR TITLE
[AN] 분실물 추가 시 패딩이 적용 안되는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemDecoration.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemDecoration.kt
@@ -14,12 +14,13 @@ class LostItemDecoration(
         parent: RecyclerView,
         state: RecyclerView.State,
     ) {
-        val position = parent.getChildLayoutPosition(view)
-        val column = position % spanCount
+        val position = parent.getChildAdapterPosition(view)
+        if (position == RecyclerView.NO_POSITION) return
 
+        val column = position % spanCount
         outRect.left = column * spacing / spanCount
         outRect.right = spacing - (column + 1) * spacing / spanCount
-        outRect.top = spacing
-        if (position >= state.itemCount - 1) outRect.bottom = spacing
+        if (position < spanCount) outRect.top = spacing
+        outRect.bottom = spacing
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemDecoration.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemDecoration.kt
@@ -20,7 +20,6 @@ class LostItemDecoration(
         val column = position % spanCount
         outRect.left = column * spacing / spanCount
         outRect.right = spacing - (column + 1) * spacing / spanCount
-        if (position < spanCount) outRect.top = spacing
-        outRect.bottom = spacing
+        outRect.top = spacing
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#649 

<br>

## 🛠️ 작업 내용
- 분실물이 변경되었을 때 패딩이 적용 안됐던 문제 해결
- RecyclerView.NO_POSITION일 때 예외 처리 추가

<br>

## 🙇🏻 중점 리뷰 요청

- 방학이니까 편한 시간에 천천히 리뷰해주세요~
- 맨 하단 아이템이면 바텀 마진을 추가로 주었는데 분실물 아이템이 중간에 들어오면 ItemDecoration 포지션 계산을 자꾸 이상하게 합니다. 그래서 아이템 사이 마진간격이 이상해질 때가 있네요. 그래서 일단 하단 마진 로직을 뺐습니다. 혹시 하단 마진 없는거 많이 불편하신가요

<br>

## 📸 이미지 첨부 (Optional)



https://github.com/user-attachments/assets/34f9f4d3-ab74-4a80-ad4b-a35c12d4c415



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 계산 중 잘못된 항목 위치 사용을 방지해 스크롤/갱신 시 목록 표시 안정성을 개선했습니다 (유효하지 않은 항목 처리 추가).
- 스타일
  - 좌우 간격 계산은 유지하면서 하단 여백 적용을 제거해 그리드 간격 동작을 단순화했습니다. 상단 여백은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->