### PR TITLE
[BE] 분실물 페이지 안내메시지 조회 및 수정 API 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -9,6 +9,7 @@ import com.daedan.festabook.festival.dto.FestivalImageResponses;
 import com.daedan.festabook.festival.dto.FestivalImageSequenceUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalInformationResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequest;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideResponse;
 import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateResponse;
 import com.daedan.festabook.festival.dto.FestivalResponse;
@@ -108,6 +109,18 @@ public class FestivalController {
             @RequestParam String universityName
     ) {
         return festivalService.getUniversitiesByUniversityName(universityName);
+    }
+
+    @GetMapping("/lost-item-guide")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제의 분실물 가이드 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public FestivalLostItemGuideResponse getFestivalLostItemGuide(
+            @Parameter(hidden = true) @FestivalId Long festivalId
+    ) {
+        return festivalService.getFestivalLostItemGuide(festivalId);
     }
 
     @PreAuthorize("hasRole('COUNCIL')")

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalController.java
@@ -9,6 +9,8 @@ import com.daedan.festabook.festival.dto.FestivalImageResponses;
 import com.daedan.festabook.festival.dto.FestivalImageSequenceUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalInformationResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequest;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateRequest;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateResponse;
 import com.daedan.festabook.festival.dto.FestivalResponse;
 import com.daedan.festabook.festival.dto.FestivalUniversityResponses;
 import com.daedan.festabook.festival.service.FestivalImageService;
@@ -120,6 +122,20 @@ public class FestivalController {
             @RequestBody FestivalInformationUpdateRequest request
     ) {
         return festivalService.updateFestivalInformation(councilDetails.getFestivalId(), request);
+    }
+
+    @PreAuthorize("hasRole('COUNCIL')")
+    @PatchMapping("/lost-item-guide")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 축제의 분실물 가이드 정보 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public FestivalLostItemGuideUpdateResponse updateFestivalLostItemGuide(
+            @AuthenticationPrincipal CouncilDetails councilDetails,
+            @RequestBody FestivalLostItemGuideUpdateRequest request
+    ) {
+        return festivalService.updateFestivalLostItemGuide(councilDetails.getFestivalId(), request);
     }
 
     @PreAuthorize("hasRole('COUNCIL')")

--- a/backend/src/main/java/com/daedan/festabook/festival/domain/Festival.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/domain/Festival.java
@@ -33,15 +33,16 @@ public class Festival extends BaseEntity {
     private static final int MAX_NAME_LENGTH = 50;
     private static final int MIN_ZOOM = 0;
     private static final int MAX_ZOOM = 30;
+    private static final int MAX_LOST_ITEM_GUIDE_LENGTH = 1000;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = MAX_NAME_LENGTH)
     private String universityName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = MAX_NAME_LENGTH)
     private String festivalName;
 
     @Column(nullable = false)
@@ -53,7 +54,7 @@ public class Festival extends BaseEntity {
     @Column(nullable = false)
     private boolean userVisible;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = MAX_ZOOM)
     private Integer zoom;
 
     @Embedded
@@ -67,6 +68,9 @@ public class Festival extends BaseEntity {
     )
     private List<Coordinate> polygonHoleBoundary = new ArrayList<>();
 
