### PR TITLE
[BE] Announcement 인가 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -9,13 +9,16 @@ import com.daedan.festabook.announcement.dto.AnnouncementUpdateRequest;
 import com.daedan.festabook.announcement.dto.AnnouncementUpdateResponse;
 import com.daedan.festabook.announcement.service.AnnouncementService;
 import com.daedan.festabook.global.argumentresolver.FestivalId;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,15 +44,15 @@ public class AnnouncementController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
     public AnnouncementResponse createAnnouncement(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody AnnouncementRequest request
     ) {
-        return announcementService.createAnnouncement(festivalId, request);
+        return announcementService.createAnnouncement(councilDetails.getFestivalId(), request);
     }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "모든 공지 조회")
+    @Operation(summary = "모든 공지 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -67,9 +70,10 @@ public class AnnouncementController {
     })
     public AnnouncementUpdateResponse updateAnnouncement(
             @PathVariable Long announcementId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody AnnouncementUpdateRequest request
     ) {
-        return announcementService.updateAnnouncement(announcementId, request);
+        return announcementService.updateAnnouncement(announcementId, councilDetails.getFestivalId(), request);
     }
 
     @PatchMapping("/{announcementId}/pin")
@@ -80,10 +84,10 @@ public class AnnouncementController {
     })
     public AnnouncementPinUpdateResponse updateAnnouncementPin(
             @PathVariable Long announcementId,
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody AnnouncementPinUpdateRequest request
     ) {
-        return announcementService.updateAnnouncementPin(announcementId, festivalId, request);
+        return announcementService.updateAnnouncementPin(announcementId, councilDetails.getFestivalId(), request);
     }
 
     @DeleteMapping("/{announcementId}")
