### PR TITLE
[BE] Question 인가 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/daedan/festabook/question/controller/QuestionController.java
@@ -72,7 +72,7 @@ public class QuestionController {
             @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody QuestionRequest request
     ) {
-        return questionService.updateQuestionAndAnswer(questionId, councilDetails.getFestivalId(), request);
+        return questionService.updateQuestionAndAnswer(councilDetails.getFestivalId(), questionId, request);
     }
 
     @PatchMapping("/sequences")
@@ -98,6 +98,6 @@ public class QuestionController {
             @PathVariable Long questionId,
             @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        questionService.deleteQuestionByQuestionId(questionId, councilDetails.getFestivalId());
+        questionService.deleteQuestionByQuestionId(councilDetails.getFestivalId(), questionId);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/daedan/festabook/question/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.question.controller;
 
 import com.daedan.festabook.global.argumentresolver.FestivalId;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import com.daedan.festabook.question.dto.QuestionRequest;
 import com.daedan.festabook.question.dto.QuestionResponse;
 import com.daedan.festabook.question.dto.QuestionResponses;
@@ -11,10 +12,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -40,15 +43,15 @@ public class QuestionController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
     public QuestionResponse createQuestion(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody QuestionRequest request
     ) {
-        return questionService.createQuestion(festivalId, request);
+        return questionService.createQuestion(councilDetails.getFestivalId(), request);
     }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 모든 FAQ 조회")
+    @Operation(summary = "특정 축제의 모든 FAQ 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -66,9 +69,10 @@ public class QuestionController {
     })
     public QuestionResponse updateQuestionAndAnswer(
             @PathVariable Long questionId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody QuestionRequest request
     ) {
-        return questionService.updateQuestionAndAnswer(questionId, request);
+        return questionService.updateQuestionAndAnswer(questionId, councilDetails.getFestivalId(), request);
     }
 
     @PatchMapping("/sequences")
@@ -78,9 +82,10 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
     public QuestionSequenceUpdateResponses updateSequence(
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody List<QuestionSequenceUpdateRequest> requests
     ) {
-        return questionService.updateSequence(requests);
+        return questionService.updateSequence(councilDetails.getFestivalId(), requests);
     }
 
     @DeleteMapping("/{questionId}")
