### PR TITLE
[BE] dev cd 파이프라인 실패하더라도 git actions는 성공하는 문제

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ backend ]
     paths: [ 'backend/**' ]
+  pull_request:
+    branches: [ backend ]
   workflow_dispatch:
 
 jobs:
@@ -105,5 +107,7 @@ jobs:
             echo "Application started with PID: $NEW_WAS_PID."
           else
             echo "Error: Application failed to start."
+            # git action failed 처리
+            exit 1
           fi
           echo "Deployment complete."

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ backend ]
     paths: [ 'backend/**' ]
-  pull_request:
-    branches: [ backend ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## #️⃣ 이슈 번호

#663 

<br>

## 🛠️ 작업 내용

- 애플리케이션 실행에 실패했을 때, 문자열 출력뿐만 아니라 종료 코드를 1로 설정해서 github actions step도 실패하도록 변경

<br>