### PR TITLE
[FE] 분실물 습득/수령 가이드 학생회 페이지 추가

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,0 @@
-VITE_API_HOST="http://localhost/api"

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_HOST="http://localhost/api"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,7 @@ import LineupAddModal from './components/modals/LineupAddModal';
 import LineupEditModal from './components/modals/LineupEditModal';
 import PushNotificationConfirmModal from './components/modals/PushNotificationConfirmModal';
 import PasswordChangeModal from './components/modals/PasswordChangeModal';
+import LostItemGuideModal from './components/modals/LostItemGuideModal';
 
 // Common Components
 import Toast from './components/common/Toast';
@@ -96,6 +97,7 @@ function App() {
             case 'add-image': return <AddImageModal isOpen={true} {...allProps} />;
             case 'pushNotificationConfirm': return <PushNotificationConfirmModal {...allProps} onConfirm={() => { props.onConfirm(); closeModal(); }} onCancel={closeModal} />;
             case 'passwordChange': return <PasswordChangeModal isOpen={true} {...allProps} />;
+            case 'lostItemGuide': return <LostItemGuideModal {...allProps} />;
             
             default: return null;
         }

--- a/frontend/src/components/modals/LostItemGuideModal.jsx
+++ b/frontend/src/components/modals/LostItemGuideModal.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import Modal from '../common/Modal';
+
+const LostItemGuideModal = ({ initialGuide, onSave, onClose }) => {
+    const [guide, setGuide] = useState('');
+
+    useEffect(() => {
+        setGuide(initialGuide || '');
+    }, [initialGuide]);
+
+    return (
+        <Modal isOpen={true} onClose={onClose} maxWidth="max-w-xl">
+            <div className="p-6">
+                <h2 className="text-2xl font-bold text-gray-900 mb-4">분실물 안내 수정</h2>
+                <div className="flex items-center justify-between mb-3">
+                    <p className="text-gray-500 text-sm">분실물 수령/제보 가이드를 입력하세요.</p>
+                    <span className="text-xs text-gray-400">{guide.length}/1000</span>
+                </div>
+                <textarea
+                    value={guide}
+                    onChange={(e) => setGuide(e.target.value)}
+                    rows={6}
+                    placeholder="예) 분실물을 발견하시면 운영본부로 제출해 주세요..."
+                    maxLength={1000}
+                    className="w-full border border-gray-300 rounded-md p-3 focus:outline-none focus:ring-2 focus:ring-gray-800"
+                />
+                <div className="flex justify-end gap-2 mt-4">
+                    <button onClick={onClose} className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300">취소</button>
+                    <button
+                        onClick={() => { onSave(guide); onClose(); }}
+                        className="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900"
+                        disabled={!guide.trim() || guide.length > 1000}
+                    >저장</button>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default LostItemGuideModal;
+
+

--- a/frontend/src/data/initialData.js
+++ b/frontend/src/data/initialData.js
@@ -1,4 +1,5 @@
 export const initialData = {
+    lostItemGuide: '분실물을 발견하신 경우 가까운 운영본부 또는 안내 데스크에 제출해주세요. 수령을 원하시는 분은 신분증을 지참하시고 보관 장소로 방문해 주세요.',
     notices: [
         { id: 1, title: '2025 대학 축제에 오신 것을 환영합니다!', content: '축제 기간 동안 다양한 이벤트와 공연이 준비되어 있으니 마음껏 즐겨주세요!', date: '2025-07-18', pinned: true },
         { id: 2, title: '분실물 센터 안내', content: '분실물은 학생회관 101호에서 보관하고 있습니다.', date: '2025-07-17', pinned: true },

--- a/frontend/src/pages/LostItemPage.jsx
+++ b/frontend/src/pages/LostItemPage.jsx
@@ -13,7 +13,7 @@ function formatDate(dateString) {
 }
 
 const LostItemPage = () => {
-    const { lostItems, toggleLostItemStatus, addLostItem, updateLostItem, deleteLostItem, fetchLostItems } = useData();
+    const { lostItems, lostItemGuide, updateLostItemGuide, toggleLostItemStatus, addLostItem, updateLostItem, deleteLostItem, fetchLostItems } = useData();
     const { openModal, showToast } = useModal();
     const [selectedImage, setSelectedImage] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -84,6 +84,20 @@ const LostItemPage = () => {
                     >
                         <i className="fas fa-plus mr-2"></i> 분실물 등록
                     </button>
+                </div>
+            </div>
+
+            {/* 가이드 카드 */}
+            <div className="bg-white border border-gray-200 rounded-lg p-5 mb-6 shadow-sm">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h3 className="text-lg font-semibold mb-1">분실물 수령/제보 가이드</h3>
+                        <p className="text-gray-600 whitespace-pre-line">{lostItemGuide || '가이드를 등록해 주세요.'}</p>
+                    </div>
+                    <button
+                        onClick={() => openModal('lostItemGuide', { initialGuide: lostItemGuide, onSave: (text) => updateLostItemGuide(text, showToast) })}
+                        className="text-blue-600 hover:text-blue-800 font-bold shrink-0"
+                    >수정</button>
                 </div>
             </div>
             

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -106,6 +106,29 @@ export const festivalAPI = {
     }
   },
 
+  // 분실물 가이드 조회
+  getLostItemGuide: async () => {
+    try {
+      const response = await api.get('/festivals/lost-item-guide');
+      // 응답 구조 문서 상과 실제는 다를 수 있으나, 여기서는 lostItemGuide만 추출하도록 가정
+      return response.data?.lostItemGuide ?? '';
+    } catch (error) {
+      console.error('Failed to fetch lost item guide:', error);
+      throw new Error('분실물 가이드 조회에 실패했습니다.');
+    }
+  },
+
+  // 분실물 가이드 수정
+  updateLostItemGuide: async (lostItemGuide) => {
+    try {
+      const response = await api.patch('/festivals/lost-item-guide', { lostItemGuide });
+      return response.data?.lostItemGuide ?? lostItemGuide;
+    } catch (error) {
+      console.error('Failed to update lost item guide:', error);
+      throw new Error('분실물 가이드 수정에 실패했습니다.');
+    }
+  },
+
   // 축제 정보 수정
   updateFestivalInfo: async (festivalInfo) => {
     try {


### PR DESCRIPTION
## #️⃣ 이슈 번호

#825 

<br>

## 🛠️ 작업 내용

- 분실물 습득 및 수령 가이드를 학생회 페이지에서 조회/수정 가능하도록 연결

<br>

## 📸 이미지 첨부 (Optional)
<img width="1397" height="751" alt="image" src="https://github.com/user-attachments/assets/e659402c-c2a6-414b-b69c-e53611997cc0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 분실물 페이지에 분실물 안내 가이드를 카드 형태로 표시하고, 수정 버튼을 통해 내용을 편집할 수 있습니다.
  - 가이드 편집 모달 추가: 실시간 글자 수 표시, 최대 1000자 제한, 공백만 입력 시 저장 비활성화. 저장 시 즉시 화면에 반영됩니다.
  - 가이드 내용은 서버와 동기화되어 조회·수정이 가능합니다. 오류 시 알림이 표시됩니다.

- 작업
  - 프런트엔드에서 환경 변수 파일(.env)을 버전 관리에서 제외했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->