### PR TITLE
[AN] 스낵바 띄울 때 바텀 내비게이션 뷰 떠오르는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/FragmentUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/FragmentUtil.kt
@@ -8,12 +8,14 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.util.TypedValue
 import android.view.View
+import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import com.daedan.festabook.R
 import com.daedan.festabook.data.util.ApiResultException
 import com.daedan.festabook.presentation.placeList.behavior.PlaceListBottomSheetFollowBehavior
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 
 inline fun <reified T : Parcelable> Bundle.getObject(key: String): T? =
@@ -53,7 +55,15 @@ fun Fragment.showErrorSnackBar(exception: Throwable?) {
 }
 
 fun Activity.showErrorSnackBar(msg: String) {
-    val snackBar = Snackbar.make(window.decorView.rootView, msg, Snackbar.LENGTH_SHORT)
+    val snackBar =
+        Snackbar.make(
+            findViewById<ViewGroup>(android.R.id.content).getChildAt(0),
+            msg,
+            Snackbar.LENGTH_SHORT,
+        )
+    snackBar.setAnchorView(
+        findViewById<FloatingActionButton>(R.id.bab_menu),
+    )
     snackBar
         .setAction(
             getString(R.string.fail_snackbar_confirm),

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/PermissionUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/PermissionUtil.kt
@@ -29,7 +29,8 @@ fun showNotificationDeniedSnackbar(
             view,
             context.getString(R.string.notification_permission_denied_message),
             Snackbar.LENGTH_LONG,
-        ).setAction(context.getString(R.string.move_to_setting_text)) {
+        ).setAnchorView(view.rootView.findViewById(R.id.bab_menu))
+        .setAction(context.getString(R.string.move_to_setting_text)) {
             val intent =
                 Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                     data = Uri.fromParts("package", context.packageName, null)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -139,13 +139,6 @@ class MainActivity :
     }
 
     private fun setUpBottomNavigation() {
-        binding.fabMap.post {
-            binding.fabMap.translationY = FLOATING_ACTION_BUTTON_INITIAL_TRANSLATION_Y
-            binding.fcvFragmentContainer.updatePadding(
-                bottom = binding.babMenu.height + binding.babMenu.marginBottom,
-            )
-            binding.bnvMenu.x /= 2
-        }
         binding.babMenu.setOnApplyWindowInsetsListener(null)
         binding.babMenu.setPadding(0, 0, 0, 0)
         binding.bnvMenu.setOnApplyWindowInsetsListener(null)

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,7 @@
             android:layout_gravity="bottom"
             app:backgroundTint="@color/gray050"
             app:addElevationShadow="true"
+            app:contentInsetStart="0dp"
             app:elevation="3dp"
             app:fabAlignmentMode="center">
 
@@ -34,8 +35,6 @@
                 app:itemTextColor="@color/menu_bottom_navigation_color"
                 app:labelVisibilityMode="labeled"
                 app:menu="@menu/menu_bottom_navigation" />
-
-
         </com.google.android.material.bottomappbar.BottomAppBar>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -51,8 +50,7 @@
             app:backgroundTint="@color/black400"
             app:maxImageSize="30dp"
             app:pressedTranslationZ="0dp"
-            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
-/>
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/796

<br>

## 🛠️ 작업 내용

- 스낵 바 띄울 때 바텀 내비게이션 뷰가 떠오르는 문제 해결하였습니다
- 추가로 에러 스낵바 또한 바텀 내비게이션 위로 뜨게 변경하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 스낵바가 하단 플로팅 버튼에 앵커링되어 버튼을 가리지 않고 더 잘 보이도록 개선.
- 버그 수정
  - 스낵바 표시 기준을 안정적인 컨텐츠 뷰로 변경해 간헐적 표시 위치 문제 완화.
  - BottomAppBar의 시작 인셋을 0dp로 조정해 아이콘/콘텐츠 정렬 개선.
- 리팩터링
  - 초기 FAB 이동 및 컨테이너 패딩·바 위치 보정 로직 제거로 하단 내비게이션 동작 단순화.
- 스타일
  - 레이아웃 마크업 정리(형식 변경만, 동작 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->