### PR TITLE
[BE] Lineup Entity 검증 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/lineup/domain/Lineup.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/domain/Lineup.java
@@ -38,7 +38,6 @@ public class Lineup extends BaseEntity implements Comparable<Lineup> {
     @Column(nullable = false)
     private String imageUrl;
 
-    // todo : 추후 event 테이블 조인 고려
     @Column(nullable = false)
     private LocalDateTime performanceAt;
 

--- a/backend/src/main/java/com/daedan/festabook/lineup/domain/Lineup.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/domain/Lineup.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.lineup.domain;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.global.domain.BaseEntity;
+import com.daedan.festabook.global.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -16,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Getter
@@ -35,7 +38,6 @@ public class Lineup extends BaseEntity implements Comparable<Lineup> {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
     private String imageUrl;
 
     @Column(nullable = false)
@@ -47,6 +49,8 @@ public class Lineup extends BaseEntity implements Comparable<Lineup> {
             String imageUrl,
             LocalDateTime performanceAt
     ) {
+        validateName(name);
+
         this.festival = festival;
         this.name = name;
         this.imageUrl = imageUrl;
@@ -54,6 +58,8 @@ public class Lineup extends BaseEntity implements Comparable<Lineup> {
     }
 
     public void updateLineup(String name, String imageUrl, LocalDateTime performanceAt) {
+        validateName(name);
+
         this.name = name;
         this.imageUrl = imageUrl;
         this.performanceAt = performanceAt;
@@ -61,6 +67,12 @@ public class Lineup extends BaseEntity implements Comparable<Lineup> {
 
     public boolean isFestivalIdEqualTo(Long festivalId) {
         return this.getFestival().getId().equals(festivalId);
+    }
+
+    private void validateName(String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new BusinessException("이름은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 
     @Override

--- a/backend/src/main/java/com/daedan/festabook/lineup/infrastructure/LineupJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/infrastructure/LineupJpaRepository.java
@@ -1,10 +1,13 @@
 package com.daedan.festabook.lineup.infrastructure;
 
 import com.daedan.festabook.lineup.domain.Lineup;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineupJpaRepository extends JpaRepository<Lineup, Long> {
 
     List<Lineup> findAllByFestivalId(Long festivalId);
+
+    boolean existsByFestivalIdAndPerformanceAt(Long festivalId, LocalDateTime performanceAt);
 }

--- a/backend/src/main/java/com/daedan/festabook/lineup/service/LineupService.java
+++ b/backend/src/main/java/com/daedan/festabook/lineup/service/LineupService.java
@@ -9,6 +9,7 @@ import com.daedan.festabook.lineup.dto.LineupResponse;
 import com.daedan.festabook.lineup.dto.LineupResponses;
 import com.daedan.festabook.lineup.dto.LineupUpdateRequest;
 import com.daedan.festabook.lineup.infrastructure.LineupJpaRepository;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +26,10 @@ public class LineupService {
 
     public LineupResponse addLineup(Long festivalId, LineupRequest request) {
         Festival festival = getFestivalById(festivalId);
+        validateLineupPerformanceAtDuplicate(festival, request.performanceAt());
 
         Lineup lineup = request.toEntity(festival);
         Lineup savedLineup = lineupJpaRepository.save(lineup);
-
         return LineupResponse.from(savedLineup);
     }
 
@@ -41,7 +42,9 @@ public class LineupService {
     @Transactional
     public LineupResponse updateLineup(Long festivalId, Long lineupId, LineupUpdateRequest request) {
         Lineup lineup = getLineupById(lineupId);
+
         validateLineupBelongsToFestival(lineup, festivalId);
+        validateLineupPerformanceAtDuplicate(lineup.getFestival(), request.performanceAt());
 
         lineup.updateLineup(request.name(), request.imageUrl(), request.performanceAt());
         return LineupResponse.from(lineup);
@@ -52,6 +55,12 @@ public class LineupService {
         validateLineupBelongsToFestival(lineup, festivalId);
 
         lineupJpaRepository.deleteById(lineupId);
+    }
+
+    private void validateLineupPerformanceAtDuplicate(Festival festival, LocalDateTime performanceAt) {
+        if (lineupJpaRepository.existsByFestivalIdAndPerformanceAt(festival.getId(), performanceAt)) {
+            throw new BusinessException("해당 시간에 이미 라인업이 존재합니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 
     private Festival getFestivalById(Long festivalId) {

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
@@ -8,7 +8,7 @@ public class LineupFixture {
 
     private static final String DEFAULT_LINEUP_NAME = "이미소";
     private static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
-    private static final LocalDateTime DEFAULT_PERFORM_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
+    private static final LocalDateTime DEFAULT_PERFORMANCE_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
 
     public static Lineup create(
             Festival festival
@@ -17,7 +17,8 @@ public class LineupFixture {
                 festival,
                 DEFAULT_LINEUP_NAME,
                 DEFAULT_IMAGE_URL,
-                DEFAULT_PERFORM_AT
+                DEFAULT_PERFORMANCE_AT
+
         );
     }
 
@@ -29,7 +30,7 @@ public class LineupFixture {
                 festival,
                 DEFAULT_LINEUP_NAME,
                 DEFAULT_IMAGE_URL,
-                DEFAULT_PERFORM_AT
+                DEFAULT_PERFORMANCE_AT
         );
         BaseEntityTestHelper.setId(lineup, lineupId);
         return lineup;
@@ -37,14 +38,26 @@ public class LineupFixture {
 
     public static Lineup create(
             Festival festival,
+            LocalDateTime performanceAt
+    ) {
+        return new Lineup(
+                festival,
+                DEFAULT_LINEUP_NAME,
+                DEFAULT_IMAGE_URL,
+                performanceAt
+        );
+    }
+
+    public static Lineup create(
+            Festival festival,
             String name,
-            LocalDateTime dateTime
+            LocalDateTime performanceAt
     ) {
         return new Lineup(
                 festival,
                 name,
                 DEFAULT_IMAGE_URL,
-                dateTime
+                performanceAt
         );
     }
 
@@ -52,14 +65,14 @@ public class LineupFixture {
             Festival festival,
             String name,
             String imageUrl,
-            LocalDateTime dateTime,
+            LocalDateTime performanceAt,
             Long lineupId
     ) {
         Lineup lineup = new Lineup(
                 festival,
                 name,
                 imageUrl,
-                dateTime
+                performanceAt
         );
         BaseEntityTestHelper.setId(lineup, lineupId);
         return lineup;

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupFixture.java
@@ -1,11 +1,13 @@
 package com.daedan.festabook.lineup.domain;
 
 import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
 import com.daedan.festabook.global.fixture.BaseEntityTestHelper;
 import java.time.LocalDateTime;
 
 public class LineupFixture {
 
+    private static final Festival DEFAULT_FESTIVAL = FestivalFixture.create();
     private static final String DEFAULT_LINEUP_NAME = "이미소";
     private static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
     private static final LocalDateTime DEFAULT_PERFORMANCE_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
@@ -16,6 +18,18 @@ public class LineupFixture {
         return new Lineup(
                 festival,
                 DEFAULT_LINEUP_NAME,
+                DEFAULT_IMAGE_URL,
+                DEFAULT_PERFORMANCE_AT
+
+        );
+    }
+
+    public static Lineup create(
+            String name
+    ) {
+        return new Lineup(
+                DEFAULT_FESTIVAL,
+                name,
                 DEFAULT_IMAGE_URL,
                 DEFAULT_PERFORMANCE_AT
 

--- a/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/domain/LineupTest.java
@@ -1,15 +1,21 @@
 package com.daedan.festabook.lineup.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.daedan.festabook.festival.domain.Festival;
 import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.global.exception.BusinessException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class LineupTest {
@@ -73,6 +79,29 @@ class LineupTest {
 
             // then
             assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class validateName {
+
+        @Test
+        void 이름_유효성_검증_성공() {
+            // given
+            String name = "비타";
+
+            // when & then
+            assertThatCode(() -> LineupFixture.create(name))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "  "})
+        void 이름_유효성_검증_실패(String invalidName) {
+            assertThatThrownBy(() -> LineupFixture.create(invalidName))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("이름은 비어 있을 수 없습니다.");
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lineup/dto/LineupRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/dto/LineupRequestFixture.java
@@ -6,13 +6,23 @@ public class LineupRequestFixture {
 
     private final static String DEFAULT_LINEUP_NAME = "이미소";
     private final static String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
-    private final static LocalDateTime DEFAULT_PERFORM_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
+    private final static LocalDateTime DEFAULT_PERFORMANCE_AT = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
 
     public static LineupRequest create() {
         return new LineupRequest(
                 DEFAULT_LINEUP_NAME,
                 DEFAULT_IMAGE_URL,
-                DEFAULT_PERFORM_AT
+                DEFAULT_PERFORMANCE_AT
+        );
+    }
+
+    public static LineupRequest create(
+            LocalDateTime performanceAt
+    ) {
+        return new LineupRequest(
+                DEFAULT_LINEUP_NAME,
+                DEFAULT_IMAGE_URL,
+                performanceAt
         );
     }
 

--- a/backend/src/test/java/com/daedan/festabook/lineup/dto/LineupUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/dto/LineupUpdateRequestFixture.java
@@ -6,25 +6,35 @@ public class LineupUpdateRequestFixture {
 
     private static final String DEFAULT_LINEUP_NAME = "김후유";
     private static final String DEFAULT_IMAGE_URL = "https://example.com/updated-image.jpg";
-    private static final LocalDateTime DEFAULT_PERFORM_AT = LocalDateTime.of(2025, 10, 16, 15, 0, 0);
+    private static final LocalDateTime DEFAULT_PERFORMANCE_AT = LocalDateTime.of(2025, 10, 16, 15, 0, 0);
 
     public static LineupUpdateRequest create() {
         return new LineupUpdateRequest(
                 DEFAULT_LINEUP_NAME,
                 DEFAULT_IMAGE_URL,
-                DEFAULT_PERFORM_AT
+                DEFAULT_PERFORMANCE_AT
+        );
+    }
+
+    public static LineupUpdateRequest create(
+            LocalDateTime performanceAt
+    ) {
+        return new LineupUpdateRequest(
+                DEFAULT_LINEUP_NAME,
+                DEFAULT_IMAGE_URL,
+                performanceAt
         );
     }
 
     public static LineupUpdateRequest create(
             String name,
             String imageUrl,
-            LocalDateTime performAt
+            LocalDateTime performanceAt
     ) {
         return new LineupUpdateRequest(
                 name,
                 imageUrl,
-                performAt
+                performanceAt
         );
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/lineup/infrastructure/LineupJpaRepositoryTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/infrastructure/LineupJpaRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.daedan.festabook.lineup.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.lineup.domain.Lineup;
+import com.daedan.festabook.lineup.domain.LineupFixture;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LineupJpaRepositoryTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private LineupJpaRepository lineupJpaRepository;
+
+    @Nested
+    class existsByFestivalIdAndPerformanceAt {
+
+        @Test
+        void 페스티벌ID와_공연시간_일치_데이터_존재_여부() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            LocalDateTime performanceAt = LocalDateTime.of(2025, 10, 1, 18, 0);
+            Lineup lineup = LineupFixture.create(festival, performanceAt);
+            lineupJpaRepository.save(lineup);
+
+            // when
+            boolean exists = lineupJpaRepository.existsByFestivalIdAndPerformanceAt(festival.getId(), performanceAt);
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void 동일_페스티벌ID_다른_공연시간_데이터_존재_여부() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            LocalDateTime savedPerformanceAt = LocalDateTime.of(2025, 10, 1, 18, 0);
+            Lineup savedLineup = LineupFixture.create(festival, savedPerformanceAt);
+            lineupJpaRepository.save(savedLineup);
+
+            LocalDateTime searchPerformanceAt = LocalDateTime.of(2025, 10, 1, 19, 0);
+
+            // when
+            boolean exists = lineupJpaRepository.existsByFestivalIdAndPerformanceAt(festival.getId(),
+                    searchPerformanceAt);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void 동일_공연시간_다른_페스티벌ID_데이터_존재_여부() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            LocalDateTime performanceAt = LocalDateTime.of(2025, 10, 1, 18, 0);
+            Lineup lineup = LineupFixture.create(festival, performanceAt);
+            lineupJpaRepository.save(lineup);
+
+            Festival otherFestival = FestivalFixture.create();
+            festivalJpaRepository.save(otherFestival);
+
+            // when
+            boolean exists = lineupJpaRepository.existsByFestivalIdAndPerformanceAt(otherFestival.getId(),
+                    performanceAt);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void 존재하지_않는_데이터_조회_결과() {
+            // given
+            Long nonExistentFestivalId = 0L;
+            LocalDateTime nonExistentPerformanceAt = LocalDateTime.of(2025, 12, 31, 23, 59);
+
+            // when
+            boolean exists = lineupJpaRepository.existsByFestivalIdAndPerformanceAt(
+                    nonExistentFestivalId,
+                    nonExistentPerformanceAt
+            );
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/lineup/service/LineupServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/lineup/service/LineupServiceTest.java
@@ -79,6 +79,26 @@ class LineupServiceTest {
         }
 
         @Test
+        void 예외_동일_공연_시간_라인업_존재() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+
+            LocalDateTime performanceAt = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
+            LineupRequest request = LineupRequestFixture.create(performanceAt);
+
+            given(festivalJpaRepository.findById(festivalId))
+                    .willReturn(Optional.of(festival));
+            given(lineupJpaRepository.existsByFestivalIdAndPerformanceAt(festivalId, performanceAt))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> lineupService.addLineup(festivalId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 시간에 이미 라인업이 존재합니다.");
+        }
+
+        @Test
         void 예외_존재하지_않는_축제() {
             // given
             Long invalidFestivalId = 0L;
@@ -149,6 +169,29 @@ class LineupServiceTest {
                 s.assertThat(result.imageUrl()).isEqualTo(request.imageUrl());
                 s.assertThat(result.performanceAt()).isEqualTo(request.performanceAt());
             });
+        }
+
+        @Test
+        void 예외_동일_공연_시간_라인업_존재() {
+            // given
+            Long festivalId = 1L;
+            Festival festival = FestivalFixture.create(festivalId);
+
+            Long lineupId = 1L;
+            Lineup lineup = LineupFixture.create(festival, lineupId);
+
+            LocalDateTime performanceAt = LocalDateTime.of(2025, 10, 15, 12, 0, 0);
+            LineupUpdateRequest request = LineupUpdateRequestFixture.create(performanceAt);
+
+            given(lineupJpaRepository.findById(lineupId))
+                    .willReturn(Optional.of(lineup));
+            given(lineupJpaRepository.existsByFestivalIdAndPerformanceAt(festivalId, performanceAt))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> lineupService.updateLineup(festivalId, lineupId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 시간에 이미 라인업이 존재합니다.");
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #842 

<br>

## 🛠️ 작업 내용

- 라인업 검증 추가했습니다.
  - 이름 검증 50자 내외
  - 이미지 nullable
  - 연예인 시간 중복
