### PR TITLE
[FE] 프론트엔드 CICD 파이프라인를 AWS CodePipeline으로 이전

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -23,8 +23,9 @@ phases:
       - echo "✅ [Build Phase] 빌드 성공"
 
 artifacts:
+  base-directory: frontend/dist
   files:
-    - frontend/dist/**
+    - '**/*'
 
 cache:
   paths:

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -1,0 +1,33 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 20
+    commands:
+      - echo "📦 [Install Phase] 의존성 설치 시작"
+      - cd frontend
+      - npm ci
+      - echo "✅ [Install Phase] 완료"
+
+  pre_build:
+    commands:
+      - echo "⚙️ [Pre Build Phase] 환경 변수 생성"
+      - cd frontend
+      - echo "VITE_API_HOST=https://festabook.app/api" > ./frontend/.env.production
+      - echo "✅ [Pre Build Phase] 완료"
+
+  build:
+    commands:
+      - echo "🚀 [Build Phase] Vite 빌드 시작"
+      - cd frontend
+      - npx vite build
+      - echo "✅ [Build Phase] 빌드 성공"
+
+artifacts:
+  files:
+    - frontend/dist/**
+
+cache:
+  paths:
+    - frontend/node_modules/**/*

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -23,9 +23,9 @@ phases:
       - echo "✅ [Build Phase] 빌드 성공"
 
 artifacts:
-  base-directory: frontend/dist
+  base-directory: frontend
   files:
-    - '**/*'
+    - 'dist/**/*'
 
 cache:
   paths:

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -13,14 +13,12 @@ phases:
   pre_build:
     commands:
       - echo "⚙️ [Pre Build Phase] 환경 변수 생성"
-      - cd frontend
       - echo "VITE_API_HOST=https://festabook.app/api" > ./frontend/.env.production
       - echo "✅ [Pre Build Phase] 완료"
 
   build:
     commands:
       - echo "🚀 [Build Phase] Vite 빌드 시작"
-      - cd frontend
       - npx vite build
       - echo "✅ [Build Phase] 빌드 성공"
 

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -23,9 +23,9 @@ phases:
       - echo "✅ [Build Phase] 빌드 성공"
 
 artifacts:
-  base-directory: frontend
+  base-directory: frontend/dist
   files:
-    - 'dist/**/*'
+    - '**/*'
 
 cache:
   paths:

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -13,7 +13,7 @@ phases:
   pre_build:
     commands:
       - echo "⚙️ [Pre Build Phase] 환경 변수 생성"
-      - echo "VITE_API_HOST=https://festabook.app/api" > ./frontend/.env.production
+      - echo "VITE_API_HOST=https://festabook.app/api" > .env.production
       - echo "✅ [Pre Build Phase] 완료"
 
   build:


### PR DESCRIPTION
## #️⃣ 이슈 번호

#698 

<br>

## 🛠️ 작업 내용

- 프론트엔드 CICD 파이프라인를 AWS CodePipeline으로 이전

- main 브랜치에 트리거가 발생하면 webhook이 aws로 날라감
- 그럼, aws codepipeline이 동작하고 프론트엔드 코드를 빌드하여 S3에 우리 디렉터리에 저장됨

<br>

## 📸 이미지 첨부 (Optional)

<img width="1020" height="313" alt="image" src="https://github.com/user-attachments/assets/59eb8e3e-0dd6-4b57-a128-5a42b2c44950" />