@@ -93,8 +97,9 @@ public class AnnouncementController {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })
     public void deleteAnnouncementByAnnouncementId(
-            @PathVariable Long announcementId
+            @PathVariable Long announcementId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        announcementService.deleteAnnouncementByAnnouncementId(announcementId);
+        announcementService.deleteAnnouncementByAnnouncementId(announcementId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -73,7 +73,7 @@ public class AnnouncementController {
             @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody AnnouncementUpdateRequest request
     ) {
-        return announcementService.updateAnnouncement(announcementId, councilDetails.getFestivalId(), request);
+        return announcementService.updateAnnouncement(councilDetails.getFestivalId(), announcementId, request);
     }
 
     @PatchMapping("/{announcementId}/pin")
@@ -87,7 +87,7 @@ public class AnnouncementController {
             @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody AnnouncementPinUpdateRequest request
     ) {
-        return announcementService.updateAnnouncementPin(announcementId, councilDetails.getFestivalId(), request);
+        return announcementService.updateAnnouncementPin(councilDetails.getFestivalId(), announcementId, request);
     }
 
     @DeleteMapping("/{announcementId}")
@@ -100,6 +100,6 @@ public class AnnouncementController {
             @PathVariable Long announcementId,
             @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        announcementService.deleteAnnouncementByAnnouncementId(announcementId, councilDetails.getFestivalId());
+        announcementService.deleteAnnouncementByAnnouncementId(councilDetails.getFestivalId(), announcementId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/domain/Announcement.java
@@ -75,6 +75,10 @@ public class Announcement extends BaseEntity {
         this.isPinned = isPinned;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.festival.getId().equals(festivalId);
+    }
+
     private void validateTitle(String title) {
         if (!StringUtils.hasText(title)) {
             throw new BusinessException("공지사항 제목은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -65,8 +65,11 @@ public class AnnouncementService {
     }
 
     @Transactional
-    public AnnouncementUpdateResponse updateAnnouncement(Long announcementId, Long festivalId,
-                                                         AnnouncementUpdateRequest request) {
+    public AnnouncementUpdateResponse updateAnnouncement(
+            Long announcementId,
+            Long festivalId,
+            AnnouncementUpdateRequest request
+    ) {
         Announcement announcement = getAnnouncementById(announcementId);
         validateAnnouncementBelongsToFestival(announcement, festivalId);
 
@@ -75,8 +78,11 @@ public class AnnouncementService {
     }
 
     @Transactional
-    public AnnouncementPinUpdateResponse updateAnnouncementPin(Long announcementId, Long festivalId,
-                                                               AnnouncementPinUpdateRequest request) {
+    public AnnouncementPinUpdateResponse updateAnnouncementPin(
+            Long announcementId,
+            Long festivalId,
+            AnnouncementPinUpdateRequest request
+    ) {
         Announcement announcement = getAnnouncementById(announcementId);
         validateAnnouncementBelongsToFestival(announcement, festivalId);
         if (announcement.isUnpinned() && request.pinned()) {

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -66,8 +66,8 @@ public class AnnouncementService {
 
     @Transactional
     public AnnouncementUpdateResponse updateAnnouncement(
-            Long announcementId,
             Long festivalId,
+            Long announcementId,
             AnnouncementUpdateRequest request
     ) {
         Announcement announcement = getAnnouncementById(announcementId);
@@ -79,8 +79,8 @@ public class AnnouncementService {
 
     @Transactional
     public AnnouncementPinUpdateResponse updateAnnouncementPin(
-            Long announcementId,
             Long festivalId,
+            Long announcementId,
             AnnouncementPinUpdateRequest request
     ) {
         Announcement announcement = getAnnouncementById(announcementId);
@@ -94,7 +94,7 @@ public class AnnouncementService {
     }
 
     @Transactional
-    public void deleteAnnouncementByAnnouncementId(Long announcementId, Long festivalId) {
+    public void deleteAnnouncementByAnnouncementId(Long festivalId, Long announcementId) {
         Announcement announcement = getAnnouncementById(announcementId);
         validateAnnouncementBelongsToFestival(announcement, festivalId);
 

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -39,7 +39,6 @@ public class AnnouncementService {
         if (request.isPinned()) {
             validatePinnedLimit(festivalId);
         }
-        validateAnnouncementBelongsToFestival(announcement, festivalId);
 
         announcementJpaRepository.save(announcement);
 

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -130,7 +130,7 @@ public class AnnouncementService {
     }
 
     private void validateAnnouncementBelongsToFestival(Announcement announcement, Long festivalId) {
-        if (!announcement.getFestival().getId().equals(festivalId)) {
+        if (!announcement.isFestivalIdEqualTo(festivalId)) {
             throw new BusinessException("해당 축제의 공지가 아닙니다.", HttpStatus.FORBIDDEN);
         }
     }

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -95,22 +95,6 @@ public class AnnouncementService {
         announcementJpaRepository.delete(announcement);
     }
 
-    private void validatePinnedLimit(Long festivalId) {
-        Long pinnedCount = announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(festivalId);
-        if (pinnedCount >= MAX_PINNED_ANNOUNCEMENTS) {
-            throw new BusinessException(
-                    String.format("공지글은 최대 %d개까지 고정할 수 있습니다.", MAX_PINNED_ANNOUNCEMENTS),
-                    HttpStatus.BAD_REQUEST
-            );
-        }
-    }
-
-    private void validateAnnouncementBelongsToFestival(Announcement announcement, Long festivalId) {
-        if (!announcement.getFestival().getId().equals(festivalId)) {
-            throw new BusinessException("해당 축제의 공지가 아닙니다.", HttpStatus.FORBIDDEN);
-        }
-    }
-
     private Announcement getAnnouncementById(Long announcementId) {
         return announcementJpaRepository.findById(announcementId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 공지입니다.", HttpStatus.BAD_REQUEST));
@@ -133,5 +117,21 @@ public class AnnouncementService {
 
     private Comparator<Announcement> createdAtDescending() {
         return Comparator.comparing(Announcement::getCreatedAt).reversed();
+    }
+
+    private void validatePinnedLimit(Long festivalId) {
+        Long pinnedCount = announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(festivalId);
+        if (pinnedCount >= MAX_PINNED_ANNOUNCEMENTS) {
+            throw new BusinessException(
+                    String.format("공지글은 최대 %d개까지 고정할 수 있습니다.", MAX_PINNED_ANNOUNCEMENTS),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+    }
+
+    private void validateAnnouncementBelongsToFestival(Announcement announcement, Long festivalId) {
+        if (!announcement.getFestival().getId().equals(festivalId)) {
+            throw new BusinessException("해당 축제의 공지가 아닙니다.", HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -91,7 +91,6 @@ class AnnouncementControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -125,7 +124,6 @@ class AnnouncementControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -358,7 +356,6 @@ class AnnouncementControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()

--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -397,25 +397,5 @@ class AnnouncementControllerTest {
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
         }
-
-        @Test
-        void 성공_존재하지_않는_공지지만_예외_없음() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long notExistId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .when()
-                    .delete("/announcements/{announcementId}", notExistId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
-        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementFixture.java
@@ -17,52 +17,128 @@ public class AnnouncementFixture {
     private static final LocalDateTime DEFAULT_CREATED_AT = LocalDateTime.now();
 
     public static Announcement create() {
-        return new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, DEFAULT_IS_PINNED, DEFAULT_FESTIVAL);
+        return new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                DEFAULT_IS_PINNED,
+                DEFAULT_FESTIVAL
+        );
     }
 
-    public static Announcement createWithTitle(String title) {
-        return new Announcement(title, DEFAULT_CONTENT, DEFAULT_IS_PINNED, DEFAULT_FESTIVAL);
+    public static Announcement createWithTitle(
+            String title
+    ) {
+        return new Announcement(
+                title,
+                DEFAULT_CONTENT,
+                DEFAULT_IS_PINNED,
+                DEFAULT_FESTIVAL
+        );
     }
 
-    public static Announcement createWithContent(String content) {
-        return new Announcement(DEFAULT_TITLE, content, DEFAULT_IS_PINNED, DEFAULT_FESTIVAL);
+    public static Announcement createWithContent(
+            String content
+    ) {
+        return new Announcement(
+                DEFAULT_TITLE,
+                content,
+                DEFAULT_IS_PINNED,
+                DEFAULT_FESTIVAL
+        );
     }
 
     public static Announcement create(
             boolean isPinned
     ) {
-        Announcement announcement = new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, isPinned, DEFAULT_FESTIVAL);
-        return BaseEntityTestHelper.setCreatedAt(announcement, DEFAULT_CREATED_AT);
+        Announcement announcement = new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                isPinned,
+                DEFAULT_FESTIVAL
+        );
+        BaseEntityTestHelper.setCreatedAt(announcement, DEFAULT_CREATED_AT);
+        return announcement;
     }
 
     public static Announcement create(
             Festival festival
     ) {
-        return new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, DEFAULT_IS_PINNED, festival);
+        return new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                DEFAULT_IS_PINNED,
+                festival
+        );
     }
 
     public static Announcement create(
             Long announcementId,
             boolean isPinned
     ) {
-        Announcement announcement = new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, isPinned, DEFAULT_FESTIVAL);
+        Announcement announcement = new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                isPinned,
+                DEFAULT_FESTIVAL
+        );
         BaseEntityTestHelper.setId(announcement, announcementId);
-        return BaseEntityTestHelper.setCreatedAt(announcement, DEFAULT_CREATED_AT);
+        BaseEntityTestHelper.setCreatedAt(announcement, DEFAULT_CREATED_AT);
+        return announcement;
     }
 
     public static Announcement create(
             boolean isPinned,
             LocalDateTime createdAt
     ) {
-        Announcement announcement = new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, isPinned, DEFAULT_FESTIVAL);
-        return BaseEntityTestHelper.setCreatedAt(announcement, createdAt);
+        Announcement announcement = new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                isPinned,
+                DEFAULT_FESTIVAL
+        );
+        BaseEntityTestHelper.setCreatedAt(announcement, createdAt);
+        return announcement;
+    }
+
+    public static Announcement create(
+            Long announcementId,
+            Festival festival
+    ) {
+        Announcement announcement = new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                DEFAULT_IS_PINNED,
+                festival
+        );
+        BaseEntityTestHelper.setId(announcement, announcementId);
+        return announcement;
+    }
+
+    public static Announcement create(
+            Long announcementId,
+            boolean isPinned,
+            Festival festival
+    ) {
+        Announcement announcement = new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                isPinned,
+                festival
+        );
+        BaseEntityTestHelper.setId(announcement, announcementId);
+        return announcement;
     }
 
     public static Announcement create(
             boolean isPinned,
             Festival festival
     ) {
-        return new Announcement(DEFAULT_TITLE, DEFAULT_CONTENT, isPinned, festival);
+        return new Announcement(
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                isPinned,
+                festival
+        );
     }
 
     public static Announcement create(
@@ -71,7 +147,12 @@ public class AnnouncementFixture {
             boolean isPinned,
             Festival festival
     ) {
-        return new Announcement(title, content, isPinned, festival);
+        return new Announcement(
+                title,
+                content,
+                isPinned,
+                festival
+        );
     }
 
     public static List<Announcement> createList(

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementFixture.java
@@ -16,15 +16,6 @@ public class AnnouncementFixture {
     private static final Festival DEFAULT_FESTIVAL = FestivalFixture.create();
     private static final LocalDateTime DEFAULT_CREATED_AT = LocalDateTime.now();
 
-    public static Announcement create() {
-        return new Announcement(
-                DEFAULT_TITLE,
-                DEFAULT_CONTENT,
-                DEFAULT_IS_PINNED,
-                DEFAULT_FESTIVAL
-        );
-    }
-
     public static Announcement createWithTitle(
             String title
     ) {
@@ -69,21 +60,6 @@ public class AnnouncementFixture {
                 DEFAULT_IS_PINNED,
                 festival
         );
-    }
-
-    public static Announcement create(
-            Long announcementId,
-            boolean isPinned
-    ) {
-        Announcement announcement = new Announcement(
-                DEFAULT_TITLE,
-                DEFAULT_CONTENT,
-                isPinned,
-                DEFAULT_FESTIVAL
-        );
-        BaseEntityTestHelper.setId(announcement, announcementId);
-        BaseEntityTestHelper.setCreatedAt(announcement, DEFAULT_CREATED_AT);
-        return announcement;
     }
 
     public static Announcement create(

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.announcement.domain;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
@@ -151,6 +152,39 @@ class AnnouncementTest {
             assertThatThrownBy(() -> AnnouncementFixture.create(festival))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("축제는 null일 수 없습니다.");
+        }
+    }
+
+    @Nested
+    class isFestivalIdEqualTo {
+
+        @Test
+        void 같은_축제의_id이면_true() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(festival);
+
+            // when
+            boolean result = announcement.isFestivalIdEqualTo(festivalId);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 다른_축제의_id이면_false() {
+            // given
+            Long festivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(festival);
+
+            // when
+            boolean result = announcement.isFestivalIdEqualTo(otherFestivalId);
+
+            // then
+            assertThat(result).isFalse();
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/domain/AnnouncementTest.java
@@ -1,8 +1,8 @@
 package com.daedan.festabook.announcement.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;

--- a/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementPinUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementPinUpdateRequestFixture.java
@@ -10,7 +10,9 @@ public class AnnouncementPinUpdateRequestFixture {
         );
     }
 
-    public static AnnouncementPinUpdateRequest create(boolean pinned) {
+    public static AnnouncementPinUpdateRequest create(
+            boolean pinned
+    ) {
         return new AnnouncementPinUpdateRequest(
                 pinned
         );

--- a/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementRequestFixture.java
@@ -14,26 +14,6 @@ public class AnnouncementRequestFixture {
         );
     }
 
-    public static AnnouncementRequest createWithTitle(
-            String title
-    ) {
-        return new AnnouncementRequest(
-                title,
-                DEFAULT_CONTENT,
-                DEFAULT_IS_PINNED
-        );
-    }
-
-    public static AnnouncementRequest createWithContent(
-            String content
-    ) {
-        return new AnnouncementRequest(
-                DEFAULT_TITLE,
-                content,
-                DEFAULT_IS_PINNED
-        );
-    }
-
     public static AnnouncementRequest create(
             boolean isPinned
     ) {

--- a/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/dto/AnnouncementUpdateRequestFixture.java
@@ -12,20 +12,6 @@ public class AnnouncementUpdateRequestFixture {
         );
     }
 
-    public static AnnouncementUpdateRequest createWithTitle(String title) {
-        return new AnnouncementUpdateRequest(
-                title,
-                DEFAULT_CONTENT
-        );
-    }
-
-    public static AnnouncementUpdateRequest createWithContent(String content) {
-        return new AnnouncementUpdateRequest(
-                DEFAULT_TITLE,
-                content
-        );
-    }
-
     public static AnnouncementUpdateRequest create(String title, String content) {
         return new AnnouncementUpdateRequest(
                 title,

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -152,9 +152,7 @@ class AnnouncementServiceTest {
         }
 
         @ParameterizedTest(name = "고정 공지 개수: {0}")
-        @ValueSource(longs = {
-                3L, 4L, 10L
-        })
+        @ValueSource(longs = {3L, 4L, 10L})
         void 예외_고정_공지_개수_제한_초과(Long maxPinnedCount) {
             // given
             Long festivalId = 1L;

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -344,6 +344,8 @@ class AnnouncementServiceTest {
 
             given(announcementJpaRepository.findById(announcementId))
                     .willReturn(Optional.of(announcement));
+            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(festivalId))
+                    .willReturn(0L);
 
             // when
             AnnouncementPinUpdateResponse result = announcementService.updateAnnouncementPin(

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -276,8 +276,8 @@ class AnnouncementServiceTest {
 
             // when
             AnnouncementUpdateResponse result = announcementService.updateAnnouncement(
-                    announcement.getId(),
                     festival.getId(),
+                    announcement.getId(),
                     request
             );
 
@@ -300,7 +300,7 @@ class AnnouncementServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    announcementService.updateAnnouncement(invalidAnnouncementId, festival.getId(), request)
+                    announcementService.updateAnnouncement(festival.getId(), invalidAnnouncementId, request)
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 공지입니다.");
@@ -322,7 +322,7 @@ class AnnouncementServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    announcementService.updateAnnouncement(announcement.getId(), otherFestival.getId(), request)
+                    announcementService.updateAnnouncement(otherFestival.getId(), announcement.getId(), request)
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 공지가 아닙니다.");
@@ -348,8 +348,8 @@ class AnnouncementServiceTest {
 
             // when
             AnnouncementPinUpdateResponse result = announcementService.updateAnnouncementPin(
-                    announcementId,
                     festivalId,
+                    announcementId,
                     request
             );
 
@@ -370,8 +370,8 @@ class AnnouncementServiceTest {
             // when & then
             assertThatThrownBy(() ->
                     announcementService.updateAnnouncementPin(
-                            invalidAnnouncementId,
                             festivalId,
+                            invalidAnnouncementId,
                             request
                     )
             )
@@ -398,8 +398,8 @@ class AnnouncementServiceTest {
             // when & then
             assertThatThrownBy(() ->
                     announcementService.updateAnnouncementPin(
-                            announcementId,
                             festivalId,
+                            announcementId,
                             request
                     )
             )
@@ -420,7 +420,7 @@ class AnnouncementServiceTest {
                     .willReturn(Optional.of(announcement));
 
             // when
-            announcementService.updateAnnouncementPin(announcementId, festivalId, request);
+            announcementService.updateAnnouncementPin(festivalId, announcementId, request);
 
             // then
             then(announcementJpaRepository).should(never())
@@ -443,7 +443,7 @@ class AnnouncementServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    announcementService.updateAnnouncementPin(announcement.getId(), otherFestival.getId(), request)
+                    announcementService.updateAnnouncementPin(otherFestival.getId(), announcement.getId(), request)
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 공지가 아닙니다.");
@@ -465,7 +465,7 @@ class AnnouncementServiceTest {
                     .willReturn(Optional.of(announcement));
 
             // when
-            announcementService.deleteAnnouncementByAnnouncementId(announcementId, festivalId);
+            announcementService.deleteAnnouncementByAnnouncementId(festivalId, announcementId);
 
             // then
             then(announcementJpaRepository).should()
@@ -487,8 +487,8 @@ class AnnouncementServiceTest {
             // when & then
             assertThatThrownBy(() ->
                     announcementService.deleteAnnouncementByAnnouncementId(
-                            announcement.getId(),
-                            otherFestival.getId()
+                            otherFestival.getId(),
+                            announcement.getId()
                     )
             )
                     .isInstanceOf(BusinessException.class)

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -171,25 +171,6 @@ class AnnouncementServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("공지글은 최대 3개까지 고정할 수 있습니다.");
         }
-
-        @Test
-        void 예외_다른_축제의_공지일_경우() {
-            // given
-            Long requestFestivalId = 1L;
-            Long otherFestivalId = 999L;
-            Festival requestFestival = FestivalFixture.create(requestFestivalId);
-            Festival otherFestival = FestivalFixture.create(otherFestivalId);
-
-            given(festivalJpaRepository.findById(otherFestival.getId()))
-                    .willReturn(Optional.of(requestFestival));
-
-            AnnouncementRequest request = AnnouncementRequestFixture.create();
-
-            // when & then
-            assertThatThrownBy(() -> announcementService.createAnnouncement(otherFestivalId, request))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("해당 축제의 공지가 아닙니다.");
-        }
     }
 
     @Nested

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
@@ -48,8 +47,6 @@ import org.springframework.http.HttpStatus;
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class AnnouncementServiceTest {
-
-    private static final Long DEFAULT_FESTIVAL_ID = 1L;
 
     @Mock
     private AnnouncementJpaRepository announcementJpaRepository;
@@ -94,6 +91,30 @@ class AnnouncementServiceTest {
                     .sendToFestivalTopic(any(), any());
         }
 
+        @ParameterizedTest(name = "고정 공지 개수: {0}")
+        @ValueSource(longs = {0L, 1L, 2L})
+        void 성공_고정_공지_개수_제한_미만(Long pinnedCount) {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            AnnouncementRequest request = AnnouncementRequestFixture.create(true);
+
+            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(festivalId))
+                    .willReturn(pinnedCount);
+            given(festivalJpaRepository.findById(festivalId))
+                    .willReturn(Optional.of(festival));
+
+            // when
+            announcementService.createAnnouncement(festivalId, request);
+
+            // then
+            then(announcementJpaRepository).should()
+                    .save(any(Announcement.class));
+
+            then(festivalNotificationManager).should()
+                    .sendToFestivalTopic(any(), any());
+        }
+
         @Test
         void 예외_존재하지_않는_축제_ID() {
             // given
@@ -131,43 +152,43 @@ class AnnouncementServiceTest {
         }
 
         @ParameterizedTest(name = "고정 공지 개수: {0}")
-        @ValueSource(longs = {0L, 1L, 2L})
-        void 성공_고정_공지_개수_제한_미만(Long pinnedCount) {
-            // given
-            AnnouncementRequest request = AnnouncementRequestFixture.create(true);
-            Festival festival = FestivalFixture.create(DEFAULT_FESTIVAL_ID);
-
-            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(DEFAULT_FESTIVAL_ID))
-                    .willReturn(pinnedCount);
-            given(festivalJpaRepository.findById(DEFAULT_FESTIVAL_ID))
-                    .willReturn(Optional.of(festival));
-
-            // when
-            announcementService.createAnnouncement(DEFAULT_FESTIVAL_ID, request);
-
-            // then
-            then(announcementJpaRepository).should()
-                    .save(any(Announcement.class));
-
-            then(festivalNotificationManager).should()
-                    .sendToFestivalTopic(any(), any());
-        }
-
-        @ParameterizedTest(name = "고정 공지 개수: {0}")
         @ValueSource(longs = {
                 3L, 4L, 10L
         })
         void 예외_고정_공지_개수_제한_초과(Long maxPinnedCount) {
             // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
             AnnouncementRequest request = AnnouncementRequestFixture.create(true);
 
-            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(DEFAULT_FESTIVAL_ID))
+            given(festivalJpaRepository.findById(festival.getId()))
+                    .willReturn(Optional.of(festival));
+            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(festivalId))
                     .willReturn(maxPinnedCount);
 
             // when & then
-            assertThatThrownBy(() -> announcementService.createAnnouncement(DEFAULT_FESTIVAL_ID, request))
+            assertThatThrownBy(() -> announcementService.createAnnouncement(festivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("공지글은 최대 3개까지 고정할 수 있습니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_공지일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+
+            given(festivalJpaRepository.findById(otherFestival.getId()))
+                    .willReturn(Optional.of(requestFestival));
+
+            AnnouncementRequest request = AnnouncementRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> announcementService.createAnnouncement(otherFestivalId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 공지가 아닙니다.");
         }
     }
 
@@ -177,6 +198,7 @@ class AnnouncementServiceTest {
         @Test
         void 성공_고정_분류() {
             // given
+            Long festivalId = 1L;
             int expectedPinedSize = 1;
             int expectedUnPinedSize = 2;
 
@@ -187,12 +209,11 @@ class AnnouncementServiceTest {
             allAnnouncements.addAll(pinnedAnnouncements);
             allAnnouncements.addAll(unPinnedAnnouncements);
 
-            given(announcementJpaRepository.findAllByFestivalId(DEFAULT_FESTIVAL_ID))
+            given(announcementJpaRepository.findAllByFestivalId(festivalId))
                     .willReturn(allAnnouncements);
 
             // when
-            AnnouncementGroupedResponses result = announcementService.getGroupedAnnouncementByFestivalId(
-                    DEFAULT_FESTIVAL_ID);
+            AnnouncementGroupedResponses result = announcementService.getGroupedAnnouncementByFestivalId(festivalId);
 
             // then
             assertSoftly(s -> {
@@ -204,6 +225,8 @@ class AnnouncementServiceTest {
         @Test
         void 성공_생성_날짜_시간_역순으로_정렬() {
             // given
+            Long festivalId = 1L;
+
             // pinned 공지
             Announcement announcement1 = AnnouncementFixture.create(true, LocalDateTime.of(2025, 5, 2, 10, 0));
             Announcement announcement2 = AnnouncementFixture.create(true, LocalDateTime.of(2025, 5, 3, 10, 0));
@@ -214,15 +237,14 @@ class AnnouncementServiceTest {
             Announcement announcement5 = AnnouncementFixture.create(false, LocalDateTime.of(2025, 5, 3, 10, 0));
             Announcement announcement6 = AnnouncementFixture.create(false, LocalDateTime.of(2025, 6, 2, 10, 0));
 
-            given(announcementJpaRepository.findAllByFestivalId(DEFAULT_FESTIVAL_ID))
+            given(announcementJpaRepository.findAllByFestivalId(festivalId))
                     .willReturn(List.of(
                             announcement1, announcement2, announcement3,
                             announcement4, announcement5, announcement6
                     ));
 
             // when
-            AnnouncementGroupedResponses result = announcementService.getGroupedAnnouncementByFestivalId(
-                    DEFAULT_FESTIVAL_ID);
+            AnnouncementGroupedResponses result = announcementService.getGroupedAnnouncementByFestivalId(festivalId);
 
             // then
             assertSoftly(s -> {
@@ -242,12 +264,13 @@ class AnnouncementServiceTest {
         @Test
         void 성공_빈_컬렉션() {
             // given
-            given(announcementJpaRepository.findAllByFestivalId(DEFAULT_FESTIVAL_ID))
+            Long festivalId = 1L;
+
+            given(announcementJpaRepository.findAllByFestivalId(festivalId))
                     .willReturn(List.of());
 
             // when
-            AnnouncementGroupedResponses result = announcementService.getGroupedAnnouncementByFestivalId(
-                    DEFAULT_FESTIVAL_ID);
+            AnnouncementGroupedResponses result = announcementService.getGroupedAnnouncementByFestivalId(festivalId);
 
             // then
             assertSoftly(s -> {
@@ -263,7 +286,9 @@ class AnnouncementServiceTest {
         @Test
         void 성공() {
             // given
-            Announcement announcement = AnnouncementFixture.create();
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(festival);
 
             given(announcementJpaRepository.findById(announcement.getId()))
                     .willReturn(Optional.of(announcement));
@@ -271,7 +296,11 @@ class AnnouncementServiceTest {
             AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.create("new title", "new content");
 
             // when
-            AnnouncementUpdateResponse result = announcementService.updateAnnouncement(announcement.getId(), request);
+            AnnouncementUpdateResponse result = announcementService.updateAnnouncement(
+                    announcement.getId(),
+                    festival.getId(),
+                    request
+            );
 
             // then
             assertSoftly(s -> {
@@ -284,15 +313,39 @@ class AnnouncementServiceTest {
         void 예외_존재하지_않는_공지사항_ID() {
             // given
             Long invalidAnnouncementId = 0L;
+            Festival festival = FestivalFixture.create();
             AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.create();
 
             given(announcementJpaRepository.findById(invalidAnnouncementId))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> announcementService.updateAnnouncement(invalidAnnouncementId, request))
+            assertThatThrownBy(() ->
+                    announcementService.updateAnnouncement(invalidAnnouncementId, festival.getId(), request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 공지입니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_공지일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            Announcement announcement = AnnouncementFixture.create(requestFestival);
+
+            given(announcementJpaRepository.findById(announcement.getId()))
+                    .willReturn(Optional.of(announcement));
+
+            AnnouncementUpdateRequest request = AnnouncementUpdateRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() ->
+                    announcementService.updateAnnouncement(announcement.getId(), otherFestival.getId(), request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 공지가 아닙니다.");
         }
     }
 
@@ -302,16 +355,21 @@ class AnnouncementServiceTest {
         @Test
         void 성공() {
             // given
+            Long festivalId = 1L;
             Long announcementId = 1L;
-            Announcement announcement = AnnouncementFixture.create(announcementId, false);
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(announcementId, false, festival);
             AnnouncementPinUpdateRequest request = AnnouncementPinUpdateRequestFixture.create(true);
 
             given(announcementJpaRepository.findById(announcementId))
                     .willReturn(Optional.of(announcement));
 
             // when
-            AnnouncementPinUpdateResponse result = announcementService.updateAnnouncementPin(announcementId,
-                    DEFAULT_FESTIVAL_ID, request);
+            AnnouncementPinUpdateResponse result = announcementService.updateAnnouncementPin(
+                    announcementId,
+                    festivalId,
+                    request
+            );
 
             // then
             assertThat(result.isPinned()).isEqualTo(request.pinned());
@@ -320,6 +378,7 @@ class AnnouncementServiceTest {
         @Test
         void 예외_존재하지_않는_공지사항_ID() {
             // given
+            Long festivalId = 1L;
             Long invalidAnnouncementId = 0L;
             AnnouncementPinUpdateRequest request = AnnouncementPinUpdateRequestFixture.create();
 
@@ -329,7 +388,7 @@ class AnnouncementServiceTest {
             // when & then
             assertThatThrownBy(() -> announcementService.updateAnnouncementPin(
                     invalidAnnouncementId,
-                    DEFAULT_FESTIVAL_ID,
+                    festivalId,
                     request)
             )
                     .isInstanceOf(BusinessException.class)
@@ -339,21 +398,23 @@ class AnnouncementServiceTest {
         @Test
         void 예외_고정_공지_개수_제한_초과() {
             // given
+            Long festivalId = 1L;
             Long announcementId = 1L;
-            Announcement announcement = AnnouncementFixture.create(announcementId, false);
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(announcementId, false, festival);
             AnnouncementPinUpdateRequest request = AnnouncementPinUpdateRequestFixture.create(true);
 
             given(announcementJpaRepository.findById(announcementId))
                     .willReturn(Optional.of(announcement));
 
             Long pinnedCountLimit = 3L;
-            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(DEFAULT_FESTIVAL_ID))
+            given(announcementJpaRepository.countByFestivalIdAndIsPinnedTrue(festivalId))
                     .willReturn(pinnedCountLimit);
 
             // when & then
             assertThatThrownBy(() -> announcementService.updateAnnouncementPin(
                     announcementId,
-                    DEFAULT_FESTIVAL_ID,
+                    festivalId,
                     request)
             )
                     .isInstanceOf(BusinessException.class)
@@ -363,19 +424,43 @@ class AnnouncementServiceTest {
         @Test
         void 성공_고정된_공지는_고정_공지_개수_제한_검증_안함() {
             // given
+            Long festivalId = 1L;
             Long announcementId = 1L;
-            Announcement announcement = AnnouncementFixture.create(announcementId, true);
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(announcementId, true, festival);
             AnnouncementPinUpdateRequest request = AnnouncementPinUpdateRequestFixture.create(true);
 
             given(announcementJpaRepository.findById(announcementId))
                     .willReturn(Optional.of(announcement));
 
             // when
-            announcementService.updateAnnouncementPin(announcementId, DEFAULT_FESTIVAL_ID, request);
+            announcementService.updateAnnouncementPin(announcementId, festivalId, request);
 
             // then
             then(announcementJpaRepository).should(never())
-                    .countByFestivalIdAndIsPinnedTrue(DEFAULT_FESTIVAL_ID);
+                    .countByFestivalIdAndIsPinnedTrue(festivalId);
+        }
+
+        @Test
+        void 예외_다른_축제의_공지일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            Announcement announcement = AnnouncementFixture.create(requestFestival);
+
+            given(announcementJpaRepository.findById(announcement.getId()))
+                    .willReturn(Optional.of(announcement));
+
+            AnnouncementPinUpdateRequest request = AnnouncementPinUpdateRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() ->
+                    announcementService.updateAnnouncementPin(announcement.getId(), otherFestival.getId(), request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 공지가 아닙니다.");
         }
     }
 
@@ -386,15 +471,42 @@ class AnnouncementServiceTest {
         void 성공() {
             // given
             Long announcementId = 1L;
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Announcement announcement = AnnouncementFixture.create(announcementId, festival);
 
-            willDoNothing().given(announcementJpaRepository).deleteById(announcementId);
+            given(announcementJpaRepository.findById(announcementId))
+                    .willReturn(Optional.of(announcement));
 
             // when
-            announcementService.deleteAnnouncementByAnnouncementId(announcementId);
+            announcementService.deleteAnnouncementByAnnouncementId(announcementId, festivalId);
 
             // then
             then(announcementJpaRepository).should()
-                    .deleteById(announcementId);
+                    .delete(announcement);
+        }
+
+        @Test
+        void 예외_다른_축제의_공지일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            Announcement announcement = AnnouncementFixture.create(requestFestival);
+
+            given(announcementJpaRepository.findById(announcement.getId()))
+                    .willReturn(Optional.of(announcement));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    announcementService.deleteAnnouncementByAnnouncementId(
+                            announcement.getId(),
+                            otherFestival.getId()
+                    )
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 공지가 아닙니다.");
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -300,7 +300,8 @@ class AnnouncementServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    announcementService.updateAnnouncement(invalidAnnouncementId, festival.getId(), request))
+                    announcementService.updateAnnouncement(invalidAnnouncementId, festival.getId(), request)
+            )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 공지입니다.");
         }
@@ -367,10 +368,12 @@ class AnnouncementServiceTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> announcementService.updateAnnouncementPin(
-                    invalidAnnouncementId,
-                    festivalId,
-                    request)
+            assertThatThrownBy(() ->
+                    announcementService.updateAnnouncementPin(
+                            invalidAnnouncementId,
+                            festivalId,
+                            request
+                    )
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 공지입니다.");
@@ -393,10 +396,12 @@ class AnnouncementServiceTest {
                     .willReturn(pinnedCountLimit);
 
             // when & then
-            assertThatThrownBy(() -> announcementService.updateAnnouncementPin(
-                    announcementId,
-                    festivalId,
-                    request)
+            assertThatThrownBy(() ->
+                    announcementService.updateAnnouncementPin(
+                            announcementId,
+                            festivalId,
+                            request
+                    )
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("공지글은 최대 3개까지 고정할 수 있습니다.");

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -1,7 +1,7 @@
 package com.daedan.festabook.announcement.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
## #️⃣ 이슈 번호

#578

<br>

## 🛠️ 작업 내용

- Announcement 인가 처리
- 헤더에 실린 토큰의 festival 소유의 공지가 아니라면 리소스의 CUD를 하지 못하도록 변경했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

<br>

## 📸 이미지 첨부 (Optional)

<img width="1734" height="672" alt="image" src="https://github.com/user-attachments/assets/c77ca715-9fc1-4fed-a304-f149d632c1af" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 공지 생성·수정·고정·삭제가 인증된 운영진(CouncilDetails)의 축제 범위(festivalId)를 사용해 권한 기준으로 처리됩니다.
  - 공지 고정 시 축제별 고정 개수 검증 강화(초과 시 오류 반환).
  - 공지 소유권 검증 추가로 타 축제 공지 조작 시 접근 거부(403) 반환.

- Documentation
  - 전체 공지 조회 API에 인증 불필요 명시 추가.

- Tests
  - 축제 범위 검증·고정 제한·삭제 흐름 관련 테스트 보강 및 정비.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->