### PR TITLE
[BE] LostItem 인가 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/lostitem/controller/LostItemController.java
+++ b/backend/src/main/java/com/daedan/festabook/lostitem/controller/LostItemController.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.lostitem.controller;
 
 import com.daedan.festabook.global.argumentresolver.FestivalId;
+import com.daedan.festabook.global.security.council.CouncilDetails;
 import com.daedan.festabook.lostitem.dto.LostItemRequest;
 import com.daedan.festabook.lostitem.dto.LostItemResponse;
 import com.daedan.festabook.lostitem.dto.LostItemResponses;
@@ -12,9 +13,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -40,15 +43,15 @@ class LostItemController {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
     public LostItemResponse createLostItem(
-            @Parameter(hidden = true) @FestivalId Long festivalId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody LostItemRequest request
     ) {
-        return lostItemService.createLostItem(festivalId, request);
+        return lostItemService.createLostItem(councilDetails.getFestivalId(), request);
     }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 모든 분실물 조회")
+    @Operation(summary = "특정 축제의 모든 분실물 조회", security = @SecurityRequirement(name = "none"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -66,9 +69,10 @@ class LostItemController {
     })
     public LostItemUpdateResponse updateLostItem(
             @PathVariable Long lostItemId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody LostItemRequest request
     ) {
-        return lostItemService.updateLostItem(lostItemId, request);
+        return lostItemService.updateLostItem(lostItemId, councilDetails.getFestivalId(), request);
     }
 
     @PatchMapping("/{lostItemId}/status")
@@ -79,9 +83,10 @@ class LostItemController {
     })
     public LostItemStatusUpdateResponse updateLostItemStatus(
             @PathVariable Long lostItemId,
+            @AuthenticationPrincipal CouncilDetails councilDetails,
             @RequestBody LostItemStatusUpdateRequest request
     ) {
-        return lostItemService.updateLostItemStatus(lostItemId, request);
+        return lostItemService.updateLostItemStatus(lostItemId, councilDetails.getFestivalId(), request);
     }
 
     @DeleteMapping("/{lostItemId}")
@@ -91,8 +96,9 @@ class LostItemController {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })
     public void deleteLostItemByLostItemId(
-            @PathVariable Long lostItemId
+            @PathVariable Long lostItemId,
+            @AuthenticationPrincipal CouncilDetails councilDetails
     ) {
-        lostItemService.deleteLostItemByLostItemId(lostItemId);
+        lostItemService.deleteLostItemByLostItemId(lostItemId, councilDetails.getFestivalId());
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/lostitem/domain/LostItem.java
+++ b/backend/src/main/java/com/daedan/festabook/lostitem/domain/LostItem.java
@@ -79,6 +79,10 @@ public class LostItem extends BaseEntity {
         this.status = status;
     }
 
+    public boolean isFestivalIdEqualTo(Long festivalId) {
+        return this.getFestival().getId().equals(festivalId);
+    }
+
     private void validateImageUrl(String imageUrl) {
         if (!StringUtils.hasText(imageUrl)) {
             throw new BusinessException("이미지 URL은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/daedan/festabook/lostitem/service/LostItemService.java
+++ b/backend/src/main/java/com/daedan/festabook/lostitem/service/LostItemService.java
@@ -39,20 +39,28 @@ public class LostItemService {
     }
 
     @Transactional
-    public LostItemUpdateResponse updateLostItem(Long lostItemId, LostItemRequest request) {
+    public LostItemUpdateResponse updateLostItem(Long lostItemId, Long festivalId, LostItemRequest request) {
         LostItem lostItem = getLostItemById(lostItemId);
+        validateLostItemBelongsToFestival(lostItem, festivalId);
+
         lostItem.updateLostItem(request.imageUrl(), request.storageLocation());
         return LostItemUpdateResponse.from(lostItem);
     }
 
     @Transactional
-    public LostItemStatusUpdateResponse updateLostItemStatus(Long lostItemId, LostItemStatusUpdateRequest request) {
+    public LostItemStatusUpdateResponse updateLostItemStatus(Long lostItemId, Long festivalId,
+                                                             LostItemStatusUpdateRequest request) {
         LostItem lostItem = getLostItemById(lostItemId);
+        validateLostItemBelongsToFestival(lostItem, festivalId);
+
         lostItem.updateStatus(request.pickupStatus());
         return LostItemStatusUpdateResponse.from(lostItem);
     }
 
-    public void deleteLostItemByLostItemId(Long lostItemId) {
+    public void deleteLostItemByLostItemId(Long lostItemId, Long festivalId) {
+        LostItem lostItem = getLostItemById(lostItemId);
+        validateLostItemBelongsToFestival(lostItem, festivalId);
+
         lostItemJpaRepository.deleteById(lostItemId);
     }
 
@@ -64,5 +72,11 @@ public class LostItemService {
     private Festival getFestivalById(Long festivalId) {
         return festivalJpaRepository.findById(festivalId)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 축제입니다.", HttpStatus.BAD_REQUEST));
+    }
+
+    private void validateLostItemBelongsToFestival(LostItem lostItem, Long festivalId) {
+        if (!lostItem.isFestivalIdEqualTo(festivalId)) {
+            throw new BusinessException("해당 축제의 분실물이 아닙니다.", HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lostitem/controller/LostItemControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lostitem/controller/LostItemControllerTest.java
@@ -75,7 +75,6 @@ class LostItemControllerTest {
             // when & then
             given()
                     .header(authorizationHeader)
-                    .header(FESTIVAL_HEADER_NAME, festival.getId())
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when()
@@ -261,26 +260,6 @@ class LostItemControllerTest {
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
             assertThat(lostItemJpaRepository.findById(lostItem.getId())).isEmpty();
-        }
-
-        @Test
-        void 성공_존재하지_않는_분실물_삭제() {
-            // given
-            Festival festival = FestivalFixture.create();
-            festivalJpaRepository.save(festival);
-
-            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
-
-            Long notExistId = 0L;
-
-            // when & then
-            RestAssured
-                    .given()
-                    .header(authorizationHeader)
-                    .when()
-                    .delete("/lost-items/{lostItemId}", notExistId)
-                    .then()
-                    .statusCode(HttpStatus.NO_CONTENT.value());
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lostitem/domain/LostItemFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lostitem/domain/LostItemFixture.java
@@ -80,10 +80,25 @@ public class LostItemFixture {
 
     public static LostItem create(
             Long lostItemId,
+            Festival festival
+    ) {
+        LostItem lostItem = new LostItem(
+                festival,
+                DEFAULT_IMAGE_URL,
+                DEFAULT_STORAGE_LOCATION,
+                DEFAULT_PICK_UP_STATUS
+        );
+        BaseEntityTestHelper.setId(lostItem, lostItemId);
+        return BaseEntityTestHelper.setCreatedAt(lostItem, DEFAULT_CREATED_AT);
+    }
+
+    public static LostItem create(
+            Long lostItemId,
+            Festival festival,
             PickupStatus status
     ) {
         LostItem lostItem = new LostItem(
-                DEFAULT_FESTIVAL,
+                festival,
                 DEFAULT_IMAGE_URL,
                 DEFAULT_STORAGE_LOCATION,
                 status
@@ -94,11 +109,12 @@ public class LostItemFixture {
 
     public static LostItem create(
             Long lostItemId,
+            Festival festival,
             String imageUrl,
             String storageLocation
     ) {
         LostItem lostItem = new LostItem(
-                DEFAULT_FESTIVAL,
+                festival,
                 imageUrl,
                 storageLocation,
                 DEFAULT_PICK_UP_STATUS

--- a/backend/src/test/java/com/daedan/festabook/lostitem/domain/LostItemTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lostitem/domain/LostItemTest.java
@@ -2,7 +2,10 @@ package com.daedan.festabook.lostitem.domain;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -132,6 +135,39 @@ class LostItemTest {
             assertThatThrownBy(() -> LostItemFixture.create(status))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("수령 상태는 null일 수 없습니다.");
+        }
+    }
+
+    @Nested
+    class isFestivalIdEqualTo {
+
+        @Test
+        void 같은_축제의_id이면_true() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            LostItem lostItem = LostItemFixture.create(festival);
+
+            // when
+            boolean result = lostItem.isFestivalIdEqualTo(festivalId);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 다른_축제의_id이면_false() {
+            // given
+            Long festivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival festival = FestivalFixture.create(festivalId);
+            LostItem lostItem = LostItemFixture.create(festival);
+
+            // when
+            boolean result = lostItem.isFestivalIdEqualTo(otherFestivalId);
+
+            // then
+            assertThat(result).isFalse();
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lostitem/service/LostItemServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lostitem/service/LostItemServiceTest.java
@@ -120,9 +120,11 @@ class LostItemServiceTest {
         void 성공() {
             // given
             Long lostItemId = 1L;
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
             String previousImageUrl = "https://example.com/previous.jpg";
             String previousStorageLocation = "서울특별시 강남구";
-            LostItem lostItem = LostItemFixture.create(lostItemId, previousImageUrl, previousStorageLocation);
+            LostItem lostItem = LostItemFixture.create(lostItemId, festival, previousImageUrl, previousStorageLocation);
 
             LostItemRequest request = LostItemRequestFixture.create(
                     "https://example.com/change.jpg",
@@ -133,7 +135,7 @@ class LostItemServiceTest {
                     .willReturn(Optional.of(lostItem));
 
             // when
-            LostItemUpdateResponse result = lostItemService.updateLostItem(lostItemId, request);
+            LostItemUpdateResponse result = lostItemService.updateLostItem(lostItemId, festivalId, request);
 
             // then
             assertSoftly(s -> {
@@ -147,15 +149,36 @@ class LostItemServiceTest {
         void 예외_존재하지_않는_분실물_ID() {
             // given
             Long invalidLostItemId = 0L;
+            Long festivalId = 1L;
             LostItemRequest request = LostItemRequestFixture.create();
 
             given(lostItemJpaRepository.findById(invalidLostItemId))
                     .willReturn(Optional.empty());
 
             // then
-            assertThatThrownBy(() -> lostItemService.updateLostItem(invalidLostItemId, request))
+            assertThatThrownBy(() -> lostItemService.updateLostItem(invalidLostItemId, festivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 분실물입니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_분실물일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            LostItem lostItem = LostItemFixture.create(requestFestival);
+
+            given(lostItemJpaRepository.findById(lostItem.getId()))
+                    .willReturn(Optional.of(lostItem));
+
+            LostItemRequest request = LostItemRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(() -> lostItemService.updateLostItem(lostItem.getId(), otherFestival.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 분실물이 아닙니다.");
         }
     }
 
@@ -166,8 +189,10 @@ class LostItemServiceTest {
         void 성공() {
             // given
             Long lostItemId = 1L;
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
             PickupStatus previousStatus = PickupStatus.PENDING;
-            LostItem lostItem = LostItemFixture.create(lostItemId, previousStatus);
+            LostItem lostItem = LostItemFixture.create(lostItemId, festival, previousStatus);
 
             PickupStatus updateStatus = PickupStatus.COMPLETED;
             LostItemStatusUpdateRequest request = LostItemStatusUpdateRequestFixture.create(updateStatus);
@@ -176,7 +201,7 @@ class LostItemServiceTest {
                     .willReturn(Optional.of(lostItem));
 
             // when
-            LostItemStatusUpdateResponse result = lostItemService.updateLostItemStatus(lostItemId, request);
+            LostItemStatusUpdateResponse result = lostItemService.updateLostItemStatus(lostItemId, festivalId, request);
 
             // then
             assertSoftly(s -> {
@@ -189,15 +214,38 @@ class LostItemServiceTest {
         void 예외_존재하지_않는_분실물_ID() {
             // given
             Long invalidLostItemId = 0L;
+            Long festivalId = 1L;
             LostItemStatusUpdateRequest request = LostItemStatusUpdateRequestFixture.create();
 
             given(lostItemJpaRepository.findById(invalidLostItemId))
                     .willReturn(Optional.empty());
 
             // then
-            assertThatThrownBy(() -> lostItemService.updateLostItemStatus(invalidLostItemId, request))
+            assertThatThrownBy(() -> lostItemService.updateLostItemStatus(invalidLostItemId, festivalId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 분실물입니다.");
+        }
+
+        @Test
+        void 예외_다른_축제의_분실물일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            LostItem lostItem = LostItemFixture.create(requestFestival);
+
+            given(lostItemJpaRepository.findById(lostItem.getId()))
+                    .willReturn(Optional.of(lostItem));
+
+            LostItemStatusUpdateRequest request = LostItemStatusUpdateRequestFixture.create();
+
+            // when & then
+            assertThatThrownBy(
+                    () -> lostItemService.updateLostItemStatus(lostItem.getId(), otherFestival.getId(), request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 분실물이 아닙니다.");
         }
     }
 
@@ -208,13 +256,39 @@ class LostItemServiceTest {
         void 성공() {
             // given
             Long lostItemId = 1L;
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+            LostItem lostItem = LostItemFixture.create(lostItemId, festival);
+
+            given(lostItemJpaRepository.findById(lostItemId))
+                    .willReturn(Optional.of(lostItem));
 
             // when
-            lostItemService.deleteLostItemByLostItemId(lostItemId);
+            lostItemService.deleteLostItemByLostItemId(lostItem.getId(), festival.getId());
 
             // then
             then(lostItemJpaRepository).should()
                     .deleteById(lostItemId);
+        }
+
+        @Test
+        void 예외_다른_축제의_분실물일_경우() {
+            // given
+            Long requestFestivalId = 1L;
+            Long otherFestivalId = 999L;
+            Festival requestFestival = FestivalFixture.create(requestFestivalId);
+            Festival otherFestival = FestivalFixture.create(otherFestivalId);
+            LostItem lostItem = LostItemFixture.create(requestFestival);
+
+            given(lostItemJpaRepository.findById(lostItem.getId()))
+                    .willReturn(Optional.of(lostItem));
+
+            // when & then
+            assertThatThrownBy(
+                    () -> lostItemService.deleteLostItemByLostItemId(lostItem.getId(), otherFestival.getId())
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 축제의 분실물이 아닙니다.");
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#673

<br>

## 🛠️ 작업 내용

- LostItem 인가 처리
- 헤더에 실린 토큰의 festival 소유의 분실물이 아니라면 리소스의 CUD를 하지 못하도록 변경했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

<br>

## 📸 이미지 첨부 (Optional)

<img width="1714" height="672" alt="image" src="https://github.com/user-attachments/assets/2100d979-6bb4-4f45-b82a-b0b4480201c4" />
