### PR TITLE
[AN] 알림 스위치 버튼 연속클릭 제한

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -75,18 +75,14 @@ class SettingFragment :
 
     private fun setupObservers() {
         viewModel.allowClickEvent.observe(viewLifecycleOwner) {
-            it.getContentIfNotHandled()?.let {
-                if (viewModel.isAllowed) {
-                    notificationPermissionManager.requestNotificationPermission(
-                        requireContext(),
-                    )
-                }
+            if (viewModel.isAllowed) {
+                notificationPermissionManager.requestNotificationPermission(
+                    requireContext(),
+                )
             }
         }
-        viewModel.error.observe(viewLifecycleOwner) {
-            it.getContentIfNotHandled()?.let { throwable ->
-                showErrorSnackBar(throwable)
-            }
+        viewModel.error.observe(viewLifecycleOwner) { throwable ->
+            showErrorSnackBar(throwable)
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -84,6 +84,9 @@ class SettingFragment :
         viewModel.error.observe(viewLifecycleOwner) { throwable ->
             showErrorSnackBar(throwable)
         }
+        viewModel.isLoading.observe(viewLifecycleOwner) { loading ->
+            binding.btnNoticeAllow.isEnabled = !loading
+        }
     }
 
     private fun setupServicePolicyClickListener() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -26,13 +26,15 @@ class SettingViewModel(
     private val _error: SingleLiveData<Throwable> = SingleLiveData()
     val error: LiveData<Throwable> get() = _error
 
-    private val _isLoading: MutableLiveData<Boolean> = MutableLiveData()
+    private val _isLoading: MutableLiveData<Boolean> = MutableLiveData(false)
     val isLoading: LiveData<Boolean> get() = _isLoading
 
     fun notificationAllowClick() {
+        if (_isLoading.value == true) return
         updateNotificationIsAllowed(!isAllowed)
         _allowClickEvent.setValue(Unit)
-        Timber.d("$isAllowed")
+
+        _isLoading.value = true
         if (isAllowed) saveNotificationId() else deleteNotificationId()
     }
 
@@ -55,6 +57,8 @@ class SettingViewModel(
                 }.onFailure {
                     _error.setValue(it)
                     Timber.e(it, "${::SettingViewModel.javaClass.simpleName} NotificationId 저장 실패")
+                }.also {
+                    _isLoading.value = false
                 }
         }
     }
@@ -70,6 +74,8 @@ class SettingViewModel(
                 }.onFailure {
                     _error.setValue(it)
                     Timber.e(it, "${::SettingViewModel.name} NotificationId 삭제 실패")
+                }.also {
+                    _isLoading.value = false
                 }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -56,7 +56,7 @@ class SettingViewModel(
                     saveNotificationIsAllowed(isAllowed)
                 }.onFailure {
                     _error.setValue(it)
-                    Timber.e(it, "${::SettingViewModel.javaClass.simpleName} NotificationId 저장 실패")
+                    Timber.e(it, "${this::class.java.simpleName} NotificationId 저장 실패")
                 }.also {
                     _isLoading.value = false
                 }
@@ -73,7 +73,7 @@ class SettingViewModel(
                     saveNotificationIsAllowed(isAllowed)
                 }.onFailure {
                     _error.setValue(it)
-                    Timber.e(it, "${::SettingViewModel.name} NotificationId 삭제 실패")
+                    Timber.e(it, "${this::class.java.simpleName} NotificationId 삭제 실패")
                 }.also {
                     _isLoading.value = false
                 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -10,25 +10,28 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.daedan.festabook.FestaBookApp
 import com.daedan.festabook.domain.repository.FestivalNotificationRepository
-import com.daedan.festabook.presentation.common.Event
+import com.daedan.festabook.presentation.common.SingleLiveData
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class SettingViewModel(
     private val festivalNotificationRepository: FestivalNotificationRepository,
 ) : ViewModel() {
-    private val _allowClickEvent: MutableLiveData<Event<Unit>> = MutableLiveData()
-    val allowClickEvent: LiveData<Event<Unit>> get() = _allowClickEvent
+    private val _allowClickEvent: SingleLiveData<Unit> = SingleLiveData()
+    val allowClickEvent: LiveData<Unit> get() = _allowClickEvent
 
     var isAllowed = festivalNotificationRepository.getFestivalNotificationIsAllow()
         private set
 
-    private val _error: MutableLiveData<Event<Throwable>> = MutableLiveData()
-    val error: LiveData<Event<Throwable>> get() = _error
+    private val _error: SingleLiveData<Throwable> = SingleLiveData()
+    val error: LiveData<Throwable> get() = _error
+
+    private val _isLoading: MutableLiveData<Boolean> = MutableLiveData()
+    val isLoading: LiveData<Boolean> get() = _isLoading
 
     fun notificationAllowClick() {
         updateNotificationIsAllowed(!isAllowed)
-        _allowClickEvent.value = Event(Unit)
+        _allowClickEvent.setValue(Unit)
         Timber.d("$isAllowed")
         if (isAllowed) saveNotificationId() else deleteNotificationId()
     }
@@ -50,7 +53,7 @@ class SettingViewModel(
                 .onSuccess {
                     saveNotificationIsAllowed(isAllowed)
                 }.onFailure {
-                    _error.value = Event(it)
+                    _error.setValue(it)
                     Timber.e(it, "${::SettingViewModel.javaClass.simpleName} NotificationId 저장 실패")
                 }
         }
@@ -65,7 +68,7 @@ class SettingViewModel(
                 .onSuccess {
                     saveNotificationIsAllowed(isAllowed)
                 }.onFailure {
-                    _error.value = Event(it)
+                    _error.setValue(it)
                     Timber.e(it, "${::SettingViewModel.name} NotificationId 삭제 실패")
                 }
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#654 

<br>

## 🛠️ 작업 내용

- 서버 통신 중에는 스위치버튼을 클릭하지 못하게 하여 재요청을 방지했습니다.

<br>

## 🙇🏻 중점 리뷰 요청



<br>

## 📸 이미지 첨부 (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 알림 허용 처리 중 버튼이 자동으로 비활성화되어 중복 입력을 방지하고 진행 상태를 명확히 보여줍니다.
- Bug Fixes
  - 빠른 연속 탭 시 알림 권한 요청이 중복 실행되던 문제를 방지했습니다.
  - 설정 처리 실패 시 오류 스낵바가 누락되지 않고 일관되게 표시되도록 수정했습니다.
  - 진행 중에 추가 동작이 트리거되던 간헐적 현상을 제거해 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->