### PR TITLE
[FE] DEV 환경 프론트엔드 빌드시 업로드 된 이미지가 사라지는 버그 수정 

### DIFF
--- a/.github/workflows/frontend-ci-cd-dev.yml
+++ b/.github/workflows/frontend-ci-cd-dev.yml
@@ -36,14 +36,22 @@ jobs:
         working-directory: ./frontend
 
       # 빌드 파일 /home/ubuntu/2025-festabook/static/frontend/dist 이동
+      # 이미지 저장 경로 디렉토리 생성 /home/ubuntu/2025-festabook/static/images
       - name: Move build files
         run: |
           DEPLOY_PATH="/home/ubuntu/2025-festabook/static/frontend"
-          SOURCE_PATH="./frontend/dist"
+          BUILD_DIST_PATH="./frontend/dist/"
+          LOCAL_IMAGES_PATH="/home/ubuntu/2025-festabook/static/images"
+          
+          # 기존 빌드 파일 삭제
+          sudo rm -rf "${DEPLOY_PATH}"
 
+          # 디렉토리 생성
           sudo mkdir -p "${DEPLOY_PATH}"
-          sudo rm -rf "${DEPLOY_PATH}/dist"
-          sudo cp -r "${SOURCE_PATH}" "${DEPLOY_PATH}"
+          sudo mkdir -p "${LOCAL_IMAGES_PATH}"
+
+          # 빌드 결과물 이동
+          sudo cp -r "${BUILD_DIST_PATH}" "${DEPLOY_PATH}"
           sudo chmod -R 755 "${DEPLOY_PATH}"
 
           echo "Build files moved to ${DEPLOY_PATH}."


### PR DESCRIPTION
## #️⃣ 이슈 번호

# 829

<br>

## 🛠️ 작업 내용

CD 스크립트 변경 작업 진행했습니다.

1. 이미지 저장 경로를 변경하기 위해 백엔드에서사용하는 appication-secret.yml이 변경되었습니다.
/home/ubuntu/2025-festabook/static/frontend/dist →
/home/ubuntu/2025-festabook/static
2. nginx 설정 값이 변경되었습니다.
프론트엔드 빌드 정적 파일 위치와 images 정적 파일 위치를 구별하도록 변경합니다.
상세 내용은 노션 ‘우분투 nginx 설정하기’ 항목을 참고해주세요.
3. 프론트엔드 CD 스크립트가 변경되었습니다.
- 이전 프론트엔드 빌드 파일 삭제
- 필요한 디렉토리 생성
- 빌드 결과물 이동
