### PR TITLE
[BE] 축제 정보 수정 API 누락된 필드 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalInformationUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalInformationUpdateRequest.java
@@ -12,6 +12,9 @@ public record FestivalInformationUpdateRequest(
         LocalDate startDate,
 
         @Schema(description = "축제 종료 날짜", example = "2025-08-07")
-        LocalDate endDate
+        LocalDate endDate,
+
+        @Schema(description = "축제 공개 여부", example = "false")
+        boolean userVisible
 ) {
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -399,10 +399,12 @@ class FestivalControllerTest {
             String changedFestivalName = "수정 후 제목";
             LocalDate changedStartDate = LocalDate.of(2025, 11, 1);
             LocalDate changedEndDate = LocalDate.of(2025, 11, 2);
+            boolean userVisible = true;
             FestivalInformationUpdateRequest request = FestivalInformationUpdateRequestFixture.create(
                     changedFestivalName,
                     changedStartDate,
-                    changedEndDate
+                    changedEndDate,
+                    userVisible
             );
 
             int expectedFieldSize = 5;
@@ -421,7 +423,8 @@ class FestivalControllerTest {
                     .body("festivalId", equalTo(festival.getId().intValue()))
                     .body("festivalName", equalTo(changedFestivalName))
                     .body("startDate", equalTo(changedStartDate.toString()))
-                    .body("endDate", equalTo(changedEndDate.toString()));
+                    .body("endDate", equalTo(changedEndDate.toString()))
+                    .body("userVisible", equalTo(userVisible));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/dto/FestivalInformationUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/dto/FestivalInformationUpdateRequestFixture.java
@@ -7,24 +7,28 @@ public class FestivalInformationUpdateRequestFixture {
     private static final String DEFAULT_FESTIVAL_NAME = "축제 이름";
     private static final LocalDate DEFAULT_START_DATE = LocalDate.of(2025, 10, 1);
     private static final LocalDate DEFAULT_END_DATE = LocalDate.of(2025, 10, 2);
+    private static final boolean DEFAULT_USER_VISIBLE = false;
 
     public static FestivalInformationUpdateRequest create() {
         return new FestivalInformationUpdateRequest(
                 DEFAULT_FESTIVAL_NAME,
                 DEFAULT_START_DATE,
-                DEFAULT_END_DATE
+                DEFAULT_END_DATE,
+                DEFAULT_USER_VISIBLE
         );
     }
 
     public static FestivalInformationUpdateRequest create(
             String festivalName,
             LocalDate startDate,
-            LocalDate endDate
+            LocalDate endDate,
+            boolean DEFAULT_USER_VISIBLE
     ) {
         return new FestivalInformationUpdateRequest(
                 festivalName,
                 startDate,
-                endDate
+                endDate,
+                DEFAULT_USER_VISIBLE
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
@@ -228,7 +228,8 @@ class FestivalServiceTest {
             FestivalInformationUpdateRequest request = FestivalInformationUpdateRequestFixture.create(
                     "수정 후 제목",
                     LocalDate.of(2025, 10, 1),
-                    LocalDate.of(2025, 10, 2)
+                    LocalDate.of(2025, 10, 2),
+                    false
             );
 
             // when


### PR DESCRIPTION
## #️⃣ 이슈 번호

#803

<br>

## 🛠️ 작업 내용

-  축제 정보 수정 API 누락된 필드 추가

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 축제 정보 수정 시 공개 여부를 설정할 수 있는 옵션이 추가되었습니다. 공개/비공개 전환이 가능하며, 수정 후 응답에 현재 공개 상태가 함께 반환되어 화면에서 즉시 확인할 수 있습니다.
  - API를 연동하는 사용자라면 요청/응답 본문에 공개 여부 필드가 추가된 점을 반영해 주세요. 기존 필드와의 호환성은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->