### PR TITLE
[BE] Council 생성 시 권한 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/council/dto/CouncilResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/council/dto/CouncilResponse.java
@@ -1,16 +1,20 @@
 package com.daedan.festabook.council.dto;
 
 import com.daedan.festabook.council.domain.Council;
+import com.daedan.festabook.global.security.role.RoleType;
+import java.util.Set;
 
 public record CouncilResponse(
         Long festivalId,
-        String username
+        String username,
+        Set<RoleType> roleTypes
 ) {
 
     public static CouncilResponse from(Council council) {
         return new CouncilResponse(
                 council.getFestival().getId(),
-                council.getUsername()
+                council.getUsername(),
+                council.getRoles()
         );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/council/service/CouncilService.java
+++ b/backend/src/main/java/com/daedan/festabook/council/service/CouncilService.java
@@ -9,7 +9,9 @@ import com.daedan.festabook.council.infrastructure.CouncilJpaRepository;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.global.security.role.RoleType;
 import com.daedan.festabook.global.security.util.JwtProvider;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,6 +39,9 @@ public class CouncilService {
                 encodedPassword
         );
         Council savedCouncil = councilJpaRepository.save(council);
+
+        // TODO: 추후 회원가입 방식이 생긴다면 삭제
+        council.updateRole(Set.of(RoleType.ROLE_COUNCIL));
 
         return CouncilResponse.from(savedCouncil);
     }

--- a/backend/src/test/java/com/daedan/festabook/council/controller/CouncilControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/council/controller/CouncilControllerTest.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.council.controller;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.daedan.festabook.council.dto.CouncilLoginRequest;
@@ -10,6 +11,7 @@ import com.daedan.festabook.council.dto.CouncilRequestFixture;
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.global.security.role.RoleType;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +62,8 @@ class CouncilControllerTest {
                     .then()
                     .statusCode(HttpStatus.CREATED.value())
                     .body("festivalId", notNullValue())
-                    .body("username", equalTo(username));
+                    .body("username", equalTo(username))
+                    .body("roleTypes", hasItem(RoleType.ROLE_COUNCIL.name()));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/council/service/CouncilServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/council/service/CouncilServiceTest.java
@@ -22,6 +22,7 @@ import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.global.security.role.RoleType;
 import com.daedan.festabook.global.security.util.JwtProvider;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -65,6 +66,7 @@ class CouncilServiceTest {
             String username = "test";
             String rawPassword = "1234";
             String encodedPassword = "{encoded}1234";
+            RoleType roleType = RoleType.ROLE_COUNCIL;
             Long councilId = 10L;
             Council council = CouncilFixture.create(festival, username, encodedPassword, councilId);
 
@@ -98,6 +100,7 @@ class CouncilServiceTest {
                 s.assertThat(savedCouncil.getFestival()).isEqualTo(festival);
                 s.assertThat(savedCouncil.getUsername()).isEqualTo(username);
                 s.assertThat(savedCouncil.getPassword()).isEqualTo(encodedPassword);
+                s.assertThat(savedCouncil.getRoles()).containsOnly(roleType);
                 s.assertThat(result).isNotNull();
             });
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#712

<br>

## 🛠️ 작업 내용

- Council 생성 시 권한 추가

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 위원 생성 시 기본 역할 ROLE_COUNCIL이 자동 부여됩니다. 별도 설정 없이 기본 권한으로 바로 이용할 수 있습니다.
  * 위원 정보 응답에 roleTypes 항목이 추가되어 사용자의 역할 목록을 함께 반환합니다. 이를 통해 클라이언트는 화면 표시 및 권한 제어에 필요한 역할 정보를 즉시 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->