### PR TITLE
[BE] 축제 정보 update 로직 수정

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/domain/Festival.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/domain/Festival.java
@@ -94,13 +94,14 @@ public class Festival extends BaseEntity {
         this.polygonHoleBoundary = polygonHoleBoundary;
     }
 
-    public void updateFestival(String festivalName, LocalDate startDate, LocalDate endDate) {
+    public void updateFestival(String festivalName, LocalDate startDate, LocalDate endDate, boolean userVisible) {
         validateName(festivalName);
         validateDates(startDate, endDate);
 
         this.festivalName = festivalName;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.userVisible = userVisible;
     }
 
     private void validateName(String name) {

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalResponse.java
@@ -11,7 +11,8 @@ public record FestivalResponse(
         FestivalImageResponses festivalImages,
         String festivalName,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        boolean userVisible
 ) {
 
     public static FestivalResponse from(Festival festival, List<FestivalImage> festivalImages) {
@@ -21,7 +22,8 @@ public record FestivalResponse(
                 FestivalImageResponses.from(festivalImages),
                 festival.getFestivalName(),
                 festival.getStartDate(),
-                festival.getEndDate()
+                festival.getEndDate(),
+                festival.isUserVisible()
         );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
@@ -58,7 +58,7 @@ public class FestivalService {
             FestivalInformationUpdateRequest request
     ) {
         Festival festival = getFestivalById(festivalId);
-        festival.updateFestival(request.festivalName(), request.startDate(), request.endDate());
+        festival.updateFestival(request.festivalName(), request.startDate(), request.endDate(), request.userVisible());
         return FestivalInformationResponse.from(festival);
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -216,7 +216,7 @@ class FestivalControllerTest {
             festivalImageJpaRepository.saveAll(List.of(festivalImage2, festivalImage1));
 
             int festivalImageSize = 2;
-            int expectedFieldSize = 6;
+            int expectedFieldSize = 7;
 
             // when & then
             RestAssured


### PR DESCRIPTION
## #️⃣ 이슈 번호

#810

<br>

## 🛠️ 작업 내용

- 축제 정보 update 로직 수정

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 축제 정보에 ‘노출 여부(userVisible)’ 설정이 추가되어, 관리자가 축제를 사용자에게 공개하거나 비공개로 전환할 수 있습니다. 변경된 노출 상태는 즉시 반영됩니다.
- **테스트**
  - 축제 조회 관련 테스트가 응답 필드 수 변경에 맞춰 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->