### PR TITLE
[BE] Lineup 인가 처리 

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lineups")
-@Tag(name = "축제 라인업", description = "축제 라인업 관련 API")
+@Tag(name = "라인업", description = "라인업 관련 API")
 public class LineupController {
 
     private final LineupService lineupService;

--- a/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
@@ -70,7 +70,7 @@ public class LineupController {
             @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody LineupUpdateRequest request
     ) {
-        return lineupService.updateLineup(lineupId, councilDetails.getFestivalId(), request);
+        return lineupService.updateLineup(councilDetails.getFestivalId(), lineupId, request);
     }
 
     @DeleteMapping("/{lineupId}")
@@ -83,6 +83,6 @@ public class LineupController {
             @PathVariable Long lineupId,
             @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        lineupService.deleteLineupByLineupId(lineupId, councilDetails.getFestivalId());
+        lineupService.deleteLineupByLineupId(councilDetails.getFestivalId(), lineupId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.lineup.controller;
 
 import com.daedan.festabook.global.argumentresolver.FestivalId;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import com.daedan.festabook.lineup.dto.LineupRequest;
 import com.daedan.festabook.lineup.dto.LineupResponse;
 import com.daedan.festabook.lineup.dto.LineupResponses;
@@ -10,9 +11,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -38,15 +41,15 @@ public class LineupController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
     public LineupResponse addLineup(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody LineupRequest request
     ) {
-        return lineupService.addLineup(festivalId, request);
+        return lineupService.addLineup(councilDetails.getFestivalId(), request);
     }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 라인업 조회")
+    @Operation(summary = "특정 축제의 라인업 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -64,9 +67,10 @@ public class LineupController {
     })
     public LineupResponse updateLineup(
             @PathVariable Long lineupId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody LineupUpdateRequest request
     ) {
-        return lineupService.updateLineup(lineupId, request);
+        return lineupService.updateLineup(lineupId, councilDetails.getFestivalId(), request);
     }
 
     @DeleteMapping("/{lineupId}")
@@ -76,8 +80,9 @@ public class LineupController {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })
     public void deleteLineupByLineupId(
-            @PathVariable Long lineupId
+            @PathVariable Long lineupId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        lineupService.deleteLineupByLineupId(lineupId);
+        lineupService.deleteLineupByLineupId(lineupId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/lineup/domain/Lineup.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/domain/Lineup.java
@@ -60,6 +60,10 @@ public class Lineup extends BaseEntity implements Comparable<Lineup> {
         this.performanceAt = performanceAt;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.getFestival().getId().equals(festivalId);
+    }
+
     @Override
     public int compareTo(Lineup otherLineup) {
         return performanceAt.compareTo(otherLineup.performanceAt);

--- a/backend/src/main/java/com/daedan/festabook/lineup/service/LineupService.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/service/LineupService.java
@@ -39,13 +39,18 @@ public class LineupService {
     }
 
     @Transactional
-    public LineupResponse updateLineup(Long lineupId, LineupUpdateRequest request) {
+    public LineupResponse updateLineup(Long lineupId, Long festivalId, LineupUpdateRequest request) {
         Lineup lineup = getLineupById(lineupId);
+        validateLineupBelongsToFestival(lineup, festivalId);
+
         lineup.updateLineup(request.name(), request.imageUrl(), request.performanceAt());
         return LineupResponse.from(lineup);
     }
 
-    public void deleteLineupByLineupId(Long lineupId) {
+    public void deleteLineupByLineupId(Long lineupId, Long festivalId) {
+        Lineup lineup = getLineupById(lineupId);
+        validateLineupBelongsToFestival(lineup, festivalId);
+
         lineupJpaRepository.deleteById(lineupId);
     }
 
@@ -57,5 +62,11 @@ public class LineupService {
     private Lineup getLineupById(Long lineupId) {
         return lineupJpaRepository.findById(lineupId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 라인업입니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private void validateLineupBelongsToFestival(Lineup lineup, Long festivalId) {
+        if (!lineup.isFestivalIdEqualTo(festivalId)) {
+            throw new BusinessException("해당 축제의 라인업이 아닙니다.", HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/lineup/service/LineupService.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/service/LineupService.java
@@ -39,7 +39,7 @@ public class LineupService {
     }
 
     @Transactional
-    public LineupResponse updateLineup(Long lineupId, Long festivalId, LineupUpdateRequest request) {
+    public LineupResponse updateLineup(Long festivalId, Long lineupId, LineupUpdateRequest request) {
         Lineup lineup = getLineupById(lineupId);
         validateLineupBelongsToFestival(lineup, festivalId);
 
@@ -47,7 +47,7 @@ public class LineupService {
         return LineupResponse.from(lineup);
     }
 
-    public void deleteLineupByLineupId(Long lineupId, Long festivalId) {
+    public void deleteLineupByLineupId(Long festivalId, Long lineupId) {
         Lineup lineup = getLineupById(lineupId);
         validateLineupBelongsToFestival(lineup, festivalId);
 

--- a/backend/src/test/java/com/daedan/festabook/lineup/controller/LineupControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/controller/LineupControllerTest.java
@@ -81,7 +81,6 @@ class LineupControllerTest {
             RestAssured
                     .given()
                     .header(header)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -105,8 +104,6 @@ class LineupControllerTest {
             Festival festival = FestivalFixture.create();
             festivalJpaRepository.save(festival);
 
-            Header header = jwtTestHelper.createAuthorizationHeader(festival);
-
             LocalDateTime dateTime1 = LocalDateTime.of(2025, 5, 20, 20, 0);
             LocalDateTime dateTime2 = LocalDateTime.of(2025, 5, 19, 20, 0);
             LocalDateTime dateTime3 = LocalDateTime.of(2025, 5, 18, 20, 0);
@@ -122,7 +119,6 @@ class LineupControllerTest {
             // when & then
             RestAssured
                     .given()
-                    .header(header)
                     .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .when()
                     .get("/lineups")
@@ -166,7 +162,6 @@ class LineupControllerTest {
             RestAssured
                     .given()
                     .header(header)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -206,26 +201,6 @@ class LineupControllerTest {
 
             // 실제 삭제 확인
             assertThat(lineupJpaRepository.findById(lineup.getId())).isEmpty();
-        }
-
-        @Test
-        void 성공_존재하지_않는_라인업() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header header = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long invalidLineupId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(header)
-                    .when()
-                    .delete("/lineups/{lineupId}", invalidLineupId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
@@ -29,6 +29,20 @@ public class LineupFixture {
     }
 
     public static Lineup create(
+            Long lineupId,
+            Festival festival
+    ) {
+        Lineup lineup = new Lineup(
+                festival,
+                DEFAULT_LINEUP_NAME,
+                DEFAULT_IMAGE_URL,
+                DEFAULT_PERFORM_AT
+        );
+        BaseEntityTestHelper.setId(lineup, lineupId);
+        return lineup;
+    }
+
+    public static Lineup create(
             Festival festival
     ) {
         return new Lineup(

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
@@ -4,9 +4,6 @@ import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.global.fixture.BaseEntityTestHelper;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class LineupFixture {
 
@@ -14,19 +11,6 @@ public class LineupFixture {
     private static final String DEFAULT_LINEUP_NAME = "이미소";
     private static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
     private static final LocalDateTime DEFAULT_PERFORM_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
-
-    public static Lineup create(
-            Long lineupId
-    ) {
-        Lineup lineup = new Lineup(
-                DEFAULT_FESTIVAL,
-                DEFAULT_LINEUP_NAME,
-                DEFAULT_IMAGE_URL,
-                DEFAULT_PERFORM_AT
-        );
-        BaseEntityTestHelper.setId(lineup, lineupId);
-        return lineup;
-    }
 
     public static Lineup create(
             Long lineupId,
@@ -50,18 +34,6 @@ public class LineupFixture {
                 DEFAULT_LINEUP_NAME,
                 DEFAULT_IMAGE_URL,
                 DEFAULT_PERFORM_AT
-        );
-    }
-
-    public static Lineup create(
-            Festival festival,
-            LocalDateTime dateTime
-    ) {
-        return new Lineup(
-                festival,
-                DEFAULT_LINEUP_NAME,
-                DEFAULT_IMAGE_URL,
-                dateTime
         );
     }
 
@@ -93,11 +65,5 @@ public class LineupFixture {
         );
         BaseEntityTestHelper.setId(lineup, lineupId);
         return lineup;
-    }
-
-    public static List<Lineup> createList(int size, Festival festival) {
-        return IntStream.range(0, size)
-                .mapToObj(i -> LineupFixture.create(festival))
-                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
@@ -1,13 +1,11 @@
 package com.daedan.festabook.lineup.domain;
 
 import com.daedan.festabook.festival.domain.Festival;
-import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.global.fixture.BaseEntityTestHelper;
 import java.time.LocalDateTime;
 
 public class LineupFixture {
 
-    private static final Festival DEFAULT_FESTIVAL = FestivalFixture.create();
     private static final String DEFAULT_LINEUP_NAME = "이미소";
     private static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
     private static final LocalDateTime DEFAULT_PERFORM_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupTest.java
@@ -1,6 +1,6 @@
 package com.daedan.festabook.lineup.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.daedan.festabook.festival.domain.Festival;

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupTest.java
@@ -1,5 +1,6 @@
 package com.daedan.festabook.lineup.domain;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.daedan.festabook.festival.domain.Festival;
@@ -39,6 +40,39 @@ class LineupTest {
                 s.assertThat(lineup.getImageUrl()).isEqualTo(updatedImageUrl);
                 s.assertThat(lineup.getPerformanceAt()).isEqualTo(updatedPerformanceAt);
             });
+        }
+    }
+
+    @Nested
+    class isFestivalIdEqualTo {
+
+        @Test
+        void 같은_축제의_id이면_true() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Lineup lineup = LineupFixture.create(festival);
+
+            // when
+            boolean result = lineup.isFestivalIdEqualTo(festivalId);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 다른_축제의_id이면_false() {
+            // given
+            Long festivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Lineup lineup = LineupFixture.create(festival);
+
+            // when
+            boolean result = lineup.isFestivalIdEqualTo(otherFestivalId);
+
+            // then
+            assertThat(result).isFalse();
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lineup/service/LineupServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/service/LineupServiceTest.java
@@ -140,7 +140,7 @@ class LineupServiceTest {
                     .willReturn(Optional.of(lineup));
 
             // when
-            LineupResponse result = lineupService.updateLineup(lineupId, festivalId, request);
+            LineupResponse result = lineupService.updateLineup(festivalId, lineupId, request);
 
             // then
             assertSoftly(s -> {
@@ -162,7 +162,7 @@ class LineupServiceTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> lineupService.updateLineup(invalidLineupId, festivalId, request))
+            assertThatThrownBy(() -> lineupService.updateLineup(festivalId, invalidLineupId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 라인업입니다.");
         }
@@ -182,7 +182,7 @@ class LineupServiceTest {
             LineupUpdateRequest request = LineupUpdateRequestFixture.create();
 
             // when & then
-            assertThatThrownBy(() -> lineupService.updateLineup(lineup.getId(), otherFestival.getId(), request))
+            assertThatThrownBy(() -> lineupService.updateLineup(otherFestival.getId(), lineup.getId(), request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 라인업이 아닙니다.");
         }
@@ -203,7 +203,7 @@ class LineupServiceTest {
                     .willReturn(Optional.of(lineup));
 
             // when
-            lineupService.deleteLineupByLineupId(lineupId, festival.getId());
+            lineupService.deleteLineupByLineupId(festival.getId(), lineupId);
 
             // then
             then(lineupJpaRepository).should()
@@ -223,7 +223,7 @@ class LineupServiceTest {
                     .willReturn(Optional.of(lineup));
 
             // when & then
-            assertThatThrownBy(() -> lineupService.deleteLineupByLineupId(lineup.getId(), otherFestival.getId()))
+            assertThatThrownBy(() -> lineupService.deleteLineupByLineupId(otherFestival.getId(), lineup.getId()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 라인업이 아닙니다.");
         }

--- a/backend/src/test/java/com/daedan/festabook/lineup/service/LineupServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/service/LineupServiceTest.java
@@ -1,7 +1,7 @@
 package com.daedan.festabook.lineup.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
## #️⃣ 이슈 번호

#680

<br>

## 🛠️ 작업 내용

- Lineup 인가 처리 
- 헤더에 실린 토큰의 festival 소유의 라인업이 아니라면 리소스의 CUD를 하지 못하도록 변경했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

<br>

## 📸 이미지 첨부 (Optional)
<img width="1732" height="572" alt="image" src="https://github.com/user-attachments/assets/54cbb5c9-3959-4234-969e-c907c36e9337" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 로그인한 계정으로 축제를 자동 식별하여 라인업 추가/수정/삭제 시 별도의 축제 ID 전달이 필요 없습니다.
* Bug Fixes
  * 다른 축제의 라인업을 수정·삭제하려는 시도가 차단되며, 권한 없음 오류가 명확히 안내됩니다.
* Documentation
  * API 문서에 보안 요구사항이 표시되었고, 공개 태그명이 ‘라인업’으로 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->