### PR TITLE
[AN] 인앱 업데이트 addOnFailureListener 로직 수정하여 크래시 방지

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/splash/AppVersionManager.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/splash/AppVersionManager.kt
@@ -30,7 +30,11 @@ class AppVersionManager(
                         ),
                     )
                 }.addOnFailureListener { e ->
-                    continuation.resumeWith(Result.failure(e))
+                    continuation.resumeWith(
+                        Result.success(
+                            Result.failure(e),
+                        ),
+                    )
                 }
         }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/823

<br>

## 🛠️ 작업 내용

- 인앱 업데이트에서 addOnFailure 로직을 수정하여 크래시를 방지했습니다
addOnFailureListener가 정상 작동하는 것을 확인하여, resumeWith 메서드에 Result 객체를 한 번더 감싸서 전달하도록 변경했습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 앱 업데이트 확인 과정의 오류 처리를 개선해 실패 상황에서도 앱이 중단되지 않고 안정적으로 동작합니다.
  - 일시적 네트워크/서비스 오류 시에도 일관된 결과를 제공하여 업데이트 알림의 신뢰성을 높였습니다.
  - 예외 상황 처리 로직을 정비해 예외가 사용자 경험에 미치는 영향을 최소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->