### PR TITLE
[BE] FCM 알림 구독 PREFIX 주입 방식 변경

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
+++ b/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
@@ -16,26 +16,26 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmNotificationManager implements FestivalNotificationManager {
 
-    @Value("${fcm.topic.prefix}")
-    private String topicPrefix;
+    @Value("${fcm.topic.festival-prefix}")
+    private String topicFestivalPrefix;
 
     private final FirebaseMessaging firebaseMessaging;
 
     @Override
     public void subscribeFestivalTopic(Long festivalId, String fcmToken) {
-        String topic = topicPrefix + festivalId;
+        String topic = topicFestivalPrefix + festivalId;
         subscribeTopic(topic, fcmToken);
     }
 
     @Override
     public void unsubscribeFestivalTopic(Long festivalId, String fcmToken) {
-        String topic = topicPrefix + festivalId;
+        String topic = topicFestivalPrefix + festivalId;
         unsubscribeTopic(topic, fcmToken);
     }
 
     @Override
     public void sendToFestivalTopic(Long festivalId, NotificationSendRequest request) {
-        sendToTopic(topicPrefix, festivalId, request);
+        sendToTopic(topicFestivalPrefix, festivalId, request);
     }
 
     private void subscribeTopic(String topic, String fcmToken) {

--- a/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
+++ b/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
@@ -15,25 +16,26 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmNotificationManager implements FestivalNotificationManager {
 
-    private static final String FESTIVAL_PREFIX = "festival";
+    @Value("${fcm.topic.prefix}")
+    private String topicPrefix;
 
     private final FirebaseMessaging firebaseMessaging;
 
     @Override
     public void subscribeFestivalTopic(Long festivalId, String fcmToken) {
-        String topic = FESTIVAL_PREFIX + festivalId;
+        String topic = topicPrefix + festivalId;
         subscribeTopic(topic, fcmToken);
     }
 
     @Override
     public void unsubscribeFestivalTopic(Long festivalId, String fcmToken) {
-        String topic = FESTIVAL_PREFIX + festivalId;
+        String topic = topicPrefix + festivalId;
         unsubscribeTopic(topic, fcmToken);
     }
 
     @Override
     public void sendToFestivalTopic(Long festivalId, NotificationSendRequest request) {
-        sendToTopic(FESTIVAL_PREFIX, festivalId, request);
+        sendToTopic(topicPrefix, festivalId, request);
     }
 
     private void subscribeTopic(String topic, String fcmToken) {

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -27,3 +27,7 @@ springdoc:
 secret:
   jwt-key: asidjiogorepgkpoergkorepgkopergkgopkregopqwrokgro
   jwt-expiration: 9023859840385093458
+
+fcm:
+  topic:
+    prefix: test-topic

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -30,4 +30,4 @@ secret:
 
 fcm:
   topic:
-    prefix: test-topic
+    festival-prefix: test-topic


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #860 

<br>

## 🛠️ 작업 내용

- FCM 알림 구독 환경을 Dev 와 Prod 분리하기 위해 환경변수 분리했습니다.

Merge 할 때, 환경 변수 바꿔서 적용하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 알림(FCM) 주제의 접두사를 하드코딩에서 환경 설정값으로 전환하여 운영 환경별로 주제 네이밍을 유연하게 구성할 수 있게 함.
- Tests
  - 테스트 환경에 알림 주제 접두사 기본값을 추가해 테스트 시 일관된 토픽 동작을 보장하고 설정 기반 동작을 검증할 수 있도록 함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->