### PR TITLE
[AN] 일정 화면 로딩 상태 개선

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleFragment.kt
@@ -86,7 +86,7 @@ class ScheduleFragment :
                     showLoadingView(isLoading = false)
                     Timber.w(
                         scheduleDatesUiState.throwable,
-                        "ScheduleFragment: ${scheduleDatesUiState.throwable.message}",
+                        "${this::class.simpleName}: ${scheduleDatesUiState.throwable.message}",
                     )
                     showErrorSnackBar(scheduleDatesUiState.throwable)
                 }
@@ -96,6 +96,7 @@ class ScheduleFragment :
 
     private fun showLoadingView(isLoading: Boolean) {
         binding.lavScheduleLoading.visibility = if (isLoading) View.VISIBLE else View.GONE
+        binding.vpSchedule.visibility = if (isLoading) View.INVISIBLE else View.VISIBLE
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -80,8 +80,8 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
             binding.rvScheduleEvent.visibility = View.INVISIBLE
             binding.lavScheduleLoading.visibility = View.VISIBLE
         } else {
-            binding.rvScheduleEvent.visibility = View.VISIBLE
             binding.lavScheduleLoading.visibility = View.GONE
+            binding.rvScheduleEvent.visibility = View.VISIBLE
         }
         binding.srlScheduleEvent.isRefreshing = false
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -13,7 +13,6 @@ import com.daedan.festabook.domain.repository.ScheduleRepository
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiStatus
 import com.daedan.festabook.presentation.schedule.model.toUiModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleViewModel.kt
@@ -13,6 +13,7 @@ import com.daedan.festabook.domain.repository.ScheduleRepository
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
 import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiStatus
 import com.daedan.festabook.presentation.schedule.model.toUiModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
@@ -58,7 +59,7 @@ class ScheduleViewModel(
                         scheduleEventUiModels
                             .indexOfFirst { scheduleEvent -> scheduleEvent.status == ScheduleEventUiStatus.ONGOING }
                             .coerceAtLeast(FIRST_INDEX)
-                          
+
                     _scheduleEventsUiState.value =
                         ScheduleEventsUiState.Success(scheduleEventUiModels, currentEventPosition)
                 }.onFailure {


### PR DESCRIPTION
## #️⃣ 이슈 번호

#740

<br>

## 🛠️ 작업 내용

- 로딩 화면 이후 컨텐츠 표시

<br>

## 🙇🏻 중점 리뷰 요청



<br>

## 📸 이미지 첨부 (Optional)


https://github.com/user-attachments/assets/87dc8039-8faa-4df3-8f3d-75a1a538596e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 스케줄 화면 로딩 중 콘텐츠가 노출되던 경우를 방지하여, 로딩 애니메이션만 표시되고 로딩 완료 시 목록/탭이 즉시 나타나도록 개선했습니다. 화면 깜빡임이 줄어들고 전환이 더 부드러워졌습니다.

- Refactor
  - 로딩 표시/숨김 순서를 정리해 UI 동작 일관성을 높였습니다.
  - 오류 로그의 화면 식별성을 개선해 문제 추적이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->