+    @Column(nullable = false, length = MAX_LOST_ITEM_GUIDE_LENGTH)
+    private String lostItemGuide;
+
     public Festival(
             String universityName,
             String festivalName,
@@ -75,7 +79,8 @@ public class Festival extends BaseEntity {
             boolean userVisible,
             Integer zoom,
             Coordinate centerCoordinate,
-            List<Coordinate> polygonHoleBoundary
+            List<Coordinate> polygonHoleBoundary,
+            String lostItemGuide
     ) {
         validateName(universityName);
         validateName(festivalName);
@@ -83,6 +88,7 @@ public class Festival extends BaseEntity {
         validateZoom(zoom);
         validateCenterCoordinate(centerCoordinate);
         validatePolygonHoleBoundary(polygonHoleBoundary);
+        validateLostItemGuide(lostItemGuide);
 
         this.universityName = universityName;
         this.festivalName = festivalName;
@@ -92,6 +98,7 @@ public class Festival extends BaseEntity {
         this.zoom = zoom;
         this.centerCoordinate = centerCoordinate;
         this.polygonHoleBoundary = polygonHoleBoundary;
+        this.lostItemGuide = lostItemGuide;
     }
 
     public void updateFestival(String festivalName, LocalDate startDate, LocalDate endDate, boolean userVisible) {
@@ -102,6 +109,12 @@ public class Festival extends BaseEntity {
         this.startDate = startDate;
         this.endDate = endDate;
         this.userVisible = userVisible;
+    }
+
+    public void updateFestival(String lostItemGuide) {
+        validateLostItemGuide(lostItemGuide);
+
+        this.lostItemGuide = lostItemGuide;
     }
 
     private void validateName(String name) {
@@ -146,6 +159,18 @@ public class Festival extends BaseEntity {
     private void validatePolygonHoleBoundary(List<Coordinate> polygonHoleBoundary) {
         if (polygonHoleBoundary == null || polygonHoleBoundary.isEmpty()) {
             throw new BusinessException("폴리곤 내부 구멍 좌표 리스트는 비어있을 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateLostItemGuide(String lostItemGuide) {
+        if (!StringUtils.hasText(lostItemGuide)) {
+            throw new BusinessException("분실물 가이드는 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (lostItemGuide.length() > MAX_LOST_ITEM_GUIDE_LENGTH) {
+            throw new BusinessException(
+                    String.format("분실물 가이드는 %d자를 초과할 수 없습니다.", MAX_LOST_ITEM_GUIDE_LENGTH),
+                    HttpStatus.BAD_REQUEST
+            );
         }
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalCreateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalCreateRequest.java
@@ -39,7 +39,10 @@ public record FestivalCreateRequest(
                         "{\"latitude\": 37.5862547, \"longitude\": 127.0591545}, " +
                         "{\"latitude\": 37.5865607, \"longitude\": 127.0569872}]"
         )
-        List<Coordinate> polygonHoleBoundary
+        List<Coordinate> polygonHoleBoundary,
+
+        @Schema(description = "분실물 수령/습득 가이드", example = "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요.")
+        String lostItemGuide
 ) {
 
     public Festival toEntity() {
@@ -51,7 +54,8 @@ public record FestivalCreateRequest(
                 false,
                 zoom,
                 centerCoordinate,
-                polygonHoleBoundary
+                polygonHoleBoundary,
+                lostItemGuide
         );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideResponse.java
@@ -1,0 +1,13 @@
+package com.daedan.festabook.festival.dto;
+
+import com.daedan.festabook.festival.domain.Festival;
+
+public record FestivalLostItemGuideResponse(
+
+        String lostItemGuide
+) {
+
+    public static FestivalLostItemGuideResponse from(Festival festival) {
+        return new FestivalLostItemGuideResponse(festival.getLostItemGuide());
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideResponse.java
@@ -3,7 +3,6 @@ package com.daedan.festabook.festival.dto;
 import com.daedan.festabook.festival.domain.Festival;
 
 public record FestivalLostItemGuideResponse(
-
         String lostItemGuide
 ) {
 

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.festival.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FestivalLostItemGuideUpdateRequest(
+
+        @Schema(description = "분실물 제보 및 수령 안내", example = "습득하신 분실물 또는 분실물 수령 문의는 구바우어관 301로 찾아와주세요.")
+        String lostItemGuide
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideUpdateResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalLostItemGuideUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.daedan.festabook.festival.dto;
+
+import com.daedan.festabook.festival.domain.Festival;
+
+public record FestivalLostItemGuideUpdateResponse(
+        String lostItemGuide
+) {
+
+    public static FestivalLostItemGuideUpdateResponse from(Festival festival) {
+        return new FestivalLostItemGuideUpdateResponse(festival.getLostItemGuide());
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
@@ -7,6 +7,8 @@ import com.daedan.festabook.festival.dto.FestivalCreateResponse;
 import com.daedan.festabook.festival.dto.FestivalGeographyResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequest;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateRequest;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateResponse;
 import com.daedan.festabook.festival.dto.FestivalResponse;
 import com.daedan.festabook.festival.dto.FestivalUniversityResponses;
 import com.daedan.festabook.festival.infrastructure.FestivalImageJpaRepository;
@@ -60,6 +62,16 @@ public class FestivalService {
         Festival festival = getFestivalById(festivalId);
         festival.updateFestival(request.festivalName(), request.startDate(), request.endDate(), request.userVisible());
         return FestivalInformationResponse.from(festival);
+    }
+
+    @Transactional
+    public FestivalLostItemGuideUpdateResponse updateFestivalLostItemGuide(
+            Long festivalId,
+            FestivalLostItemGuideUpdateRequest request
+    ) {
+        Festival festival = getFestivalById(festivalId);
+        festival.updateFestival(request.lostItemGuide());
+        return FestivalLostItemGuideUpdateResponse.from(festival);
     }
 
     private Festival getFestivalById(Long festivalId) {

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalService.java
@@ -7,6 +7,7 @@ import com.daedan.festabook.festival.dto.FestivalCreateResponse;
 import com.daedan.festabook.festival.dto.FestivalGeographyResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequest;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideResponse;
 import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateResponse;
 import com.daedan.festabook.festival.dto.FestivalResponse;
@@ -52,6 +53,11 @@ public class FestivalService {
                 universityName
         );
         return FestivalUniversityResponses.from(festivals);
+    }
+
+    public FestivalLostItemGuideResponse getFestivalLostItemGuide(Long festivalId) {
+        Festival festival = getFestivalById(festivalId);
+        return FestivalLostItemGuideResponse.from(festival);
     }
 
     @Transactional

--- a/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
             "/festivals/universities",
             "/festivals/geography",
             "/festivals/notifications/*",
+            "/festivals/lost-item-guide",
             "/lost-items",
             "/questions",
             "/lineups",

--- a/backend/src/main/resources/db/migration/V8__festival_lost_item_add.sql
+++ b/backend/src/main/resources/db/migration/V8__festival_lost_item_add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE festival
+    ADD COLUMN lost_item_guide VARCHAR(1000) NOT NULL DEFAULT '분실물 습득/수령 가이드를 추가하여주십시오';

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -299,7 +299,7 @@ class FestivalControllerTest {
                     .get("/festivals/universities?universityName={universityName}", universityNameToSearch)
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("size()", equalTo(expectedSize))
+                    .body("$", hasSize(expectedSize))
 
                     .body("[0].size()", equalTo(expectedFieldSize))
                     .body("[0].festivalId", equalTo(festival1.getId().intValue()))
@@ -335,7 +335,7 @@ class FestivalControllerTest {
                     .get("/festivals/universities?universityName={universityName}", universityNameToSearch)
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("size()", equalTo(expectedSize))
+                    .body("$", hasSize(expectedSize))
 
                     .body("[0].festivalId", equalTo(festival1.getId().intValue()))
                     .body("[0].universityName", equalTo(festival1.getUniversityName()));
@@ -359,7 +359,7 @@ class FestivalControllerTest {
                     .get("/festivals/universities?universityName={universityName}", universityNameToSearch)
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("size()", equalTo(expectedSize));
+                    .body("$", hasSize(expectedSize));
 
             festivalJpaRepository.delete(festival);
         }
@@ -384,6 +384,29 @@ class FestivalControllerTest {
                     .statusCode(HttpStatus.OK.value())
                     .body("[0].festivalId", equalTo(userVisibleTrueFestival.getId().intValue()))
                     .body("[0].universityName", equalTo(userVisibleTrueFestival.getUniversityName()));
+        }
+    }
+
+    @Nested
+    class getFestivalLostItemGuide {
+        @Test
+        void 성공() {
+            String lostItemGuide = "습득하신 분실물은 밀러에게 전달하시기 바랍니다.";
+            Festival festival = FestivalFixture.createWithLostItemGuide(lostItemGuide);
+            festivalJpaRepository.save(festival);
+
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header("festival", festival.getId())
+                    .when()
+                    .get("/festivals/lost-item-guide")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("lostItemGuide", equalTo(lostItemGuide));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -18,6 +18,7 @@ import com.daedan.festabook.festival.dto.FestivalImageSequenceUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalImageSequenceUpdateRequestFixture;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequestFixture;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideUpdateRequest;
 import com.daedan.festabook.festival.infrastructure.FestivalImageJpaRepository;
 import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
 import com.daedan.festabook.global.security.JwtTestHelper;
@@ -92,7 +93,8 @@ class FestivalControllerTest {
                     LocalDate.of(2025, 8, 25),
                     7,
                     new Coordinate(37.5862037, 127.0565152),
-                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925))
+                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925)),
+                    "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요."
             );
 
             Festival festival = FestivalFixture.create();
@@ -425,6 +427,35 @@ class FestivalControllerTest {
                     .body("startDate", equalTo(changedStartDate.toString()))
                     .body("endDate", equalTo(changedEndDate.toString()))
                     .body("userVisible", equalTo(userVisible));
+        }
+    }
+
+    @Nested
+    class updateFestivalLostItemGuide {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Header authorizationHeader = jwtTestHelper.createAuthorizationHeader(festival);
+            FestivalLostItemGuideUpdateRequest request = new FestivalLostItemGuideUpdateRequest("수정된 가이드");
+
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .header(authorizationHeader)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .patch("/festivals/lost-item-guide")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("lostItemGuide", equalTo(request.lostItemGuide()));
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -93,8 +93,7 @@ class FestivalControllerTest {
                     LocalDate.of(2025, 8, 25),
                     7,
                     new Coordinate(37.5862037, 127.0565152),
-                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925)),
-                    "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요."
+                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925))
             );
 
             Festival festival = FestivalFixture.create();

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalFixture.java
@@ -18,6 +18,7 @@ public class FestivalFixture {
             new Coordinate(37.5801841, 127.0562684),
             new Coordinate(37.5839591, 127.0638215)
     );
+    private static final String DEFAULT_LOST_ITEM_GUIDE = "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요.";
 
     public static Festival create() {
         return new Festival(
@@ -28,7 +29,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -43,7 +45,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -58,7 +61,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 zoom,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -74,7 +78,8 @@ public class FestivalFixture {
                 userVisible,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -89,7 +94,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 centerCoordinate,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -104,7 +110,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                polygonHoleBoundary
+                polygonHoleBoundary,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -119,7 +126,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
         BaseEntityTestHelper.setId(festival, festivalId);
         return festival;
@@ -137,7 +145,8 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 
@@ -155,7 +164,24 @@ public class FestivalFixture {
                 DEFAULT_USER_VISIBLE,
                 DEFAULT_ZOOM,
                 DEFAULT_CENTER_COORDINATE,
-                DEFAULT_POLYGON_HOLE_BOUNDARY
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                DEFAULT_LOST_ITEM_GUIDE
+        );
+    }
+
+    public static Festival createWithLostItemGuide(
+            String lostItemGuide
+    ) {
+        return new Festival(
+                DEFAULT_UNIVERSITY_NAME,
+                DEFAULT_FESTIVAL_NAME,
+                DEFAULT_START_DATE,
+                DEFAULT_END_DATE,
+                DEFAULT_USER_VISIBLE,
+                DEFAULT_ZOOM,
+                DEFAULT_CENTER_COORDINATE,
+                DEFAULT_POLYGON_HOLE_BOUNDARY,
+                lostItemGuide
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/domain/FestivalTest.java
@@ -17,14 +17,18 @@ import org.junit.jupiter.params.provider.ValueSource;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class FestivalTest {
 
+    private static final int MAX_NAME_LENGTH = 50;
+    private static final int MIN_ZOOM = 0;
+    private static final int MAX_ZOOM = 30;
+    private static final int MAX_LOST_ITEM_GUIDE_LENGTH = 1000;
+
     @Nested
     class validateName {
 
         @Test
         void 성공_경계값() {
             // given
-            int maxNameLength = 50;
-            String name = "미".repeat(maxNameLength);
+            String name = "m".repeat(MAX_NAME_LENGTH);
 
             // when & then
             assertThatCode(() -> FestivalFixture.create(name))
@@ -56,13 +60,12 @@ class FestivalTest {
         @Test
         void 예외_축제_이름_길이_초과() {
             // given
-            int maxNameLength = 50;
-            String invalidName = "미".repeat(maxNameLength + 1);
+            String invalidName = "m".repeat(MAX_NAME_LENGTH + 1);
 
             // when & then
             assertThatThrownBy(() -> FestivalFixture.create(invalidName))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("이름은 50자를 초과할 수 없습니다.");
+                    .hasMessage("이름은 %d자를 초과할 수 없습니다.", MAX_NAME_LENGTH);
         }
     }
 
@@ -128,20 +131,15 @@ class FestivalTest {
         }
     }
 
-
     @Nested
     class validateZoom {
 
         @Test
         void 성공_경계값() {
-            // given
-            Integer minZoom = 0;
-            Integer maxZoom = 30;
-
-            // when & then
+            // given & when & then
             assertThatCode(() -> {
-                FestivalFixture.create(minZoom);
-                FestivalFixture.create(maxZoom);
+                FestivalFixture.create(MIN_ZOOM);
+                FestivalFixture.create(MAX_ZOOM);
             })
                     .doesNotThrowAnyException();
         }
@@ -158,14 +156,14 @@ class FestivalTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {-1, 31})
+        @ValueSource(ints = {MIN_ZOOM - 1, MAX_ZOOM + 1})
         void 예외_줌_범위_초과(Integer zoom) {
             // given
 
             // when & then
             assertThatThrownBy(() -> FestivalFixture.create(zoom))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("줌은 0 이상 30 이하이어야 합니다.");
+                    .hasMessage("줌은 %d 이상 %d 이하이어야 합니다.", MIN_ZOOM, MAX_ZOOM);
         }
     }
 
@@ -227,6 +225,53 @@ class FestivalTest {
             assertThatThrownBy(() -> FestivalFixture.create(polygonHoleBoundary))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("폴리곤 내부 구멍 좌표 리스트는 비어있을 수 없습니다.");
+        }
+    }
+
+    @Nested
+    class validateLostItemGuide {
+
+        @Test
+        void 성공_경계값() {
+            // given
+            String lostItemGuide = "m".repeat(MAX_LOST_ITEM_GUIDE_LENGTH);
+
+            // when & then
+            assertThatCode(() -> FestivalFixture.createWithLostItemGuide(lostItemGuide))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 예외_축제_분실물_가이드_null() {
+            // given
+            String lostItemGuide = null;
+
+            // when & then
+            assertThatThrownBy(() -> FestivalFixture.createWithLostItemGuide(lostItemGuide))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("분실물 가이드는 비어 있을 수 없습니다.");
+        }
+
+        @Test
+        void 예외_축제_분실물_가이드_blank() {
+            // given
+            String lostItemGuide = " ";
+
+            // when & then
+            assertThatThrownBy(() -> FestivalFixture.createWithLostItemGuide(lostItemGuide))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("분실물 가이드는 비어 있을 수 없습니다.");
+        }
+
+        @Test
+        void 예외_축제_분실물_가이드_초과() {
+            // given
+            String lostItemGuide = "m".repeat(MAX_LOST_ITEM_GUIDE_LENGTH + 1);
+
+            // when & then
+            assertThatThrownBy(() -> FestivalFixture.createWithLostItemGuide(lostItemGuide))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("분실물 가이드는 %d자를 초과할 수 없습니다.", MAX_LOST_ITEM_GUIDE_LENGTH);
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/dto/FestivalCreateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/dto/FestivalCreateRequestFixture.java
@@ -13,7 +13,8 @@ public class FestivalCreateRequestFixture {
             LocalDate endDate,
             Integer zoom,
             Coordinate centerCoordinate,
-            List<Coordinate> polygonHoleBoundary
+            List<Coordinate> polygonHoleBoundary,
+            String lostItemGuide
     ) {
         return new FestivalCreateRequest(
                 universityName,
@@ -22,7 +23,8 @@ public class FestivalCreateRequestFixture {
                 endDate,
                 zoom,
                 centerCoordinate,
-                polygonHoleBoundary
+                polygonHoleBoundary,
+                lostItemGuide
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/dto/FestivalCreateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/dto/FestivalCreateRequestFixture.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 public class FestivalCreateRequestFixture {
 
+    private static final String DEFAULT_LOST_ITEM_GUIDE = "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요.";
+
     public static FestivalCreateRequest create(
             String universityName,
             String festivalName,
@@ -13,8 +15,7 @@ public class FestivalCreateRequestFixture {
             LocalDate endDate,
             Integer zoom,
             Coordinate centerCoordinate,
-            List<Coordinate> polygonHoleBoundary,
-            String lostItemGuide
+            List<Coordinate> polygonHoleBoundary
     ) {
         return new FestivalCreateRequest(
                 universityName,
@@ -24,7 +25,7 @@ public class FestivalCreateRequestFixture {
                 zoom,
                 centerCoordinate,
                 polygonHoleBoundary,
-                lostItemGuide
+                DEFAULT_LOST_ITEM_GUIDE
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
@@ -17,6 +17,7 @@ import com.daedan.festabook.festival.dto.FestivalGeographyResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationResponse;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequest;
 import com.daedan.festabook.festival.dto.FestivalInformationUpdateRequestFixture;
+import com.daedan.festabook.festival.dto.FestivalLostItemGuideResponse;
 import com.daedan.festabook.festival.dto.FestivalResponse;
 import com.daedan.festabook.festival.dto.FestivalUniversityResponses;
 import com.daedan.festabook.festival.infrastructure.FestivalImageJpaRepository;
@@ -210,6 +211,26 @@ class FestivalServiceTest {
             // then
             assertThat(results.responses().get(0).universityName())
                     .isEqualTo(userVisibleTrueFestival.getUniversityName());
+        }
+    }
+
+    @Nested
+    class getFestivalLostItemGuide {
+
+        @Test
+        void 성공() {
+            // given
+            String lostItemGuide = "습득하신 분실물은 타마에게 전달하시기 바랍니다.";
+            Festival festival = FestivalFixture.createWithLostItemGuide(lostItemGuide);
+
+            given(festivalJpaRepository.findById(festival.getId()))
+                    .willReturn(Optional.of(festival));
+
+            // when
+            FestivalLostItemGuideResponse result = festivalService.getFestivalLostItemGuide(festival.getId());
+
+            // then
+            assertThat(result.lostItemGuide()).isEqualTo(lostItemGuide);
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
@@ -61,8 +61,7 @@ class FestivalServiceTest {
                     LocalDate.of(2025, 8, 25),
                     7,
                     new Coordinate(37.5862037, 127.0565152),
-                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925)),
-                    "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요."
+                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925))
             );
 
             // when

--- a/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/service/FestivalServiceTest.java
@@ -60,7 +60,8 @@ class FestivalServiceTest {
                     LocalDate.of(2025, 8, 25),
                     7,
                     new Coordinate(37.5862037, 127.0565152),
-                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925))
+                    List.of(new Coordinate(37.5862037, 127.0565152), new Coordinate(37.5845543, 127.0555925)),
+                    "습득하신 분실물 혹은 수령 문의는 학생회 인스타그램 DM으로 전송해주세요."
             );
 
             // when
@@ -193,9 +194,7 @@ class FestivalServiceTest {
         @Test
         void 성공_userVisible_true만_반환됨() {
             // given
-            String userVisibleFalseFestivalName = "후유바보대학교";
             String userVisibleTrueFestivalName = "미소대학교";
-            Festival userVisibleFalseFestival = FestivalFixture.create(userVisibleFalseFestivalName, false);
             Festival userVisibleTrueFestival = FestivalFixture.create(userVisibleTrueFestivalName, true);
 
             String universityNameToSearch = "미소";


### PR DESCRIPTION
## #️⃣ 이슈 번호

#734 

<br>

## 🛠️ 작업 내용

- 분실물 페이지에서 보여줄 안내 메시지 수정하는 API 구현
- 분실물 페이지에서 보여줄 안내 메시지 조회하는 API 구현
- 분실물 필드 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 축제에 '분실물 안내 가이드' 필드 추가 및 조회(PUBLIC GET)/수정(COUNCIL PATCH) API 추가.
  * 축제 생성 시 분실물 안내 가이드 입력 가능.
* **테스트**
  * 분실물 안내 가이드 생성·조회·수정 및 유효성(비어있음·최대 1000자) 검증 테스트 추가·보강.
* **작업**
  * DB 마이그레이션으로 컬럼 및 기본 안내문 추가.
  * 보안 설정에 GET 엔드포인트 화이트리스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->