### PR TITLE
[FE] dev 서버에 CICD를 실행하는 과정에 권한이 없는 문제 해결

### DIFF
--- a/.github/workflows/frontend-ci-cd-dev.yml
+++ b/.github/workflows/frontend-ci-cd-dev.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: [self-hosted]
 
     steps:
+      # 작업 환경의 권한을 변경
+      - name: Initialize workspace permissions
+        run: |
+          sudo chown -R ubuntu:ubuntu /home/ubuntu/actions-runner/_work
+
+    steps:
       # 프로젝트 체크아웃
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## #️⃣ 이슈 번호

#706 

<br>

## 🛠️ 작업 내용

- _work 디렉터리 권한 조정

