### PR TITLE
[BE] Festival 인가 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -12,6 +12,7 @@ import com.daedan.festabook.festival.dto.FestivalUniversityResponses;
 import com.daedan.festabook.festival.service.FestivalImageService;
 import com.daedan.festabook.festival.service.FestivalService;
 import com.daedan.festabook.global.argumentresolver.FestivalId;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -20,6 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -47,10 +49,10 @@ public class FestivalController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
     public FestivalImageResponse addFestivalImage(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody FestivalImageRequest request
     ) {
-        return festivalImageService.addFestivalImage(festivalId, request);
+        return festivalImageService.addFestivalImage(councilDetails.getFestivalId(), request);
     }
 
     @GetMapping("/geography")
@@ -96,10 +98,10 @@ public class FestivalController {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
     public FestivalInformationResponse updateFestivalInformation(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody FestivalInformationUpdateRequest request
     ) {
-        return festivalService.updateFestivalInformation(festivalId, request);
+        return festivalService.updateFestivalInformation(councilDetails.getFestivalId(), request);
     }
 
     @PatchMapping("/images/sequences")
@@ -109,9 +111,10 @@ public class FestivalController {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
     public FestivalImageResponses updateFestivalImagesSequence(
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody List<FestivalImageSequenceUpdateRequest> requests
     ) {
-        return festivalImageService.updateFestivalImagesSequence(requests);
+        return festivalImageService.updateFestivalImagesSequence(councilDetails.getFestivalId(), requests);
     }
 
     @DeleteMapping("/images/{festivalImageId}")
@@ -121,8 +124,9 @@ public class FestivalController {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })
     public void removeFestivalImage(
-            @PathVariable Long festivalImageId
+            @PathVariable Long festivalImageId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        festivalImageService.removeFestivalImage(festivalImageId);
+        festivalImageService.removeFestivalImage(festivalImageId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -128,6 +128,6 @@ public class FestivalController {
             @PathVariable Long festivalImageId,
             @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        festivalImageService.removeFestivalImage(festivalImageId, councilDetails.getFestivalId());
+        festivalImageService.removeFestivalImage(councilDetails.getFestivalId(), festivalImageId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +58,7 @@ public class FestivalController {
 
     @GetMapping("/geography")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 초기 지리 정보 조회")
+    @Operation(summary = "특정 축제의 초기 지리 정보 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -69,7 +70,7 @@ public class FestivalController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 정보 조회")
+    @Operation(summary = "특정 축제의 정보 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -81,7 +82,7 @@ public class FestivalController {
 
     @GetMapping("/universities")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "대학 이름으로 축제 조회")
+    @Operation(summary = "대학 이름으로 축제 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/festival/domain/FestivalImage.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/domain/FestivalImage.java
@@ -50,6 +50,10 @@ public class FestivalImage extends BaseEntity implements Comparable<FestivalImag
         this.sequence = sequence;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.getFestival().getId().equals(festivalId);
+    }
+
     @Override
     public int compareTo(FestivalImage otherFestivalImage) {
         return sequence.compareTo(otherFestivalImage.sequence);

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
@@ -56,7 +56,6 @@ public class FestivalImageService {
         return FestivalImageResponses.from(festivalImages);
     }
 
-    @Transactional
     public void removeFestivalImage(Long festivalImageId, Long festivalId) {
         FestivalImage festivalImage = getFestivalImageById(festivalImageId);
         validateFestivalImageBelongsToFestival(festivalImage, festivalId);

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
@@ -58,7 +58,7 @@ public class FestivalImageService {
         return FestivalImageResponses.from(festivalImages);
     }
 
-    public void removeFestivalImage(Long festivalImageId, Long festivalId) {
+    public void removeFestivalImage(Long festivalId, Long festivalImageId) {
         FestivalImage festivalImage = getFestivalImageById(festivalImageId);
         validateFestivalImageBelongsToFestival(festivalImage, festivalId);
 

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
@@ -56,6 +56,7 @@ public class FestivalImageService {
         return FestivalImageResponses.from(festivalImages);
     }
 
+    @Transactional
     public void removeFestivalImage(Long festivalImageId, Long festivalId) {
         FestivalImage festivalImage = getFestivalImageById(festivalImageId);
         validateFestivalImageBelongsToFestival(festivalImage, festivalId);

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
@@ -39,8 +39,10 @@ public class FestivalImageService {
     }
 
     @Transactional
-    public FestivalImageResponses updateFestivalImagesSequence(Long festivalId,
-                                                               List<FestivalImageSequenceUpdateRequest> requests) {
+    public FestivalImageResponses updateFestivalImagesSequence(
+            Long festivalId,
+            List<FestivalImageSequenceUpdateRequest> requests
+    ) {
         // TODO: sequence DTO 값 검증 추가
         List<FestivalImage> festivalImages = new ArrayList<>();
 

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalImageService.java
@@ -1,6 +1,5 @@
 package com.daedan.festabook.festival.service;
 
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalImage;
 import com.daedan.festabook.festival.dto.FestivalImageRequest;
@@ -9,6 +8,7 @@ import com.daedan.festabook.festival.dto.FestivalImageResponses;
 import com.daedan.festabook.festival.dto.FestivalImageSequenceUpdateRequest;
 import com.daedan.festabook.festival.infrastructure.FestivalImageJpaRepository;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,12 +39,14 @@ public class FestivalImageService {
     }
 
     @Transactional
-    public FestivalImageResponses updateFestivalImagesSequence(List<FestivalImageSequenceUpdateRequest> requests) {
+    public FestivalImageResponses updateFestivalImagesSequence(Long festivalId,
+                                                               List<FestivalImageSequenceUpdateRequest> requests) {
         // TODO: sequence DTO 값 검증 추가
         List<FestivalImage> festivalImages = new ArrayList<>();
 
         for (FestivalImageSequenceUpdateRequest request : requests) {
             FestivalImage festivalImage = getFestivalImageById(request.festivalImageId());
+            validateFestivalImageBelongsToFestival(festivalImage, festivalId);
             festivalImage.updateSequence(request.sequence());
             festivalImages.add(festivalImage);
         }
@@ -54,7 +56,10 @@ public class FestivalImageService {
         return FestivalImageResponses.from(festivalImages);
     }
 
-    public void removeFestivalImage(Long festivalImageId) {
+    public void removeFestivalImage(Long festivalImageId, Long festivalId) {
+        FestivalImage festivalImage = getFestivalImageById(festivalImageId);
+        validateFestivalImageBelongsToFestival(festivalImage, festivalId);
+
         festivalImageJpaRepository.deleteById(festivalImageId);
     }
 
@@ -66,5 +71,11 @@ public class FestivalImageService {
     private FestivalImage getFestivalImageById(Long festivalImageId) {
         return festivalImageJpaRepository.findById(festivalImageId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 축제 이미지입니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private void validateFestivalImageBelongsToFestival(FestivalImage festivalImage, Long festivalId) {
+        if (!festivalImage.isFestivalIdEqualTo(festivalId)) {
+            throw new BusinessException("해당 축제의 축제 이미지가 아닙니다.", HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
@@ -25,7 +25,6 @@ public class FestivalService {
 
     public FestivalGeographyResponse getFestivalGeographyByFestivalId(Long festivalId) {
         Festival festival = getFestivalById(festivalId);
-
         return FestivalGeographyResponse.from(festival);
     }
 
@@ -43,8 +42,10 @@ public class FestivalService {
     }
 
     @Transactional
-    public FestivalInformationResponse updateFestivalInformation(Long festivalId,
-                                                                 FestivalInformationUpdateRequest request) {
+    public FestivalInformationResponse updateFestivalInformation(
+            Long festivalId,
+            FestivalInformationUpdateRequest request
+    ) {
         Festival festival = getFestivalById(festivalId);
         festival.updateFestival(request.festivalName(), request.startDate(), request.endDate());
         return FestivalInformationResponse.from(festival);

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -99,7 +99,6 @@ class FestivalControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -326,7 +325,6 @@ class FestivalControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -367,7 +365,6 @@ class FestivalControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(requests)
                     .when()
@@ -403,7 +400,6 @@ class FestivalControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .when()
                     .delete("/festivals/images/{festivalImageId}", festivalImage.getId())
@@ -412,28 +408,6 @@ class FestivalControllerTest {
 
             assertThat(festivalImageJpaRepository.findAllByFestivalIdOrderBySequenceAsc(festival.getId()))
                     .isEmpty();
-        }
-
-        @Test
-        void 성공_없는_리소스_삭제() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long invalidFestivalImageId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
-                    .contentType(ContentType.JSON)
-                    .when()
-                    .delete("/festivals/images/{festivalImageId}", invalidFestivalImageId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationControllerTest.java
@@ -1,6 +1,6 @@
 package com.daedan.festabook.festival.controller;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageFixture.java
@@ -21,6 +21,19 @@ public class FestivalImageFixture {
     }
 
     public static FestivalImage create(
+            Long festivalImageId,
+            Festival festival
+    ) {
+        FestivalImage festivalImage = new FestivalImage(
+                festival,
+                DEFAULT_IMAGE_URL,
+                DEFAULT_SEQUENCE
+        );
+        BaseEntityTestHelper.setId(festivalImage, festivalImageId);
+        return festivalImage;
+    }
+
+    public static FestivalImage create(
             Festival festival,
             Integer sequence
     ) {

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageTest.java
@@ -1,0 +1,45 @@
+package com.daedan.festabook.festival.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FestivalImageTest {
+
+    @Nested
+    class isFestivalIdEqualTo {
+
+        @Test
+        void 같은_축제의_id이면_true() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            FestivalImage festivalImage = FestivalImageFixture.create(festival);
+
+            // when
+            boolean result = festivalImage.isFestivalIdEqualTo(festivalId);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 다른_축제의_id이면_false() {
+            // given
+            Long festivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival festival = FestivalFixture.create(festivalId);
+            FestivalImage festivalImage = FestivalImageFixture.create(festival);
+
+            // when
+            boolean result = festivalImage.isFestivalIdEqualTo(otherFestivalId);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalImageTest.java
@@ -1,6 +1,6 @@
 package com.daedan.festabook.festival.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalTest.java
@@ -1,7 +1,7 @@
 package com.daedan.festabook.festival.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.daedan.festabook.global.exception.BusinessException;
 import java.util.Collections;

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
@@ -79,8 +79,7 @@ class FestivalImageServiceTest {
             FestivalImageRequest request = FestivalImageRequestFixture.create();
 
             // when & then
-            assertThatThrownBy(
-                    () -> festivalImageService.addFestivalImage(invalidFestivalId, request))
+            assertThatThrownBy(() -> festivalImageService.addFestivalImage(invalidFestivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 축제입니다.");
         }

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
@@ -93,7 +93,7 @@ class FestivalImageServiceTest {
         void 성공_수정_후_응답값_오름차순_정렬() {
             // given
             Long festivalId = 1L;
-            Festival festival = FestivalFixture.create();
+            Festival festival = FestivalFixture.create(festivalId);
 
             Long festivalImageId1 = 1L;
             Long festivalImageId2 = 2L;

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
@@ -180,7 +180,7 @@ class FestivalImageServiceTest {
                     .willReturn(Optional.of(festivalImage));
 
             // when
-            festivalImageService.removeFestivalImage(festivalImageId, festivalId);
+            festivalImageService.removeFestivalImage(festivalId, festivalImageId);
 
             // then
             then(festivalImageJpaRepository).should()
@@ -202,7 +202,7 @@ class FestivalImageServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    festivalImageService.removeFestivalImage(festivalImage.getId(), otherFestival.getId())
+                    festivalImageService.removeFestivalImage(otherFestival.getId(), festivalImage.getId())
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 축제 이미지가 아닙니다.");

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalImageServiceTest.java
@@ -201,8 +201,8 @@ class FestivalImageServiceTest {
                     .willReturn(Optional.of(festivalImage));
 
             // when & then
-            assertThatThrownBy(
-                    () -> festivalImageService.removeFestivalImage(festivalImage.getId(), otherFestival.getId())
+            assertThatThrownBy(() ->
+                    festivalImageService.removeFestivalImage(festivalImage.getId(), otherFestival.getId())
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 축제 이미지가 아닙니다.");

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
@@ -1,8 +1,8 @@
 package com.daedan.festabook.festival.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
@@ -74,8 +74,7 @@ class FestivalServiceTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(
-                    () -> festivalService.getFestivalGeographyByFestivalId(invalidFestivalId))
+            assertThatThrownBy(() -> festivalService.getFestivalGeographyByFestivalId(invalidFestivalId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 축제입니다.");
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#671

<br>

## 🛠️ 작업 내용

- Festival & FestivalImage 인가 처리
- 헤더에 실린 토큰의 festival 소유의 FestivalImage가 아니라면 리소스의 CUD를 하지 못하도록 변경했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

<br>

## 📸 이미지 첨부 (Optional)

<img width="1734" height="912" alt="image" src="https://github.com/user-attachments/assets/c3b64b89-e054-48c0-97c3-c764bb6920b7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 인증된 운영자 정보로 축제를 식별해 이미지 추가·수정·삭제·순서 변경 요청을 처리하도록 변경했습니다.
- 버그 수정
  - 다른 축제의 이미지를 변경·삭제할 수 있던 경우를 차단하도록 소유권 검증을 추가했습니다.
- 기타
  - 일부 공개 엔드포인트의 보안 메타데이터를 명시적으로 조정해 API 문서 일관성을 개선했습니다.
- 테스트
  - 소유권 검증 관련 양성·음성 시나리오를 추가·보강하고 관련 테스트를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->