### PR TITLE
[BE] Device의 모든 축제 알림 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -48,7 +48,7 @@ public class FestivalController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "축제 생성")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })
     public FestivalCreateResponse createFestival(
             @RequestBody FestivalCreateRequest request

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalNotificationController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalNotificationController.java
@@ -1,5 +1,6 @@
 package com.daedan.festabook.festival.controller;
 
+import com.daedan.festabook.festival.dto.FestivalNotificationReadResponses;
 import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
 import com.daedan.festabook.festival.dto.FestivalNotificationResponse;
 import com.daedan.festabook.festival.service.FestivalNotificationService;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +38,18 @@ public class FestivalNotificationController {
             @RequestBody FestivalNotificationRequest request
     ) {
         return festivalNotificationService.subscribeFestivalNotification(festivalId, request);
+    }
+
+    @GetMapping("/notifications/{deviceId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 디바이스의 모든 축제 알림 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public FestivalNotificationReadResponses getAllFestivalNotificationByDeviceId(
+            @PathVariable Long deviceId
+    ) {
+        return festivalNotificationService.getAllFestivalNotificationByDeviceId(deviceId);
     }
 
     @DeleteMapping("/notifications/{festivalNotificationId}")

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalCreateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalCreateRequest.java
@@ -11,7 +11,7 @@ public record FestivalCreateRequest(
         @Schema(description = "학교 이름", example = "서울시립대학교")
         String universityName,
 
-        @Schema(description = "축제 이름", example = "2025 시립 Water Festival\n: AQUA WAVE")
+        @Schema(description = "축제 이름", example = "시립 Water Festival\n: AQUA WAVE")
         String festivalName,
 
         @Schema(description = "시작일", example = "2025-08-23")

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationReadResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationReadResponse.java
@@ -1,0 +1,18 @@
+package com.daedan.festabook.festival.dto;
+
+import com.daedan.festabook.festival.domain.FestivalNotification;
+
+public record FestivalNotificationReadResponse(
+        Long festivalNotificationId,
+        String universityName,
+        String festivalName
+) {
+
+    public static FestivalNotificationReadResponse from(FestivalNotification festivalNotification) {
+        return new FestivalNotificationReadResponse(
+                festivalNotification.getId(),
+                festivalNotification.getFestival().getUniversityName(),
+                festivalNotification.getFestival().getFestivalName()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationReadResponses.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationReadResponses.java
@@ -1,0 +1,18 @@
+package com.daedan.festabook.festival.dto;
+
+import com.daedan.festabook.festival.domain.FestivalNotification;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.List;
+
+public record FestivalNotificationReadResponses(
+        @JsonValue List<FestivalNotificationReadResponse> responses
+) {
+
+    public static FestivalNotificationReadResponses from(List<FestivalNotification> festivalNotifications) {
+        return new FestivalNotificationReadResponses(
+                festivalNotifications.stream()
+                        .map(FestivalNotificationReadResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/infrastructure/FestivalNotificationJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/infrastructure/FestivalNotificationJpaRepository.java
@@ -1,9 +1,12 @@
 package com.daedan.festabook.festival.infrastructure;
 
 import com.daedan.festabook.festival.domain.FestivalNotification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FestivalNotificationJpaRepository extends JpaRepository<FestivalNotification, Long> {
 
     boolean existsByFestivalIdAndDeviceId(Long festivalId, Long deviceId);
+
+    List<FestivalNotification> getAllByDeviceId(Long deviceId);
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
@@ -5,11 +5,13 @@ import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalNotification;
 import com.daedan.festabook.festival.domain.FestivalNotificationManager;
+import com.daedan.festabook.festival.dto.FestivalNotificationReadResponses;
 import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
 import com.daedan.festabook.festival.dto.FestivalNotificationResponse;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.festival.infrastructure.FestivalNotificationJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -38,6 +40,16 @@ public class FestivalNotificationService {
         festivalNotificationManager.subscribeFestivalTopic(festivalId, device.getFcmToken());
 
         return FestivalNotificationResponse.from(savedFestivalNotification);
+    }
+
+    @Transactional
+    public FestivalNotificationReadResponses getAllFestivalNotificationByDeviceId(Long deviceId) {
+        Device device = getDeviceById(deviceId);
+        List<FestivalNotification> festivalNotifications = festivalNotificationJpaRepository.getAllByDeviceId(
+                device.getId()
+        );
+
+        return FestivalNotificationReadResponses.from(festivalNotifications);
     }
 
     @Transactional

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
@@ -42,7 +42,7 @@ public class FestivalNotificationService {
         return FestivalNotificationResponse.from(savedFestivalNotification);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public FestivalNotificationReadResponses getAllFestivalNotificationByDeviceId(Long deviceId) {
         Device device = getDeviceById(deviceId);
         List<FestivalNotification> festivalNotifications = festivalNotificationJpaRepository.getAllByDeviceId(

--- a/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
             "/festivals",
             "/festivals/universities",
             "/festivals/geography",
+            "/festivals/notifications/*",
             "/lost-items",
             "/questions",
             "/lineups",

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
@@ -3,6 +3,7 @@ package com.daedan.festabook.festival.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -15,12 +16,15 @@ import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.domain.FestivalNotification;
 import com.daedan.festabook.festival.domain.FestivalNotificationFixture;
 import com.daedan.festabook.festival.domain.FestivalNotificationManager;
+import com.daedan.festabook.festival.dto.FestivalNotificationReadResponse;
+import com.daedan.festabook.festival.dto.FestivalNotificationReadResponses;
 import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
 import com.daedan.festabook.festival.dto.FestivalNotificationRequestFixture;
 import com.daedan.festabook.festival.dto.FestivalNotificationResponse;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.festival.infrastructure.FestivalNotificationJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -140,6 +144,61 @@ class FestivalNotificationServiceTest {
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("존재하지 않는 축제입니다.");
+        }
+    }
+
+    @Nested
+    class getAllFestivalNotificationByDeviceId {
+
+        @Test
+        void 성공() {
+            // given
+            Long deviceId = 1L;
+            Long festivalId1 = 1L;
+            Long festivalId2 = 2L;
+            Device device = DeviceFixture.create(deviceId);
+            Festival festival1 = FestivalFixture.create(festivalId1);
+            Festival festival2 = FestivalFixture.create(festivalId2);
+            FestivalNotification festivalNotification1 = FestivalNotificationFixture.create(festival1, device);
+            FestivalNotification festivalNotification2 = FestivalNotificationFixture.create(festival2, device);
+            List<FestivalNotification> festivalNotifications = List.of(festivalNotification1, festivalNotification2);
+
+            given(deviceJpaRepository.findById(deviceId))
+                    .willReturn(Optional.of(device));
+            given(festivalNotificationJpaRepository.getAllByDeviceId(deviceId))
+                    .willReturn(festivalNotifications);
+
+            // when
+            FestivalNotificationReadResponses result = festivalNotificationService.getAllFestivalNotificationByDeviceId(
+                    deviceId
+            );
+
+            // then
+            assertSoftly(s -> {
+                List<FestivalNotificationReadResponse> responses = result.responses();
+                s.assertThat(responses.get(0).universityName())
+                        .isEqualTo(festivalNotification1.getFestival().getUniversityName());
+                s.assertThat(responses.get(0).festivalName())
+                        .isEqualTo(festivalNotification1.getFestival().getFestivalName());
+                s.assertThat(responses.get(1).universityName())
+                        .isEqualTo(festivalNotification2.getFestival().getUniversityName());
+                s.assertThat(responses.get(1).festivalName())
+                        .isEqualTo(festivalNotification2.getFestival().getFestivalName());
+            });
+        }
+
+        @Test
+        void 예외_존재하지_않는_디바이스() {
+            // given
+            Long invalidDeviceId = 0L;
+
+            given(deviceJpaRepository.findById(invalidDeviceId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> festivalNotificationService.getAllFestivalNotificationByDeviceId(invalidDeviceId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 디바이스입니다.");
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalNotificationServiceTest.java
@@ -175,14 +175,16 @@ class FestivalNotificationServiceTest {
 
             // then
             assertSoftly(s -> {
-                List<FestivalNotificationReadResponse> responses = result.responses();
-                s.assertThat(responses.get(0).universityName())
+                FestivalNotificationReadResponse response1 = result.responses().get(0);
+                s.assertThat(response1.universityName())
                         .isEqualTo(festivalNotification1.getFestival().getUniversityName());
-                s.assertThat(responses.get(0).festivalName())
+                s.assertThat(response1.festivalName())
                         .isEqualTo(festivalNotification1.getFestival().getFestivalName());
-                s.assertThat(responses.get(1).universityName())
+                
+                FestivalNotificationReadResponse response2 = result.responses().get(1);
+                s.assertThat(response2.universityName())
                         .isEqualTo(festivalNotification2.getFestival().getUniversityName());
-                s.assertThat(responses.get(1).festivalName())
+                s.assertThat(response2.festivalName())
                         .isEqualTo(festivalNotification2.getFestival().getFestivalName());
             });
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#697

<br>

## 🛠️ 작업 내용

- Device의 모든 축제 알림 조회 API 구현
- 전 PR에서 반영하지 못했던 실수들도 엮어서 처리했읍니다... 양해 바람

<br>

## 🙇🏻 중점 리뷰 요청

- DTO 이름이 좀 별로입니다..
    - FestivalNotificationReadResponses
    - FestivalNotificationReadResponse
- 그리고 알림 조회할 때 예를 들어 id나 알림을 구독한 최신순으로 정렬해서 준다든가... 등의 작업을 진행해 주어야 할까요?
- getAllFestivalNotificationByDeviceId -> find인지 get인지 컨벤션이 뭐였죠..!?

<br>

## 📸 이미지 첨부 (Optional)
<img width="918" height="357" alt="스크린샷 2025-09-07 오후 3 15 35" src="https://github.com/user-attachments/assets/dd85fee8-d774-4a5f-8f35-ee0c0b610737" />
<img width="887" height="377" alt="스크린샷 2025-09-07 오후 3 15 30" src="https://github.com/user-attachments/assets/1b02c7d2-9c3b-414a-ad99-be55522d3f5b" />

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 기기별 축제 알림 조회 엔드포인트 추가(GET /festivals/notifications/{deviceId}). 응답에 알림 ID, 대학명, 축제명 포함. 인증 없이 접근 가능.
  - 관련 응답 DTO 및 서비스/저장소 조회 메서드 추가.
- **문서**
  - 축제 생성 API의 성공 응답 코드 문서 201(Created)로 정정.
  - 요청 스키마의 festivalName 예시값 업데이트.
- **테스트**
  - 컨트롤러·서비스 테스트 추가: 목록 조회, DTO 매핑 검증 및 잘못된 기기 ID 예외 케이스 포함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->