### PR TITLE
[BE] 플레이스 설명 3000자로 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
@@ -39,7 +39,7 @@ public class Place extends BaseEntity {
     );
 
     private static final int MAX_TITLE_LENGTH = 255;
-    private static final int MAX_DESCRIPTION_LENGTH = 100;
+    private static final int MAX_DESCRIPTION_LENGTH = 3000;
     private static final int MAX_LOCATION_LENGTH = 100;
     private static final int MAX_HOST_LENGTH = 100;
 

--- a/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
+++ b/backend/src/main/java/com/daedan/festabook/place/domain/Place.java
@@ -58,13 +58,13 @@ public class Place extends BaseEntity {
     @Column(length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
-    @Column(length = 100)
+    @Column(length = MAX_DESCRIPTION_LENGTH)
     private String description;
 
-    @Column(length = 100)
+    @Column(length = MAX_LOCATION_LENGTH)
     private String location;
 
-    @Column(length = 100)
+    @Column(length = MAX_HOST_LENGTH)
     private String host;
 
     private LocalTime startTime;

--- a/backend/src/main/resources/db/migration/V6__place_description_max_length_modify.sql
+++ b/backend/src/main/resources/db/migration/V6__place_description_max_length_modify.sql
@@ -1,0 +1,2 @@
+ALTER TABLE place
+    MODIFY COLUMN description VARCHAR(3000);

--- a/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/domain/PlaceTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PlaceTest {
 
     private static final int MAX_TITLE_LENGTH = 255;
-    private static final int MAX_DESCRIPTION_LENGTH = 100;
+    private static final int MAX_DESCRIPTION_LENGTH = 3000;
     private static final int MAX_LOCATION_LENGTH = 100;
     private static final int MAX_HOST_LENGTH = 100;
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#802

<br>

## 🛠️ 작업 내용

- 플레이스 설명 3000자로 변경

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 장소 설명 입력 한도를 100자에서 3000자로 확대하여 더 풍부한 내용 작성이 가능해졌습니다. 데이터베이스에도 해당 변경이 반영되어 긴 설명 저장이 지원됩니다.
* 테스트
  * 새 최대 길이(최대 3000자)에 맞춰 경계값 및 초과 입력 검증 테스트를 갱신하여 변경된 제한을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->