### PR TITLE
[BE] EventDate & Event 인가 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
@@ -10,6 +10,7 @@ import com.daedan.festabook.global.security.council.CouncilDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,7 +48,7 @@ public class EventController {
 
     @GetMapping("/{eventDateId}/events")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 일정 날짜의 모든 일정 조회")
+    @Operation(summary = "특정 일정 날짜의 모든 일정 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     })

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
@@ -6,12 +6,14 @@ import com.daedan.festabook.event.dto.EventResponses;
 import com.daedan.festabook.event.dto.EventUpdateRequest;
 import com.daedan.festabook.event.dto.EventUpdateResponse;
 import com.daedan.festabook.event.service.EventService;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -37,34 +39,10 @@ public class EventController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true)
     })
     public EventResponse createEvent(
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody EventRequest request
     ) {
-        return eventService.createEvent(request);
-    }
-
-    @PatchMapping("/events/{eventId}")
-    @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "일정 수정")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
-    })
-    public EventUpdateResponse updateEvent(
-            @PathVariable Long eventId,
-            @RequestBody EventUpdateRequest request
-    ) {
-        return eventService.updateEvent(eventId, request);
-    }
-
-    @DeleteMapping("/events/{eventId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "일정 삭제")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", useReturnTypeSchema = true)
-    })
-    public void deleteEventByEventId(
-            @PathVariable Long eventId
-    ) {
-        eventService.deleteEventByEventId(eventId);
+        return eventService.createEvent(councilDetails.getFestivalId(), request);
     }
 
     @GetMapping("/{eventDateId}/events")
@@ -77,5 +55,32 @@ public class EventController {
             @PathVariable Long eventDateId
     ) {
         return eventService.getAllEventByEventDateId(eventDateId);
+    }
+
+    @PatchMapping("/events/{eventId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "일정 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
+    })
+    public EventUpdateResponse updateEvent(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
+            @RequestBody EventUpdateRequest request
+    ) {
+        return eventService.updateEvent(eventId, councilDetails.getFestivalId(), request);
+    }
+
+    @DeleteMapping("/events/{eventId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "일정 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", useReturnTypeSchema = true)
+    })
+    public void deleteEventByEventId(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
+    ) {
+        eventService.deleteEventByEventId(eventId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
@@ -7,13 +7,16 @@ import com.daedan.festabook.event.dto.EventDateUpdateRequest;
 import com.daedan.festabook.event.dto.EventDateUpdateResponse;
 import com.daedan.festabook.event.service.EventDateService;
 import com.daedan.festabook.global.argumentresolver.FestivalId;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,10 +42,22 @@ public class EventDateController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true)
     })
     public EventDateResponse createEventDate(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody EventDateRequest request
     ) {
-        return eventDateService.createEventDate(festivalId, request);
+        return eventDateService.createEventDate(councilDetails.getFestivalId(), request);
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제의 모든 일정 날짜 조회", security = @SecurityRequirement(name = "none"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
+    })
+    public EventDateResponses getAllEventDateByFestivalId(
+            @Parameter(hidden = true) @FestivalId Long festivalId
+    ) {
+        return eventDateService.getAllEventDateByFestivalId(festivalId);
     }
 
     @PatchMapping("/{eventDateId}")
@@ -52,11 +67,11 @@ public class EventDateController {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     })
     public EventDateUpdateResponse updateEventDate(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
             @PathVariable Long eventDateId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody EventDateUpdateRequest request
     ) {
-        return eventDateService.updateEventDate(festivalId, eventDateId, request);
+        return eventDateService.updateEventDate(eventDateId, councilDetails.getFestivalId(), request);
     }
 
     @DeleteMapping("/{eventDateId}")
