### PR TITLE
[BE] Swagger 헤더 안 실리는 문제 해결

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/controller/AnnouncementController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -52,7 +51,7 @@ public class AnnouncementController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "모든 공지 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "모든 공지 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventController.java
@@ -10,7 +10,6 @@ import com.daedan.festabook.global.security.council.CouncilDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -48,7 +47,7 @@ public class EventController {
 
     @GetMapping("/{eventDateId}/events")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 일정 날짜의 모든 일정 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 일정 날짜의 모든 일정 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     })

--- a/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
+++ b/backend/src/main/java/com/daedan/festabook/event/controller/EventDateController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -50,7 +49,7 @@ public class EventDateController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 모든 일정 날짜 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 모든 일정 날짜 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     })

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +57,7 @@ public class FestivalController {
 
     @GetMapping("/geography")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 초기 지리 정보 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 초기 지리 정보 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -70,7 +69,7 @@ public class FestivalController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 정보 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 정보 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -82,7 +81,7 @@ public class FestivalController {
 
     @GetMapping("/universities")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "대학 이름으로 축제 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "대학 이름으로 축제 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalNotificationController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalNotificationController.java
@@ -6,7 +6,6 @@ import com.daedan.festabook.festival.service.FestivalNotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,7 +27,7 @@ public class FestivalNotificationController {
 
     @PostMapping("/{festivalId}/notifications")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "특정 축제의 알림 구독 (FCM 토픽 구독)", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 알림 구독 (FCM 토픽 구독)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
@@ -41,7 +40,7 @@ public class FestivalNotificationController {
 
     @DeleteMapping("/notifications/{festivalNotificationId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "특정 축제의 알림 구독 취소 (FCM 토픽 구독 취소)", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 알림 구독 취소 (FCM 토픽 구독 취소)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/controller/LineupController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -49,7 +48,7 @@ public class LineupController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 라인업 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 라인업 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/lostitem/controller/LostItemController.java
+++ b/backend/src/main/java/com/daedan/festabook/lostitem/controller/LostItemController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -51,7 +50,7 @@ class LostItemController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 모든 분실물 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 모든 분실물 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -53,7 +52,7 @@ public class PlaceController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제에 대한 플레이스 전체 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제에 대한 플레이스 전체 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -65,7 +64,7 @@ public class PlaceController {
 
     @GetMapping("/previews")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 랜덤 정렬된 모든 플레이스 프리뷰 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 랜덤 정렬된 모든 플레이스 프리뷰 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })
@@ -77,7 +76,7 @@ public class PlaceController {
 
     @GetMapping("/{placeId}")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 플레이스의 세부 정보와 함께 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 플레이스의 세부 정보와 함께 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceFavoriteController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceFavoriteController.java
@@ -6,7 +6,6 @@ import com.daedan.festabook.place.service.PlaceFavoriteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,7 +27,7 @@ public class PlaceFavoriteController {
 
     @PostMapping("/{placeId}/favorites")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "특정 플레이스의 즐겨찾기 추가", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 플레이스의 즐겨찾기 추가")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
@@ -41,7 +40,7 @@ public class PlaceFavoriteController {
 
     @DeleteMapping("/favorites/{placeFavoriteId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "특정 플레이스의 즐겨찾기 취소", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 플레이스의 즐겨찾기 취소")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/place/controller/PlaceGeographyController.java
+++ b/backend/src/main/java/com/daedan/festabook/place/controller/PlaceGeographyController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,7 +32,7 @@ public class PlaceGeographyController {
 
     @GetMapping("/geographies")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 플레이스 모든 지리 정보 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 플레이스 모든 지리 정보 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/daedan/festabook/question/controller/QuestionController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +50,7 @@ public class QuestionController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "특정 축제의 모든 FAQ 조회", security = @SecurityRequirement(name = "none"))
+    @Operation(summary = "특정 축제의 모든 FAQ 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
     })


### PR DESCRIPTION
## #️⃣ 이슈 번호

#694

<br>

## 🛠️ 작업 내용

- 이전에 해당 방식으로 문서화를 명확히 했는데, 현재는 헤더를 실을 수 있는 방법이 festivalId, token 두 개 라서 해당 방식으로 헤더가 필요없다는 문서화를 진행하기 어렵네요. 롤백했습니다. ㅠㅠ

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - OpenAPI/Swagger 문서에서 공지, 행사/행사일, 축제(지리/대학), 라인업, 분실물, 장소(미리보기/상세), 장소 즐겨찾기, 장소 지리, 문의 등 다수의 엔드포인트에 대한 개별 보안 표기 제거로 보안 표시를 정리했습니다. API 명세의 보안 섹션이 간소화됩니다.
- 잡무
  - 엔드포인트의 동작, 응답, 매개변수/반환 타입에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->