### PR TITLE
[AN] 플레이스 공지사항 임시로 보이지 않게 변경

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -115,13 +115,13 @@ class PlaceDetailActivity :
             placeImageAdapter.submitList(placeDetail.images)
             binding.clImageIndicator.setViewPager(binding.vpPlaceImages)
         }
-
-        if (placeDetail.notices.isEmpty()) {
-            binding.rvPlaceNotice.visibility = View.GONE
-            binding.tvNoNoticeDescription.visibility = View.VISIBLE
-        } else {
-            noticeAdapter.submitList(placeDetail.notices)
-        }
+        // 임시로 곰지사항을 보이지 않게 하였습니다. 추후 복구 예정입니다
+//        if (placeDetail.notices.isEmpty()) {
+//            binding.rvPlaceNotice.visibility = View.GONE
+//            binding.tvNoNoticeDescription.visibility = View.VISIBLE
+//        } else {
+//            noticeAdapter.submitList(placeDetail.notices)
+//        }
     }
 
     private fun showSkeleton() {

--- a/android/app/src/main/res/layout/activity_place_detail.xml
+++ b/android/app/src/main/res/layout/activity_place_detail.xml
@@ -185,16 +185,17 @@
                     app:layout_constraintStart_toStartOf="@id/iv_host"
                     app:layout_constraintTop_toBottomOf="@id/tv_host"
                     tools:text="시원한 맥주와 맛있는 파전시원한 맥주와 맛있는 파전시원한 맥주와 맛있는 파전시원한 맥주와 맛있는 파전시원한 맥주와 맛있는 파전시원한 맥주와 맛있는 파전" />
+<!--                임시로 곰지사항을 보이지 않게 하였습니다. 추후 복구 예정입니다-->
 
-                <View
-                    android:id="@+id/view_divider"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginTop="20dp"
-                    android:background="@color/gray300"
-                    app:layout_constraintEnd_toEndOf="@id/end_guideline"
-                    app:layout_constraintStart_toStartOf="@id/start_guideline"
-                    app:layout_constraintTop_toBottomOf="@id/tv_place_description" />
+<!--                <View-->
+<!--                    android:id="@+id/view_divider"-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="1dp"-->
+<!--                    android:layout_marginTop="20dp"-->
+<!--                    android:background="@color/gray300"-->
+<!--                    app:layout_constraintEnd_toEndOf="@id/end_guideline"-->
+<!--                    app:layout_constraintStart_toStartOf="@id/start_guideline"-->
+<!--                    app:layout_constraintTop_toBottomOf="@id/tv_place_description" />-->
 
                 <TextView
                     android:id="@+id/tv_notice_title"
@@ -202,6 +203,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:text="@string/place_detail_notice_title"
+                    android:visibility="gone"
                     android:textAppearance="@style/PretendardBold20"
                     android:textColor="@color/gray900"
                     app:layout_constraintEnd_toEndOf="@id/end_guideline"
@@ -216,6 +218,7 @@
                     android:text="@string/place_detail_notice_description"
                     android:textAppearance="@style/PretendardRegular12"
                     android:textColor="@color/gray500"
+                    android:visibility="gone"
                     app:layout_constraintEnd_toEndOf="@id/end_guideline"
                     app:layout_constraintStart_toStartOf="@id/tv_notice_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_notice_title" />
@@ -239,6 +242,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:nestedScrollingEnabled="false"
+                    android:visibility="gone"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="@id/end_guideline"
                     app:layout_constraintStart_toStartOf="@id/start_guideline"


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) https://github.com/woowacourse-teams/2025-festabook/issues/792

<br>

## 🛠️ 작업 내용

- 플레이스 공지사항 임시로 보이지 않게 변경하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="https://github.com/user-attachments/assets/b5a66bf0-6f18-4c65-9be0-a296d0b189f9" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 장소 상세 화면의 공지 영역을 임시로 숨겼습니다. 공지 리스트와 ‘공지 없음’ 안내가 더 이상 노출되지 않습니다.
* **Style**
  * 공지 관련 제목/설명/목록 컴포넌트를 기본 숨김 처리하고, 화면 내 구분선을 제거해 레이아웃을 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->