@@ -66,20 +81,9 @@ public class EventDateController {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true)
     })
     public void deleteEventDateByEventDateId(
-            @PathVariable Long eventDateId
+            @PathVariable Long eventDateId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        eventDateService.deleteEventDateByEventDateId(eventDateId);
-    }
-
-    @GetMapping
-    @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 모든 일정 날짜 조회")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
-    })
-    public EventDateResponses getAllEventDateByFestivalId(
-            @Parameter(hidden = true) @FestivalId Long festivalId
-    ) {
-        return eventDateService.getAllEventDateByFestivalId(festivalId);
+        eventDateService.deleteEventDateByEventDateId(eventDateId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/event/domain/Event.java
+++ b/backend/src/main/java/com/daedan/festabook/event/domain/Event.java
@@ -69,6 +69,10 @@ public class Event extends BaseEntity implements Comparable<Event> {
         this.location = newEvent.location;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.getEventDate().getFestival().getId().equals(festivalId);
+    }
+
     @Override
     public int compareTo(Event otherEvent) {
         if (startTime.equals(otherEvent.startTime)) {

--- a/backend/src/main/java/com/daedan/festabook/event/domain/EventDate.java
+++ b/backend/src/main/java/com/daedan/festabook/event/domain/EventDate.java
@@ -47,6 +47,10 @@ public class EventDate extends BaseEntity implements Comparable<EventDate> {
         this.date = date;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.getFestival().getId().equals(festivalId);
+    }
+
     @Override
     public int compareTo(EventDate otherEventDate) {
         return this.date.compareTo(otherEventDate.date);

--- a/backend/src/main/java/com/daedan/festabook/event/service/EventDateService.java
+++ b/backend/src/main/java/com/daedan/festabook/event/service/EventDateService.java
@@ -29,28 +29,11 @@ public class EventDateService {
     @Transactional
     public EventDateResponse createEventDate(Long festivalId, EventDateRequest request) {
         validateDuplicatedEventDate(festivalId, request.date());
-
         Festival festival = getFestivalById(festivalId);
         EventDate eventDate = request.toEntity(festival);
+
         EventDate savedEventDate = eventDateJpaRepository.save(eventDate);
-
         return EventDateResponse.from(savedEventDate);
-    }
-
-    @Transactional
-    public EventDateUpdateResponse updateEventDate(Long festivalId, Long eventDateId, EventDateUpdateRequest request) {
-        validateDuplicatedEventDate(festivalId, request.date());
-
-        EventDate eventDate = getEventDateById(eventDateId);
-        eventDate.updateDate(request.date());
-
-        return EventDateUpdateResponse.from(eventDate);
-    }
-
-    @Transactional
-    public void deleteEventDateByEventDateId(Long eventDateId) {
-        eventJpaRepository.deleteAllByEventDateId(eventDateId);
-        eventDateJpaRepository.deleteById(eventDateId);
     }
 
     public EventDateResponses getAllEventDateByFestivalId(Long festivalId) {
@@ -58,6 +41,25 @@ public class EventDateService {
                 .sorted()
                 .toList();
         return EventDateResponses.from(eventDates);
+    }
+
+    @Transactional
+    public EventDateUpdateResponse updateEventDate(Long eventDateId, Long festivalId, EventDateUpdateRequest request) {
+        EventDate eventDate = getEventDateById(eventDateId);
+        validateEventDateBelongsToFestival(eventDate, festivalId);
+        validateDuplicatedEventDate(festivalId, request.date());
+
+        eventDate.updateDate(request.date());
+        return EventDateUpdateResponse.from(eventDate);
+    }
+
+    @Transactional
+    public void deleteEventDateByEventDateId(Long eventDateId, Long festivalId) {
+        EventDate eventDate = getEventDateById(eventDateId);
+        validateEventDateBelongsToFestival(eventDate, festivalId);
+
+        eventJpaRepository.deleteAllByEventDateId(eventDateId);
+        eventDateJpaRepository.deleteById(eventDateId);
     }
 
     private Festival getFestivalById(Long festivalId) {
@@ -73,6 +75,12 @@ public class EventDateService {
     private void validateDuplicatedEventDate(Long festivalId, LocalDate date) {
         if (eventDateJpaRepository.existsByFestivalIdAndDate(festivalId, date)) {
             throw new BusinessException("이미 존재하는 일정 날짜입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateEventDateBelongsToFestival(EventDate eventDate, Long festivalId) {
+        if (!eventDate.isFestivalIdEqualTo(festivalId)) {
+            throw new BusinessException("해당 축제의 일정 날짜가 아닙니다.", HttpStatus.FORBIDDEN);
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventControllerTest.java
@@ -48,8 +48,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class EventControllerTest {
 
-    private static final String FESTIVAL_HEADER_NAME = "festival";
-
     @Autowired
     private EventDateJpaRepository eventDateJpaRepository;
 
@@ -98,7 +96,6 @@ class EventControllerTest {
                     .given()
                     .header(authorizationHeader)
                     .contentType(ContentType.JSON)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .body(request)
                     .when()
                     .post("/event-dates/events")
@@ -149,7 +146,6 @@ class EventControllerTest {
                     .given()
                     .contentType(ContentType.JSON)
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .body(request)
                     .when()
                     .patch("/event-dates/events/{eventId}", eventId)
@@ -186,34 +182,11 @@ class EventControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .when()
                     .delete("/event-dates/events/{eventId}", event.getId())
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
             assertThat(eventJpaRepository.findById(event.getId())).isEmpty();
-        }
-
-        @Test
-        void 성공_존재하지_않는_일정_ID() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long invalidEventId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .when()
-                    .delete("/event-dates/events/{eventId}", invalidEventId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
-            assertThat(eventJpaRepository.findById(invalidEventId)).isEmpty();
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/controller/EventDateControllerTest.java
@@ -85,7 +85,6 @@ class EventDateControllerTest {
                     .given()
                     .contentType(ContentType.JSON)
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .body(request)
                     .when()
                     .post("/event-dates")
@@ -113,7 +112,6 @@ class EventDateControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -121,156 +119,6 @@ class EventDateControllerTest {
                     .then()
                     .statusCode(HttpStatus.BAD_REQUEST.value())
                     .body("message", equalTo("이미 존재하는 일정 날짜입니다."));
-        }
-    }
-
-    @Nested
-    class updateEventDate {
-
-        @Test
-        void 성공() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            EventDate eventDate = EventDateFixture.create(festival);
-            eventDateJpaRepository.save(eventDate);
-
-            EventDateRequest request = EventDateRequestFixture.create(eventDate.getDate().plusDays(1));
-
-            int expectedSize = 2;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .patch("/event-dates/{eventDateId}", eventDate.getId())
-                    .then()
-                    .statusCode(HttpStatus.OK.value())
-                    .body("size()", equalTo(expectedSize))
-                    .body("eventDateId", equalTo(eventDate.getId().intValue()))
-                    .body("date", equalTo(request.date().toString()));
-
-            assertSoftly(s -> {
-                EventDate updatedEventDate = eventDateJpaRepository.findById(eventDate.getId()).orElseThrow();
-                s.assertThat(updatedEventDate.getDate()).isEqualTo(request.date());
-            });
-        }
-
-        @Test
-        void 성공_존재하지_않는_일정_날짜_ID_404_응답() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long notExistingEventDateId = 0L;
-            EventDateRequest request = EventDateRequestFixture.create();
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .patch("/event-dates/{eventDateId}", notExistingEventDateId)
-                    .then()
-                    .statusCode(HttpStatus.BAD_REQUEST.value())
-                    .body("message", equalTo("존재하지 않는 일정 날짜입니다."));
-        }
-
-        @Test
-        void 예외_이미_존재하는_일정_날짜() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            List<EventDate> eventDates = EventDateFixture.createList(2, festival);
-            eventDateJpaRepository.saveAll(eventDates);
-
-            EventDateRequest request = EventDateRequestFixture.create(eventDates.get(1).getDate());
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .contentType(ContentType.JSON)
-                    .body(request)
-                    .when()
-                    .patch("/event-dates/{eventDateId}", eventDates.get(0).getId())
-                    .then()
-                    .statusCode(HttpStatus.BAD_REQUEST.value())
-                    .body("message", equalTo("이미 존재하는 일정 날짜입니다."));
-        }
-    }
-
-    @Nested
-    class deleteEventDateByEventDateId {
-
-        @Test
-        void 성공() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            EventDate eventDate = EventDateFixture.create(festival);
-            eventDateJpaRepository.save(eventDate);
-
-            List<Event> events = EventFixture.createList(3, eventDate);
-            eventJpaRepository.saveAll(events);
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .when()
-                    .delete("/event-dates/{eventDateId}", eventDate.getId())
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
-            assertSoftly(s -> {
-                s.assertThat(eventDateJpaRepository.findById(eventDate.getId())).isEmpty();
-                s.assertThat(eventJpaRepository.findAllByEventDateId(eventDate.getId())).isEmpty();
-            });
-        }
-
-        @Test
-        void 성공_존재하지_않는_일정_날짜_ID() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long invalidEventDateId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .when()
-                    .delete("/event-dates/{eventDateId}", invalidEventDateId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
-            assertSoftly(s -> {
-                s.assertThat(eventDateJpaRepository.findById(invalidEventDateId)).isEmpty();
-                s.assertThat(eventJpaRepository.findAllByEventDateId(invalidEventDateId)).isEmpty();
-            });
         }
     }
 
@@ -358,6 +206,127 @@ class EventDateControllerTest {
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("date", contains(expectedSortedDates.toArray()));
+        }
+    }
+
+    @Nested
+    class updateEventDate {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
+
+            EventDate eventDate = EventDateFixture.create(festival);
+            eventDateJpaRepository.save(eventDate);
+
+            EventDateRequest request = EventDateRequestFixture.create(eventDate.getDate().plusDays(1));
+
+            int expectedSize = 2;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(authorizationHeader)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .patch("/event-dates/{eventDateId}", eventDate.getId())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedSize))
+                    .body("eventDateId", equalTo(eventDate.getId().intValue()))
+                    .body("date", equalTo(request.date().toString()));
+
+            assertSoftly(s -> {
+                EventDate updatedEventDate = eventDateJpaRepository.findById(eventDate.getId()).orElseThrow();
+                s.assertThat(updatedEventDate.getDate()).isEqualTo(request.date());
+            });
+        }
+
+        @Test
+        void 성공_존재하지_않는_일정_날짜_ID_404_응답() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
+
+            Long notExistingEventDateId = 0L;
+            EventDateRequest request = EventDateRequestFixture.create();
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(authorizationHeader)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .patch("/event-dates/{eventDateId}", notExistingEventDateId)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("존재하지 않는 일정 날짜입니다."));
+        }
+
+        @Test
+        void 예외_이미_존재하는_일정_날짜() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
+
+            List<EventDate> eventDates = EventDateFixture.createList(2, festival);
+            eventDateJpaRepository.saveAll(eventDates);
+
+            EventDateRequest request = EventDateRequestFixture.create(eventDates.get(1).getDate());
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(authorizationHeader)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .patch("/event-dates/{eventDateId}", eventDates.get(0).getId())
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("이미 존재하는 일정 날짜입니다."));
+        }
+    }
+
+    @Nested
+    class deleteEventDateByEventDateId {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
+
+            EventDate eventDate = EventDateFixture.create(festival);
+            eventDateJpaRepository.save(eventDate);
+
+            List<Event> events = EventFixture.createList(3, eventDate);
+            eventJpaRepository.saveAll(events);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(authorizationHeader)
+                    .when()
+                    .delete("/event-dates/{eventDateId}", eventDate.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+            assertSoftly(s -> {
+                s.assertThat(eventDateJpaRepository.findById(eventDate.getId())).isEmpty();
+                s.assertThat(eventJpaRepository.findAllByEventDateId(eventDate.getId())).isEmpty();
+            });
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/event/domain/EventDateFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/domain/EventDateFixture.java
@@ -26,6 +26,19 @@ public class EventDateFixture {
 
     public static EventDate create(
             Long eventDateId,
+            Festival festival,
+            LocalDate date
+    ) {
+        EventDate eventDate = new EventDate(
+                festival,
+                date
+        );
+        BaseEntityTestHelper.setId(eventDate, eventDateId);
+        return eventDate;
+    }
+
+    public static EventDate create(
+            Long eventDateId,
             Festival festival
     ) {
         EventDate eventDate = new EventDate(

--- a/backend/src/test/java/com/daedan/festabook/event/domain/EventFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/event/domain/EventFixture.java
@@ -56,6 +56,21 @@ public class EventFixture {
     }
 
     public static Event create(
+            Long eventId,
+            EventDate eventDate
+    ) {
+        Event event = new Event(
+                eventDate,
+                DEFAULT_START_TIME,
+                DEFAULT_END_TIME,
+                DEFAULT_TITLE,
+                DEFAULT_LOCATION
+        );
+        BaseEntityTestHelper.setId(event, eventId);
+        return event;
+    }
+
+    public static Event create(
             EventDate eventDate
     ) {
         return new Event(

--- a/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/event/service/EventDateServiceTest.java
@@ -38,8 +38,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class EventDateServiceTest {
 
-    private static final Long DEFAULT_FESTIVAL_ID = 1L;
-
     @Mock
     private EventDateJpaRepository eventDateJpaRepository;
 
@@ -58,17 +56,18 @@ class EventDateServiceTest {
         @Test
         void 성공() {
             // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(1L);
             EventDateRequest request = EventDateRequestFixture.create();
             EventDate eventDate = EventDateFixture.create(request.date());
+
             given(eventDateJpaRepository.save(any()))
                     .willReturn(eventDate);
-
-            Festival festival = FestivalFixture.create(DEFAULT_FESTIVAL_ID);
-            given(festivalJpaRepository.findById(DEFAULT_FESTIVAL_ID))
+            given(festivalJpaRepository.findById(festivalId))
                     .willReturn(Optional.of(festival));
 
             // when
-            EventDateResponse result = eventDateService.createEventDate(DEFAULT_FESTIVAL_ID, request);
+            EventDateResponse result = eventDateService.createEventDate(festivalId, request);
 
             // then
             assertSoftly(s -> {
@@ -80,12 +79,14 @@ class EventDateServiceTest {
         @Test
         void 예외_이미_존재하는_일정_날짜() {
             // given
+            Long festivalId = 1L;
             EventDateRequest request = EventDateRequestFixture.create();
-            given(eventDateJpaRepository.existsByFestivalIdAndDate(DEFAULT_FESTIVAL_ID, request.date()))
+
+            given(eventDateJpaRepository.existsByFestivalIdAndDate(festivalId, request.date()))
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> eventDateService.createEventDate(DEFAULT_FESTIVAL_ID, request))
+            assertThatThrownBy(() -> eventDateService.createEventDate(festivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("이미 존재하는 일정 날짜입니다.");
         }
@@ -93,14 +94,72 @@ class EventDateServiceTest {
         @Test
         void 예외_존재하지_않는_축제() {
             // given
+            Long festivalId = 1L;
             EventDateRequest request = EventDateRequestFixture.create();
-            given(festivalJpaRepository.findById(DEFAULT_FESTIVAL_ID))
+
+            given(festivalJpaRepository.findById(festivalId))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> eventDateService.createEventDate(DEFAULT_FESTIVAL_ID, request))
+            assertThatThrownBy(() -> eventDateService.createEventDate(festivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 축제입니다.");
+        }
+    }
+
+    @Nested
+    class getAllEventDateByFestivalId {
+
+        @Test
+        void 성공_응답_개수_확인() {
+            // given
+            Long festivalId = 1L;
+
+            EventDate eventDate1 = EventDateFixture.create(LocalDate.of(2025, 10, 26));
+            EventDate eventDate2 = EventDateFixture.create(LocalDate.of(2025, 10, 27));
+
+            List<EventDate> eventDates = List.of(eventDate1, eventDate2);
+
+            given(eventDateJpaRepository.findAllByFestivalId(festivalId))
+                    .willReturn(eventDates);
+
+            LocalDate expected = LocalDate.of(2025, 10, 26);
+
+            // when
+            EventDateResponses result = eventDateService.getAllEventDateByFestivalId(festivalId);
+
+            // then
+            assertSoftly(s -> {
+                s.assertThat(result.responses()).hasSize(2);
+                s.assertThat(result.responses().getFirst().date()).isEqualTo(expected);
+            });
+        }
+
+        @Test
+        void 성공_날짜_오름차순_정렬() {
+            // given
+            Long festivalId = 1L;
+
+            EventDate eventDate1 = EventDateFixture.create(LocalDate.of(2025, 10, 27));
+            EventDate eventDate2 = EventDateFixture.create(LocalDate.of(2025, 10, 26));
+            EventDate eventDate3 = EventDateFixture.create(LocalDate.of(2025, 10, 25));
+
+            List<EventDate> eventDates = List.of(eventDate1, eventDate2, eventDate3);
+
+            given(eventDateJpaRepository.findAllByFestivalId(festivalId))
+                    .willReturn(eventDates);
+
+            // when
+            EventDateResponses result = eventDateService.getAllEventDateByFestivalId(festivalId);
+
+            // then
+            assertThat(result.responses())
+                    .extracting(EventDateResponse::date)
+                    .containsExactly(
+                            eventDate3.getDate(),
+                            eventDate2.getDate(),
+                            eventDate1.getDate()
+                    );
         }
     }
 
@@ -110,16 +169,19 @@ class EventDateServiceTest {
         @Test
         void 성공() {
             // given
+            Long festivalId = 1L;
             Long eventDateId = 1L;
-            Festival festival = FestivalFixture.create(DEFAULT_FESTIVAL_ID);
+            Festival festival = FestivalFixture.create(festivalId);
             EventDate eventDate = EventDateFixture.create(eventDateId, festival);
+
             given(eventDateJpaRepository.findById(eventDateId))
                     .willReturn(Optional.of(eventDate));
+
             EventDateUpdateRequest request = EventDateUpdateRequestFixture.create(eventDate.getDate().plusDays(1));
 
             // when
             EventDateUpdateResponse result = eventDateService.updateEventDate(
-                    DEFAULT_FESTIVAL_ID,
+                    festivalId,
                     eventDateId,
                     request
             );
@@ -134,15 +196,43 @@ class EventDateServiceTest {
         @Test
         void 예외_이미_존재하는_일정_날짜() {
             // given
+            Long festivalId = 1L;
             Long eventDateId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            EventDate eventDate = EventDateFixture.create(eventDateId, festival);
             EventDateUpdateRequest request = EventDateUpdateRequestFixture.create();
-            given(eventDateJpaRepository.existsByFestivalIdAndDate(DEFAULT_FESTIVAL_ID, request.date()))
+
+            given(eventDateJpaRepository.findById(eventDateId))
+                    .willReturn(Optional.of(eventDate));
+            given(eventDateJpaRepository.existsByFestivalIdAndDate(festivalId, request.date()))
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> eventDateService.updateEventDate(DEFAULT_FESTIVAL_ID, eventDateId, request))
+            assertThatThrownBy(() -> eventDateService.updateEventDate(festivalId, eventDateId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("이미 존재하는 일정 날짜입니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_일정_날짜일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            EventDate eventDate = EventDateFixture.create(requestFestival);
+
+            given(eventDateJpaRepository.findById(eventDate.getId()))
+                    .willReturn(Optional.of(eventDate));
+
+            EventDateUpdateRequest request = EventDateUpdateRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() ->
+                    eventDateService.updateEventDate(eventDate.getId(), otherFestival.getId(), request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 일정 날짜가 아닙니다.");
         }
     }
 
@@ -152,10 +242,16 @@ class EventDateServiceTest {
         @Test
         void 성공() {
             // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
             Long eventDateId = 1L;
+            EventDate eventDate = EventDateFixture.create(eventDateId, festival);
+
+            given(eventDateJpaRepository.findById(eventDateId))
+                    .willReturn(Optional.of(eventDate));
 
             // when
-            eventDateService.deleteEventDateByEventDateId(eventDateId);
+            eventDateService.deleteEventDateByEventDateId(eventDateId, festivalId);
 
             // then
             then(eventDateJpaRepository).should()
@@ -163,57 +259,25 @@ class EventDateServiceTest {
             then(eventJpaRepository).should()
                     .deleteAllByEventDateId(eventDateId);
         }
-    }
-
-    @Nested
-    class getAllEventDateByFestivalId {
 
         @Test
-        void 성공_응답_개수_확인() {
+        void 예외_다른_축제의_일정_날짜일_경우() {
             // given
-            EventDate eventDate1 = EventDateFixture.create(LocalDate.of(2025, 10, 26));
-            EventDate eventDate2 = EventDateFixture.create(LocalDate.of(2025, 10, 27));
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            EventDate eventDate = EventDateFixture.create(requestFestival);
 
-            List<EventDate> eventDates = List.of(eventDate1, eventDate2);
+            given(eventDateJpaRepository.findById(eventDate.getId()))
+                    .willReturn(Optional.of(eventDate));
 
-            given(eventDateJpaRepository.findAllByFestivalId(DEFAULT_FESTIVAL_ID))
-                    .willReturn(eventDates);
-
-            LocalDate expected = LocalDate.of(2025, 10, 26);
-
-            // when
-            EventDateResponses result = eventDateService.getAllEventDateByFestivalId(DEFAULT_FESTIVAL_ID);
-
-            // then
-            assertSoftly(s -> {
-                s.assertThat(result.responses()).hasSize(2);
-                s.assertThat(result.responses().getFirst().date()).isEqualTo(expected);
-            });
-        }
-
-        @Test
-        void 성공_날짜_오름차순_정렬() {
-            // given
-            EventDate eventDate1 = EventDateFixture.create(LocalDate.of(2025, 10, 27));
-            EventDate eventDate2 = EventDateFixture.create(LocalDate.of(2025, 10, 26));
-            EventDate eventDate3 = EventDateFixture.create(LocalDate.of(2025, 10, 25));
-
-            List<EventDate> eventDates = List.of(eventDate1, eventDate2, eventDate3);
-
-            given(eventDateJpaRepository.findAllByFestivalId(DEFAULT_FESTIVAL_ID))
-                    .willReturn(eventDates);
-
-            // when
-            EventDateResponses result = eventDateService.getAllEventDateByFestivalId(DEFAULT_FESTIVAL_ID);
-
-            // then
-            assertThat(result.responses())
-                    .extracting(EventDateResponse::date)
-                    .containsExactly(
-                            eventDate3.getDate(),
-                            eventDate2.getDate(),
-                            eventDate1.getDate()
-                    );
+            // when & then
+            assertThatThrownBy(() ->
+                    eventDateService.deleteEventDateByEventDateId(eventDate.getId(), otherFestival.getId())
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 일정 날짜가 아닙니다.");
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#670

<br>

## 🛠️ 작업 내용

- EventDate & Event 인가 처리
- 헤더에 실린 토큰의 festival 소유의 Event와 EventDate가 아니라면 리소스의 CUD를 하지 못하도록 변경했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 원래 리소스 create를 할 때는 festival에 속하는지 검사를 하지 않는게 일반적인데, Event 같은 경우 Event-EventDate-Festival 구조로 연관관계를 맺고 있기 때문에 Event를 Create할 때 EventDate가 FestivalId에 속하는지 확인하는 로직이 있습니다. 해당 부분이 괜찮은지 확인 부탁드립니다.
- 또한 get 부분에 @Transactional(readonly = true) 어노테이션이 있는데, 이 부분을 처리하지 않으면 LazyInitialException이 터집니다. 현재 인가 처리에서 메서드 체이닝으로 Event의 EventDate의 Festival을 조회해 오는 경우가 있기 때문에 이 과정이 테스트에서 오류를 발생시킬 수 있습니다. 더 나은 구조가 있으면 제안 부탁드립니다. 

<br>

## 📸 이미지 첨부 (Optional)

<img width="1752" height="1180" alt="image" src="https://github.com/user-attachments/assets/d0385fe5-85d8-4014-b1e8-b317f21bc11c" />