### PR TITLE
[BE] CloudWatch Agent 사용자 네임스페이스 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/config/CloudWatchMetricsConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/CloudWatchMetricsConfig.java
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 @Profile("prod")
 public class CloudWatchMetricsConfig {
 
-    private static final String CLOUDWATCH_NAMESPACE = "festabook";
+    private static final String CLOUDWATCH_NAMESPACE = "Festabook/Server";
     private static final Duration CLOUDWATCH_STEP = Duration.ofMinutes(1);
 
     @Bean

--- a/backend/src/main/java/com/daedan/festabook/global/config/CloudWatchMetricsConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/config/CloudWatchMetricsConfig.java
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 @Profile("prod")
 public class CloudWatchMetricsConfig {
 
-    private static final String CLOUDWATCH_NAMESPACE = "Festabook/Server";
+    private static final String CLOUDWATCH_NAMESPACE = "festabook/server";
     private static final Duration CLOUDWATCH_STEP = Duration.ofMinutes(1);
 
     @Bean


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #821 

<br>

## 🛠️ 작업 내용

- 사용자 네임 스페이스를 변경했습니다.
  - EC2 : `'Festabook/EC2'`
  - Server : `'Festabook/Server'`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 작업(Chores)
  * 모니터링 설정을 조정해 서버 메트릭의 분류(CloudWatch 네임스페이스)를 변경했습니다. 운영 환경의 관측성·대시보드 정렬이 개선되어 이상 징후 탐지 및 용량 계획의 신뢰도가 향상됩니다. 앱의 기능·성능·UI에는 영향이 없으며, 사용자 조치 없이 동일하게 서비스를 이용하실 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->