### PR TITLE
[AN] MainActivity 에서 settingViewModel의 saveNotificationId 호출하도록 변경

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
@@ -1,11 +1,14 @@
 package com.daedan.festabook.data.datasource.local
 
 interface FestivalNotificationLocalDataSource {
-    fun saveFestivalNotificationId(festivalNotificationId: Long)
+    fun saveFestivalNotificationId(
+        festivalId: Long,
+        festivalNotificationId: Long,
+    )
 
-    fun getFestivalNotificationId(): Long
+    fun getFestivalNotificationId(festivalId: Long): Long
 
-    fun deleteFestivalNotificationId()
+    fun deleteFestivalNotificationId(festivalId: Long)
 
     fun clearAll()
 

--- a/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -6,14 +6,18 @@ import androidx.core.content.edit
 class FestivalNotificationLocalDataSourceImpl(
     private val prefs: SharedPreferences,
 ) : FestivalNotificationLocalDataSource {
-    override fun saveFestivalNotificationId(festivalNotificationId: Long) {
-        prefs.edit { putLong(KEY_FESTIVAL_NOTIFICATION_ID, festivalNotificationId) }
+    override fun saveFestivalNotificationId(
+        festivalId: Long,
+        festivalNotificationId: Long,
+    ) {
+        prefs.edit { putLong("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId", festivalNotificationId) }
     }
 
-    override fun getFestivalNotificationId(): Long = prefs.getLong(KEY_FESTIVAL_NOTIFICATION_ID, DEFAULT_FESTIVAL_NOTIFICATION_ID)
+    override fun getFestivalNotificationId(festivalId: Long): Long =
+        prefs.getLong("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId", DEFAULT_FESTIVAL_NOTIFICATION_ID)
 
-    override fun deleteFestivalNotificationId() {
-        prefs.edit { remove(KEY_FESTIVAL_NOTIFICATION_ID) }
+    override fun deleteFestivalNotificationId(festivalId: Long) {
+        prefs.edit { remove("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId") }
     }
 
     override fun clearAll() {

--- a/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -34,18 +34,18 @@ class FestivalNotificationRepositoryImpl(
         return result
             .mapCatching {
                 festivalNotificationLocalDataSource.saveFestivalNotificationId(
+                    festivalId,
                     it.festivalNotificationId,
                 )
             }
     }
 
     override suspend fun deleteFestivalNotification(): Result<Unit> {
-        val festivalNotificationId = festivalNotificationLocalDataSource.getFestivalNotificationId()
-
+        val festivalId = festivalLocalDataSource.getFestivalId() ?: return Result.failure(IllegalStateException())
+        val festivalNotificationId = festivalNotificationLocalDataSource.getFestivalNotificationId(festivalId)
         val response =
             festivalNotificationDataSource.deleteFestivalNotification(festivalNotificationId)
-
-        festivalNotificationLocalDataSource.deleteFestivalNotificationId()
+        festivalNotificationLocalDataSource.deleteFestivalNotificationId(festivalId)
 
         return response.toResult()
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/FragmentUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/FragmentUtil.kt
@@ -107,6 +107,25 @@ fun Activity.showErrorSnackBar(exception: Throwable?) {
     }
 }
 
+fun Activity.showSnackBar(msg: String) {
+    val snackBar =
+        Snackbar.make(
+            findViewById<ViewGroup>(android.R.id.content).getChildAt(0),
+            msg,
+            Snackbar.LENGTH_SHORT,
+        )
+    snackBar.setAnchorView(
+        findViewById<FloatingActionButton>(R.id.bab_menu),
+    )
+    snackBar
+        .setAction(
+            getString(R.string.fail_snackbar_confirm),
+        ) {
+            snackBar.dismiss()
+        }.setActionTextColor(getColor(R.color.blue400))
+    snackBar.show()
+}
+
 fun View.placeListBottomSheetFollowBehavior(): PlaceListBottomSheetFollowBehavior? {
     val params = layoutParams as? CoordinatorLayout.LayoutParams
     return params?.behavior as? PlaceListBottomSheetFollowBehavior

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -107,8 +107,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                 .sortedBy { it.sequence }
                 .map { it.imageUrl }
 
-        posterAdapter.submitList(posterUrls) {
-            scrollToInitialPosition(posterUrls.size)
+        if (!posterUrls.isEmpty()) {
+            posterAdapter.submitList(posterUrls) {
+                scrollToInitialPosition(posterUrls.size)
+            }
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -31,6 +31,7 @@ import com.daedan.festabook.presentation.news.NewsFragment
 import com.daedan.festabook.presentation.placeList.placeMap.PlaceMapFragment
 import com.daedan.festabook.presentation.schedule.ScheduleFragment
 import com.daedan.festabook.presentation.setting.SettingFragment
+import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import timber.log.Timber
 
@@ -43,6 +44,7 @@ class MainActivity :
 
     private val mainViewModel: MainViewModel by viewModels { MainViewModel.Factory }
     private val homeViewModel: HomeViewModel by viewModels { HomeViewModel.Factory }
+    private val settingViewModel: SettingViewModel by viewModels { SettingViewModel.factory() }
 
     private val placeMapFragment by lazy {
         PlaceMapFragment().newInstance()
@@ -78,14 +80,17 @@ class MainActivity :
         ) { isGranted: Boolean ->
             if (isGranted) {
                 Timber.d("Notification permission granted")
-                mainViewModel.saveNotificationId()
+                onPermissionGranted()
             } else {
                 Timber.d("Notification permission denied")
                 showNotificationDeniedSnackbar(window.decorView.rootView, this)
+                onPermissionDenied()
             }
         }
 
-    override fun onPermissionGranted() = Unit
+    override fun onPermissionGranted() {
+        settingViewModel.saveNotificationId()
+    }
 
     override fun onPermissionDenied() = Unit
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -23,6 +23,7 @@ import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.isGranted
 import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
+import com.daedan.festabook.presentation.common.showSnackBar
 import com.daedan.festabook.presentation.common.showToast
 import com.daedan.festabook.presentation.common.toLocationPermissionDeniedTextOrNull
 import com.daedan.festabook.presentation.home.HomeFragment
@@ -157,6 +158,9 @@ class MainActivity :
             if (isFirstVisit) {
                 showAlarmDialog()
             }
+        }
+        settingViewModel.success.observe(this) {
+            showSnackBar(getString(R.string.setting_notice_enabled))
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/main/MainViewModel.kt
@@ -73,19 +73,6 @@ class MainViewModel(
         }
     }
 
-    fun saveNotificationId() {
-        viewModelScope.launch {
-            val result = festivalNotificationRepository.saveFestivalNotification()
-
-            result
-                .onSuccess {
-                    festivalNotificationRepository.setFestivalNotificationIsAllow(true)
-                }.onFailure {
-                    Timber.e("${::MainViewModel.javaClass.simpleName}: FestivalNotificationId 저장에 실패했습니다.")
-                }
-        }
-    }
-
     private fun registerDevice(
         uuid: String,
         fcmToken: String,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -23,7 +23,7 @@ import timber.log.Timber
 class SettingFragment :
     BaseFragment<FragmentSettingBinding>(R.layout.fragment_setting),
     NotificationPermissionRequester {
-    private val settingViewModel: SettingViewModel by viewModels {
+    private val settingViewModel: SettingViewModel by viewModels({ requireActivity() }) {
         SettingViewModel.factory()
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -16,6 +16,7 @@ import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
+import com.daedan.festabook.presentation.common.showSnackBar
 import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.home.adapter.FestivalUiState
 import timber.log.Timber
@@ -87,6 +88,9 @@ class SettingFragment :
         }
         settingViewModel.isAllowed.observe(viewLifecycleOwner) {
             binding.btnNoticeAllow.isChecked = it
+        }
+        settingViewModel.success.observe(viewLifecycleOwner) {
+            requireActivity().showSnackBar(getString(R.string.setting_notice_enabled))
         }
         settingViewModel.error.observe(viewLifecycleOwner) { throwable ->
             showErrorSnackBar(throwable)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -32,6 +32,9 @@ class SettingViewModel(
     private val _isLoading: MutableLiveData<Boolean> = MutableLiveData(false)
     val isLoading: LiveData<Boolean> get() = _isLoading
 
+    private val _success: SingleLiveData<Unit> = SingleLiveData()
+    val success: LiveData<Unit> get() = _success
+
     fun notificationAllowClick() {
         if (_isAllowed.value == false) {
             _permissionCheckEvent.setValue(Unit)
@@ -55,6 +58,7 @@ class SettingViewModel(
         // Optimistic UI 적용, 요청 실패 시 원복
         saveNotificationIsAllowed(true)
         updateNotificationIsAllowed(true)
+        _success.setValue(Unit)
 
         viewModelScope.launch {
             val result =

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="setting_contact_us">개발자 문의하기</string>
     <string name="setting_contact_us_email_subject">개발자 문의하기</string>
     <string name="setting_contact_us_email">festabook2025@gmail.com</string>
+    <string name="setting_notice_enabled">알림이 설정되었습니다</string>
 
     <!-- icon description -->
     <string name="iv_speaker">speaker</string>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/837

<br>

## 🛠️ 작업 내용

- MainActivity 에서 settingViewModel의 saveNotificationId 호출하도록 변경

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 권한 거부 시 스낵바 안내 후 후속 처리가 누락되던 문제를 보완했습니다.
  - 포스터 목록이 비어 있을 때 발생하던 스크롤/크래시를 방지했습니다.
- Refactor
  - 알림 권한 처리 흐름을 중앙화해 허용/거부 후 동작을 일관되게 처리하도록 정리했습니다.
  - 설정 관련 상태를 액티비티 범위로 공유해 화면 전환 시 동기화를 개선했습니다.
- New Features
  - 축제별(페스티벌 단위) 알림 저장/삭제가 가능해졌습니다.
  - 알림 설정 성공 시 표시되는 안내 문자열("알림이 설정되었습니다")을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->