### PR TITLE
[AN]  일정 화면 텍스트가 잘리는 문제 해결

### DIFF
--- a/android/app/src/main/res/layout/item_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page.xml
@@ -32,11 +32,13 @@
             <TextView
                 android:id="@+id/tv_schedule_event_title"
                 style="@style/PretendardMedium18"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
+                android:layout_marginEnd="4dp"
                 android:text="@{scheduleEvent.title}"
+                app:layout_constraintEnd_toStartOf="@id/tv_schedule_event_status"
                 app:layout_constraintStart_toStartOf="@id/cl_schedule_event_card"
                 app:layout_constraintTop_toTopOf="@id/cl_schedule_event_card"
                 tools:text="동아리 버스킹 공연" />
@@ -49,7 +51,6 @@
                 android:layout_height="24dp"
                 android:layout_marginEnd="16dp"
                 android:gravity="center"
-                app:layout_constraintBottom_toBottomOf="@id/tv_schedule_event_title"
                 app:layout_constraintEnd_toEndOf="@id/cl_schedule_event_card"
                 app:layout_constraintTop_toTopOf="@id/tv_schedule_event_title"
                 tools:text="진행중" />


### PR DESCRIPTION
## #️⃣ 이슈 번호

#777 

<br>

## 🛠️ 작업 내용

- 일정 이벤트 제목이 상태와 겹치는 문제 해결

<br>

## 🙇🏻 중점 리뷰 요청



<br>

## 📸 이미지 첨부 (Optional)
<img width="300" height="672" alt="스크린샷 2025-09-11 오후 10 39 59" src="https://github.com/user-attachments/assets/5941c3f3-910d-4227-acfb-6f03c87d63f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 일정 카드에서 제목과 상태 배지가 겹치거나 잘리던 레이아웃 문제를 수정했습니다.
  * 다양한 화면 폭에서 제목이 상태 배지와 충돌하지 않도록 제약을 조정해 반응형 표시를 개선했습니다.
* 스타일
  * 제목과 상태 배지 사이 여백을 추가해 가독성을 높였습니다.
  * 상단 정렬을 유지하여 리스트 항목의 정렬 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->