### PR TITLE
[AN] 소식 화면 UI 개선

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
@@ -2,27 +2,30 @@ package com.daedan.festabook.presentation.news.faq
 
 import android.os.Bundle
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.DefaultItemAnimator
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentFAQBinding
-import com.daedan.festabook.databinding.ItemFaqBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.showErrorSnackBar
-import com.daedan.festabook.presentation.common.toPx
 import com.daedan.festabook.presentation.news.NewsViewModel
-import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import com.daedan.festabook.presentation.news.faq.adapter.FAQAdapter
 import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 import timber.log.Timber
 
 class FAQFragment : BaseFragment<FragmentFAQBinding>(R.layout.fragment_f_a_q) {
     private val viewModel: NewsViewModel by viewModels({ requireParentFragment() }) { NewsViewModel.Factory }
+    private val adapter by lazy {
+        FAQAdapter(requireParentFragment() as OnNewsClickListener)
+    }
 
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        binding.rvFaq.adapter = adapter
+        (binding.rvFaq.itemAnimator as DefaultItemAnimator).supportsChangeAnimations = false
         setupObservers()
     }
 
@@ -32,7 +35,7 @@ class FAQFragment : BaseFragment<FragmentFAQBinding>(R.layout.fragment_f_a_q) {
                 FAQUiState.InitialLoading -> {}
                 FAQUiState.Refreshing -> {}
                 is FAQUiState.Success -> {
-                    setupScrollview(state.faqs)
+                    adapter.submitList(state.faqs)
                 }
 
                 is FAQUiState.Error -> {
@@ -43,49 +46,7 @@ class FAQFragment : BaseFragment<FragmentFAQBinding>(R.layout.fragment_f_a_q) {
         }
     }
 
-    private fun setupScrollview(items: List<FAQItemUiModel>) {
-        binding.llFaqContainer.removeAllViews()
-
-        items.forEachIndexed { index, item ->
-            val faqItemBinding =
-                ItemFaqBinding.inflate(layoutInflater, binding.llFaqContainer, false)
-
-            setupFAQItemTopMargin(faqItemBinding, index)
-            setupFAQItemView(faqItemBinding, item)
-
-            binding.llFaqContainer.addView(faqItemBinding.root)
-        }
-    }
-
-    private fun setupFAQItemView(
-        faqItemBinding: ItemFaqBinding,
-        item: FAQItemUiModel,
-    ) {
-        faqItemBinding.tvFaqQuestion.text =
-            getString(R.string.tab_faq_question, item.question)
-        faqItemBinding.tvFaqAnswer.text = item.answer
-        faqItemBinding.ivFaqExpand.setImageResource(
-            if (item.isExpanded) R.drawable.ic_chevron_up else R.drawable.ic_chevron_down,
-        )
-        faqItemBinding.tvFaqAnswer.visibility = if (item.isExpanded) View.VISIBLE else View.GONE
-
-        faqItemBinding.clFaqItem.setOnClickListener {
-            (requireParentFragment() as OnNewsClickListener).onFAQClick(item)
-        }
-    }
-
-    private fun setupFAQItemTopMargin(
-        faqItemBinding: ItemFaqBinding,
-        index: Int,
-    ) {
-        val layoutParams = faqItemBinding.root.layoutParams as ViewGroup.MarginLayoutParams
-        layoutParams.topMargin = if (index == 0) TOP_MARGIN.toPx(requireContext()) else 0
-        faqItemBinding.root.layoutParams = layoutParams
-    }
-
     companion object {
-        private const val TOP_MARGIN = 12
-
         fun newInstance() = FAQFragment()
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/adapter/FAQAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/adapter/FAQAdapter.kt
@@ -1,0 +1,35 @@
+package com.daedan.festabook.presentation.news.faq.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
+
+class FAQAdapter(
+    private val onNewsClickListener: OnNewsClickListener,
+) : ListAdapter<FAQItemUiModel, FAQViewHolder>(
+        object : DiffUtil.ItemCallback<FAQItemUiModel>() {
+            override fun areItemsTheSame(
+                oldItem: FAQItemUiModel,
+                newItem: FAQItemUiModel,
+            ): Boolean = newItem.questionId == oldItem.questionId
+
+            override fun areContentsTheSame(
+                oldItem: FAQItemUiModel,
+                newItem: FAQItemUiModel,
+            ): Boolean = newItem == oldItem
+        },
+    ) {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): FAQViewHolder = FAQViewHolder.from(parent, onNewsClickListener)
+
+    override fun onBindViewHolder(
+        holder: FAQViewHolder,
+        position: Int,
+    ) {
+        holder.bind(getItem(position))
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/adapter/FAQAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/adapter/FAQAdapter.kt
@@ -8,19 +8,7 @@ import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 
 class FAQAdapter(
     private val onNewsClickListener: OnNewsClickListener,
-) : ListAdapter<FAQItemUiModel, FAQViewHolder>(
-        object : DiffUtil.ItemCallback<FAQItemUiModel>() {
-            override fun areItemsTheSame(
-                oldItem: FAQItemUiModel,
-                newItem: FAQItemUiModel,
-            ): Boolean = newItem.questionId == oldItem.questionId
-
-            override fun areContentsTheSame(
-                oldItem: FAQItemUiModel,
-                newItem: FAQItemUiModel,
-            ): Boolean = newItem == oldItem
-        },
-    ) {
+) : ListAdapter<FAQItemUiModel, FAQViewHolder>(faqItemDiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -31,5 +19,20 @@ class FAQAdapter(
         position: Int,
     ) {
         holder.bind(getItem(position))
+    }
+
+    companion object {
+        private val faqItemDiffCallback =
+            object : DiffUtil.ItemCallback<FAQItemUiModel>() {
+                override fun areItemsTheSame(
+                    oldItem: FAQItemUiModel,
+                    newItem: FAQItemUiModel,
+                ): Boolean = newItem.questionId == oldItem.questionId
+
+                override fun areContentsTheSame(
+                    oldItem: FAQItemUiModel,
+                    newItem: FAQItemUiModel,
+                ): Boolean = newItem == oldItem
+            }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/adapter/FAQViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/adapter/FAQViewHolder.kt
@@ -1,0 +1,73 @@
+package com.daedan.festabook.presentation.news.faq.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.transition.AutoTransition
+import androidx.transition.TransitionManager
+import com.daedan.festabook.databinding.ItemFaqBinding
+import com.daedan.festabook.presentation.common.toPx
+import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
+import timber.log.Timber
+
+class FAQViewHolder(
+    private val binding: ItemFaqBinding,
+    private val onNewsClickListener: OnNewsClickListener,
+) : RecyclerView.ViewHolder(binding.root) {
+    private var faqItem: FAQItemUiModel? = null
+
+    init {
+        binding.root.setOnClickListener {
+            faqItem?.let {
+                onNewsClickListener.onFAQClick(it)
+            } ?: run {
+                Timber.w("${::FAQViewHolder.javaClass.simpleName} : FAQ 아이템이 null입니다.")
+            }
+        }
+    }
+
+    fun bind(faqItem: FAQItemUiModel) {
+        this.faqItem = faqItem
+        setupTopMargin()
+        binding.tvFaqQuestion.text = faqItem.question
+        binding.tvFaqAnswer.text = faqItem.answer
+        binding.tvFaqAnswer.visibility = if (faqItem.isExpanded) View.VISIBLE else View.GONE
+        TransitionManager.beginDelayedTransition(binding.clFaqItem, AutoTransition())
+
+        val targetRotation =
+            if (faqItem.isExpanded) ICON_ROTATION_EXPANDED else ICON_ROTATION_COLLAPSED
+        binding.ivFaqExpand
+            .animate()
+            .rotation(targetRotation)
+            .setDuration(ICON_DURATION)
+            .start()
+    }
+
+    private fun setupTopMargin() {
+        val layoutParams = itemView.layoutParams as ViewGroup.MarginLayoutParams
+        if (layoutPosition == 0) {
+            layoutParams.topMargin = TOP_MARGIN.toPx(binding.clFaqItem.context)
+        } else {
+            layoutParams.topMargin = 0
+        }
+    }
+
+    companion object {
+        private const val TOP_MARGIN: Int = 12
+        private const val ICON_ROTATION_EXPANDED: Float = 180F
+        private const val ICON_ROTATION_COLLAPSED: Float = 0F
+        private const val ICON_DURATION: Long = 300L
+
+        fun from(
+            parent: ViewGroup,
+            onNewsClickListener: OnNewsClickListener,
+        ): FAQViewHolder {
+            val inflater = LayoutInflater.from(parent.context)
+            val binding = ItemFaqBinding.inflate(inflater, parent, false)
+
+            return FAQViewHolder(binding, onNewsClickListener)
+        }
+    }
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
@@ -4,6 +4,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import androidx.transition.AutoTransition
+import androidx.transition.TransitionManager
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ItemNoticeBinding
 import com.daedan.festabook.presentation.common.toPx
@@ -32,6 +34,7 @@ class NoticeViewHolder(
         binding.notice = notice
         binding.tvNoticeDescription.visibility =
             if (notice.isExpanded) View.VISIBLE else View.GONE
+        TransitionManager.beginDelayedTransition(binding.layoutNoticeItem, AutoTransition())
 
         if (notice.isPinned) {
             binding.ivNoticeIcon.setImageResource(R.drawable.ic_pin)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/adapter/NoticeViewHolder.kt
@@ -23,7 +23,7 @@ class NoticeViewHolder(
             noticeItem?.let {
                 onNewsClickListener.onNoticeClick(it)
             } ?: run {
-                Timber.w("${::NoticeViewHolder.name} 공지 아이템이 null입니다.")
+                Timber.w("${::NoticeViewHolder.javaClass.simpleName} 공지 아이템이 null입니다.")
             }
         }
     }

--- a/android/app/src/main/res/layout/fragment_f_a_q.xml
+++ b/android/app/src/main/res/layout/fragment_f_a_q.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ScrollView
-        android:id="@+id/sv_faq"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <LinearLayout
-            android:id="@+id/ll_faq_container"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_faq"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
-    </ScrollView>
+            android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/item_faq.xml
+++ b/android/app/src/main/res/layout/item_faq.xml
@@ -28,6 +28,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/faq_expand"
+            android:src="@drawable/ic_chevron_down"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#652 

<br>

## 🛠️ 작업 내용

- 소식화면 아이템 클릭시 아이템 확장전에 글자가 먼저 로드되는 문제 해결
- FAQ 아이템 애니메이션 적용
- FAQ리스트를 RecyclerView로 변경

<br>

## 🙇🏻 중점 리뷰 요청
- FAQ가 많아졌을 때의 상황도 고려하려면 리사이클러뷰가 맞는 것 같아서 변경했습니다.
- 스크롤 뷰 보다 리사이클러뷰 애니메이션 적용이 더 간단하더라구요.

<br>

## 📸 이미지 첨부 (Optional)

#### FAQ
https://github.com/user-attachments/assets/9b6df2b1-b5a3-4035-ad34-10370ea5e8e3

#### 공지
https://github.com/user-attachments/assets/f8771f27-df37-4689-ba12-26e7c80b72ac