@@ -90,8 +95,9 @@ public class QuestionController {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })
     public void deleteQuestionByQuestionId(
-            @PathVariable Long questionId
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        questionService.deleteQuestionByQuestionId(questionId);
+        questionService.deleteQuestionByQuestionId(questionId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/question/domain/Question.java
+++ b/backend/src/main/java/com/daedan/festabook/question/domain/Question.java
@@ -72,6 +72,10 @@ public class Question extends BaseEntity implements Comparable<Question> {
         this.sequence = sequence;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.getFestival().getId().equals(festivalId);
+    }
+
     @Override
     public int compareTo(Question otherQuestion) {
         return sequence.compareTo(otherQuestion.sequence);

--- a/backend/src/main/java/com/daedan/festabook/question/service/QuestionService.java
+++ b/backend/src/main/java/com/daedan/festabook/question/service/QuestionService.java
@@ -54,8 +54,10 @@ public class QuestionService {
     }
 
     @Transactional
-    public QuestionSequenceUpdateResponses updateSequence(Long festivalId,
-                                                          List<QuestionSequenceUpdateRequest> requests) {
+    public QuestionSequenceUpdateResponses updateSequence(
+            Long festivalId,
+            List<QuestionSequenceUpdateRequest> requests
+    ) {
         List<Question> questions = new ArrayList<>();
 
         for (QuestionSequenceUpdateRequest request : requests) {

--- a/backend/src/main/java/com/daedan/festabook/question/service/QuestionService.java
+++ b/backend/src/main/java/com/daedan/festabook/question/service/QuestionService.java
@@ -45,7 +45,7 @@ public class QuestionService {
     }
 
     @Transactional
-    public QuestionResponse updateQuestionAndAnswer(Long questionId, Long festivalId, QuestionRequest request) {
+    public QuestionResponse updateQuestionAndAnswer(Long festivalId, Long questionId, QuestionRequest request) {
         Question question = getQuestionById(questionId);
         validateLineupBelongsToFestival(question, festivalId);
 
@@ -72,7 +72,7 @@ public class QuestionService {
         return QuestionSequenceUpdateResponses.from(questions);
     }
 
-    public void deleteQuestionByQuestionId(Long questionId, Long festivalId) {
+    public void deleteQuestionByQuestionId(Long festivalId, Long questionId) {
         Question question = getQuestionById(questionId);
         validateLineupBelongsToFestival(question, festivalId);
 

--- a/backend/src/main/java/com/daedan/festabook/question/service/QuestionService.java
+++ b/backend/src/main/java/com/daedan/festabook/question/service/QuestionService.java
@@ -47,7 +47,7 @@ public class QuestionService {
     @Transactional
     public QuestionResponse updateQuestionAndAnswer(Long festivalId, Long questionId, QuestionRequest request) {
         Question question = getQuestionById(questionId);
-        validateLineupBelongsToFestival(question, festivalId);
+        validateQuestionBelongsToFestival(question, festivalId);
 
         question.updateQuestionAndAnswer(request.question(), request.answer());
         return QuestionResponse.from(question);
@@ -62,7 +62,7 @@ public class QuestionService {
 
         for (QuestionSequenceUpdateRequest request : requests) {
             Question question = getQuestionById(request.questionId());
-            validateLineupBelongsToFestival(question, festivalId);
+            validateQuestionBelongsToFestival(question, festivalId);
             question.updateSequence(request.sequence());
             questions.add(question);
         }
@@ -74,7 +74,7 @@ public class QuestionService {
 
     public void deleteQuestionByQuestionId(Long festivalId, Long questionId) {
         Question question = getQuestionById(questionId);
-        validateLineupBelongsToFestival(question, festivalId);
+        validateQuestionBelongsToFestival(question, festivalId);
 
         questionJpaRepository.deleteById(questionId);
     }
@@ -89,7 +89,7 @@ public class QuestionService {
                 .orElseThrow(() -> new BusinessException("존재하지 않는 축제입니다.", HttpStatus.BAD_REQUEST));
     }
 
-    private void validateLineupBelongsToFestival(Question question, Long festivalId) {
+    private void validateQuestionBelongsToFestival(Question question, Long festivalId) {
         if (!question.isFestivalIdEqualTo(festivalId)) {
             throw new BusinessException("해당 축제의 질문이 아닙니다.", HttpStatus.FORBIDDEN);
         }

--- a/backend/src/test/java/com/daedan/festabook/question/controller/QuestionControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/controller/QuestionControllerTest.java
@@ -82,7 +82,6 @@ class QuestionControllerTest {
             RestAssured
                     .given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -279,28 +278,6 @@ class QuestionControllerTest {
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
             assertThat(questionJpaRepository.findById(question.getId())).isEmpty();
-        }
-
-        @Test
-        void 성공_없는_리소스_삭제() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long invalidQuestionId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .when()
-                    .delete("/questions/{questionId}", invalidQuestionId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
-
-            assertThat(questionJpaRepository.findById(invalidQuestionId)).isEmpty();
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/question/controller/QuestionControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/controller/QuestionControllerTest.java
@@ -1,6 +1,6 @@
 package com.daedan.festabook.question.controller;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 

--- a/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
@@ -66,6 +66,26 @@ public class QuestionFixture {
         );
     }
 
+    public static Question create(
+            Integer sequence
+    ) {
+        return new Question(
+                DEFAULT_FESTIVAL,
+                DEFAULT_QUESTION,
+                DEFAULT_ANSWER,
+                sequence
+        );
+    }
+
+    public static Question create() {
+        return new Question(
+                DEFAULT_FESTIVAL,
+                DEFAULT_QUESTION,
+                DEFAULT_ANSWER,
+                DEFAULT_SEQUENCE
+        );
+    }
+
     public static Question createWithQuestion(
             String question
     ) {
@@ -84,26 +104,6 @@ public class QuestionFixture {
                 DEFAULT_FESTIVAL,
                 DEFAULT_QUESTION,
                 answer,
-                DEFAULT_SEQUENCE
-        );
-    }
-
-    public static Question create(
-            Integer sequence
-    ) {
-        return new Question(
-                DEFAULT_FESTIVAL,
-                DEFAULT_QUESTION,
-                DEFAULT_ANSWER,
-                sequence
-        );
-    }
-
-    public static Question create() {
-        return new Question(
-                DEFAULT_FESTIVAL,
-                DEFAULT_QUESTION,
-                DEFAULT_ANSWER,
                 DEFAULT_SEQUENCE
         );
     }

--- a/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
@@ -15,24 +15,10 @@ public class QuestionFixture {
     private static final Integer DEFAULT_SEQUENCE = 3;
 
     public static Question create(
-            Festival festival,
-            String question,
-            String answer,
-            Integer sequence
+            Festival festival
     ) {
         return new Question(
                 festival,
-                question,
-                answer,
-                sequence
-        );
-    }
-
-    public static Question create(
-            Festival festival
-    ) {
-        return create(
-                festival,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
                 DEFAULT_SEQUENCE
@@ -43,7 +29,7 @@ public class QuestionFixture {
             Long questionId,
             Festival festival
     ) {
-        Question question = create(
+        Question question = new Question(
                 festival,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
@@ -58,7 +44,7 @@ public class QuestionFixture {
             Festival festival,
             Integer sequence
     ) {
-        Question question = create(
+        Question question = new Question(
                 festival,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
@@ -72,7 +58,7 @@ public class QuestionFixture {
             Festival festival,
             Integer sequence
     ) {
-        return create(
+        return new Question(
                 festival,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
@@ -83,7 +69,7 @@ public class QuestionFixture {
     public static Question createWithQuestion(
             String question
     ) {
-        return create(
+        return new Question(
                 DEFAULT_FESTIVAL,
                 question,
                 DEFAULT_ANSWER,
@@ -94,7 +80,7 @@ public class QuestionFixture {
     public static Question createWithAnswer(
             String answer
     ) {
-        return create(
+        return new Question(
                 DEFAULT_FESTIVAL,
                 DEFAULT_QUESTION,
                 answer,
@@ -103,22 +89,9 @@ public class QuestionFixture {
     }
 
     public static Question create(
-            String question,
-            String answer,
             Integer sequence
     ) {
-        return create(
-                DEFAULT_FESTIVAL,
-                question,
-                answer,
-                sequence
-        );
-    }
-
-    public static Question create(
-            Integer sequence
-    ) {
-        return create(
+        return new Question(
                 DEFAULT_FESTIVAL,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
@@ -127,37 +100,12 @@ public class QuestionFixture {
     }
 
     public static Question create() {
-        return create(
+        return new Question(
                 DEFAULT_FESTIVAL,
                 DEFAULT_QUESTION,
                 DEFAULT_ANSWER,
                 DEFAULT_SEQUENCE
         );
-    }
-
-    public static Question create(
-            Long questionId
-    ) {
-        Question question = new Question(
-                DEFAULT_FESTIVAL,
-                DEFAULT_QUESTION,
-                DEFAULT_ANSWER,
-                DEFAULT_SEQUENCE
-        );
-        return BaseEntityTestHelper.setId(question, questionId);
-    }
-
-    public static Question create(
-            Long questionId,
-            Integer sequence
-    ) {
-        Question question = new Question(
-                DEFAULT_FESTIVAL,
-                DEFAULT_QUESTION,
-                DEFAULT_ANSWER,
-                sequence
-        );
-        return BaseEntityTestHelper.setId(question, questionId);
     }
 
     public static List<Question> createList(int size, Festival festival) {

--- a/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/question/domain/QuestionFixture.java
@@ -40,6 +40,35 @@ public class QuestionFixture {
     }
 
     public static Question create(
+            Long questionId,
+            Festival festival
+    ) {
+        Question question = create(
+                festival,
+                DEFAULT_QUESTION,
+                DEFAULT_ANSWER,
+                DEFAULT_SEQUENCE
+        );
+        BaseEntityTestHelper.setId(question, questionId);
+        return question;
+    }
+
+    public static Question create(
+            Long questionId,
+            Festival festival,
+            Integer sequence
+    ) {
+        Question question = create(
+                festival,
+                DEFAULT_QUESTION,
+                DEFAULT_ANSWER,
+                sequence
+        );
+        BaseEntityTestHelper.setId(question, questionId);
+        return question;
+    }
+
+    public static Question create(
             Festival festival,
             Integer sequence
     ) {

--- a/backend/src/test/java/com/daedan/festabook/question/domain/QuestionTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/domain/QuestionTest.java
@@ -1,11 +1,12 @@
 package com.daedan.festabook.question.domain;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import com.daedan.festabook.global.exception.BusinessException;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -134,6 +135,39 @@ class QuestionTest {
             assertThatThrownBy(() -> QuestionFixture.createWithAnswer(answer))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("답변은 1000자를 초과할 수 없습니다.");
+        }
+    }
+
+    @Nested
+    class isFestivalIdEqualTo {
+
+        @Test
+        void 같은_축제의_id이면_true() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Question question = QuestionFixture.create(festival);
+
+            // when
+            boolean result = question.isFestivalIdEqualTo(festivalId);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 다른_축제의_id이면_false() {
+            // given
+            Long festivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Question question = QuestionFixture.create(festival);
+
+            // when
+            boolean result = question.isFestivalIdEqualTo(otherFestivalId);
+
+            // then
+            assertThat(result).isFalse();
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/question/domain/QuestionTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/domain/QuestionTest.java
@@ -1,8 +1,8 @@
 package com.daedan.festabook.question.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;

--- a/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
@@ -103,8 +103,7 @@ class QuestionServiceTest {
                     .willReturn(questions);
 
             // when
-            QuestionResponses questionResponses = questionService.getAllQuestionByFestivalId(
-                    festivalId);
+            QuestionResponses questionResponses = questionService.getAllQuestionByFestivalId(festivalId);
 
             // then
             int result = questionResponses.responses().size();
@@ -152,7 +151,7 @@ class QuestionServiceTest {
             );
 
             // when
-            QuestionResponse result = questionService.updateQuestionAndAnswer(questionId, festivalId, request);
+            QuestionResponse result = questionService.updateQuestionAndAnswer(festivalId, questionId, request);
 
             // then
             assertSoftly(s -> {
@@ -169,7 +168,7 @@ class QuestionServiceTest {
             QuestionRequest request = QuestionRequestFixture.create();
 
             // when & then
-            assertThatThrownBy(() -> questionService.updateQuestionAndAnswer(invalidQuestionId, festivalId, request))
+            assertThatThrownBy(() -> questionService.updateQuestionAndAnswer(festivalId, invalidQuestionId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 질문입니다.");
         }
@@ -190,7 +189,7 @@ class QuestionServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    questionService.updateQuestionAndAnswer(question.getId(), otherFestival.getId(), request)
+                    questionService.updateQuestionAndAnswer(otherFestival.getId(), question.getId(), request)
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 질문이 아닙니다.");
@@ -291,7 +290,7 @@ class QuestionServiceTest {
                     .willReturn(Optional.of(question));
 
             // when
-            questionService.deleteQuestionByQuestionId(question.getId(), festival.getId());
+            questionService.deleteQuestionByQuestionId(festival.getId(), question.getId());
 
             // then
             then(questionJpaRepository).should()
@@ -312,7 +311,7 @@ class QuestionServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    questionService.deleteQuestionByQuestionId(question.getId(), otherFestival.getId())
+                    questionService.deleteQuestionByQuestionId(otherFestival.getId(), question.getId())
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 질문이 아닙니다.");

--- a/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
@@ -137,7 +137,9 @@ class QuestionServiceTest {
         void 성공() {
             // given
             Long questionId = 1L;
-            Question question = QuestionFixture.create(questionId);
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Question question = QuestionFixture.create(questionId, festival);
 
             given(questionJpaRepository.findById(questionId))
                     .willReturn(Optional.of(question));
@@ -148,7 +150,7 @@ class QuestionServiceTest {
             );
 
             // when
-            QuestionResponse result = questionService.updateQuestionAndAnswer(questionId, request);
+            QuestionResponse result = questionService.updateQuestionAndAnswer(questionId, festivalId, request);
 
             // then
             assertSoftly(s -> {
@@ -160,13 +162,36 @@ class QuestionServiceTest {
         @Test
         void 예외_존재하지_않는_질문() {
             // given
+            Long festivalId = 1L;
             Long invalidQuestionId = 0L;
             QuestionRequest request = QuestionRequestFixture.create();
 
             // when & then
-            assertThatThrownBy(() -> questionService.updateQuestionAndAnswer(invalidQuestionId, request))
+            assertThatThrownBy(() -> questionService.updateQuestionAndAnswer(invalidQuestionId, festivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 질문입니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_질문일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            Question question = QuestionFixture.create(requestFestival);
+
+            given(questionJpaRepository.findById(question.getId()))
+                    .willReturn(Optional.of(question));
+
+            QuestionRequest request = QuestionRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(
+                    () -> questionService.updateQuestionAndAnswer(question.getId(), otherFestival.getId(), request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 질문이 아닙니다.");
         }
     }
 
@@ -176,13 +201,16 @@ class QuestionServiceTest {
         @Test
         void 성공_수정_후에도_오름차순으로_재정렬() {
             // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+
             Long question1Id = 1L;
             Long question2Id = 2L;
             Long question3Id = 3L;
 
-            Question question1 = QuestionFixture.create(question1Id, 1);
-            Question question2 = QuestionFixture.create(question2Id, 2);
-            Question question3 = QuestionFixture.create(question3Id, 3);
+            Question question1 = QuestionFixture.create(question1Id, festival, 1);
+            Question question2 = QuestionFixture.create(question2Id, festival, 2);
+            Question question3 = QuestionFixture.create(question3Id, festival, 3);
 
             given(questionJpaRepository.findById(question1Id))
                     .willReturn(Optional.of(question1));
@@ -197,7 +225,7 @@ class QuestionServiceTest {
             List<QuestionSequenceUpdateRequest> requests = List.of(request1, request2, request3);
 
             // when
-            QuestionSequenceUpdateResponses result = questionService.updateSequence(requests);
+            QuestionSequenceUpdateResponses result = questionService.updateSequence(festival.getId(), requests);
 
             // then
             assertSoftly(s -> {
@@ -215,12 +243,34 @@ class QuestionServiceTest {
         @Test
         void 예외_존재하지_않는_질문() {
             // given
+            Long festivalId = 1L;
             List<QuestionSequenceUpdateRequest> requests = QuestionSequenceUpdateRequestFixture.createList(3);
 
             // when & then
-            assertThatThrownBy(() -> questionService.updateSequence(requests))
+            assertThatThrownBy(() -> questionService.updateSequence(festivalId, requests))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 질문입니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_질문일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Long questionId = 1L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            Question question = QuestionFixture.create(questionId, requestFestival);
+
+            given(questionJpaRepository.findById(question.getId()))
+                    .willReturn(Optional.of(question));
+
+            List<QuestionSequenceUpdateRequest> requests = QuestionSequenceUpdateRequestFixture.createList(3);
+
+            // when & then
+            assertThatThrownBy(() -> questionService.updateSequence(otherFestival.getId(), requests))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 질문이 아닙니다.");
         }
     }
 
@@ -230,14 +280,40 @@ class QuestionServiceTest {
         @Test
         void 성공() {
             // given
+            Long festivalId = 1L;
             Long questionId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            Question question = QuestionFixture.create(questionId, festival);
+
+            given(questionJpaRepository.findById(questionId))
+                    .willReturn(Optional.of(question));
 
             // when
-            questionService.deleteQuestionByQuestionId(questionId);
+            questionService.deleteQuestionByQuestionId(question.getId(), festival.getId());
 
             // then
             then(questionJpaRepository).should()
                     .deleteById(questionId);
+        }
+
+        @Test
+        void 예외_다른_축제의_질문일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            Question question = QuestionFixture.create(requestFestival);
+
+            given(questionJpaRepository.findById(question.getId()))
+                    .willReturn(Optional.of(question));
+
+            // when & then
+            assertThatThrownBy(
+                    () -> questionService.deleteQuestionByQuestionId(question.getId(), otherFestival.getId())
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 질문이 아닙니다.");
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
@@ -189,8 +189,8 @@ class QuestionServiceTest {
             QuestionRequest request = QuestionRequestFixture.create();
 
             // when & then
-            assertThatThrownBy(
-                    () -> questionService.updateQuestionAndAnswer(question.getId(), otherFestival.getId(), request)
+            assertThatThrownBy(() ->
+                    questionService.updateQuestionAndAnswer(question.getId(), otherFestival.getId(), request)
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 질문이 아닙니다.");
@@ -311,8 +311,8 @@ class QuestionServiceTest {
                     .willReturn(Optional.of(question));
 
             // when & then
-            assertThatThrownBy(
-                    () -> questionService.deleteQuestionByQuestionId(question.getId(), otherFestival.getId())
+            assertThatThrownBy(() ->
+                    questionService.deleteQuestionByQuestionId(question.getId(), otherFestival.getId())
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 축제의 질문이 아닙니다.");

--- a/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/question/service/QuestionServiceTest.java
@@ -125,8 +125,10 @@ class QuestionServiceTest {
             QuestionResponses result = questionService.getAllQuestionByFestivalId(festivalId);
 
             // then
-            assertThat(result.responses().getFirst().sequence()).isEqualTo(question1.getSequence());
-            assertThat(result.responses().getLast().sequence()).isEqualTo(question2.getSequence());
+            assertSoftly(s -> {
+                s.assertThat(result.responses().getFirst().sequence()).isEqualTo(question1.getSequence());
+                s.assertThat(result.responses().getLast().sequence()).isEqualTo(question2.getSequence());
+            });
         }
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#676

<br>

## 🛠️ 작업 내용

- Question 인가 처리
- 헤더에 실린 토큰의 festival 소유의 질문이 아니라면 리소스의 CUD를 하지 못하도록 변경했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

<br>

## 📸 이미지 첨부 (Optional)

<img width="1742" height="664" alt="image" src="https://github.com/user-attachments/assets/bfc7230d-0783-4157-9660-8b9641fe2350" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 기능
  - 로그인된 권한(CouncilDetails)을 통해 축제 컨텍스트가 자동 적용되어 별도 축제 식별자 없이 질문 생성/수정/순서변경/삭제가 가능합니다.
  - 질문 도메인에 축제 ID 비교용 헬퍼(isFestivalIdEqualTo)를 추가했습니다.

- 버그 수정
  - 질문이 해당 축제에 속하는지 검증을 추가해 다른 축제의 질문을 수정·삭제하거나 순서 변경할 수 없도록 차단합니다.

- 문서
  - 질문 목록 조회 API의 보안 요구사항 표기를 업데이트했습니다.

- 테스트
  - 단위·통합 테스트와 테스트 팩토리(QuestionFixture)를 정리·보강하고 축제 범위 검증 시나리오를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->