### PR TITLE
[AN] 일정화면 타임라인 선 변경

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -78,9 +78,11 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
     private fun showLoadingView(isLoading: Boolean) {
         if (isLoading) {
             binding.rvScheduleEvent.visibility = View.INVISIBLE
+            binding.viewScheduleEventTimeLine.visibility = View.INVISIBLE
             binding.lavScheduleLoading.visibility = View.VISIBLE
         } else {
             binding.lavScheduleLoading.visibility = View.GONE
+            binding.viewScheduleEventTimeLine.visibility = View.VISIBLE
             binding.rvScheduleEvent.visibility = View.VISIBLE
         }
         binding.srlScheduleEvent.isRefreshing = false

--- a/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
@@ -7,6 +7,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <View
+            android:id="@+id/view_schedule_event_time_line"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginStart="29dp"
+            android:background="@color/gray300"
+            app:layout_constraintStart_toStartOf="parent" />
+
+
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/srl_schedule_event"
             android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/item_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/item_schedule_tab_page.xml
@@ -121,18 +121,7 @@
                 app:layout_constraintEnd_toEndOf="@id/cl_schedule_event_card" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <View
-            android:id="@+id/view_schedule_event_time_line"
-            android:layout_width="1dp"
-            android:layout_height="0dp"
-            android:layout_marginEnd="16dp"
-            android:background="@color/gray300"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/cl_schedule_event_card"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
+        
         <com.airbnb.lottie.LottieAnimationView
             android:id="@+id/lav_schedule_event_time_line_circle"
             android:layout_width="60dp"


### PR DESCRIPTION
## #️⃣ 이슈 번호

#865 

<br>

## 🛠️ 작업 내용

- 기존: 일정 아이템의 개수만큼 선 길이가 표시
- 변경: 일정 아이템의 개수에 상관 없이 화면 높이 만큼 선 표시

<br>

## 🙇🏻 중점 리뷰 요청


<br>

## 📸 이미지 첨부 (Optional)
<img width="300" height="663" alt="image" src="https://github.com/user-attachments/assets/e5033699-9b23-43cc-bf70-aee05da0e46e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 일정 탭에 이벤트 타임라인 요소를 추가해 일정 흐름을 한눈에 확인할 수 있습니다.
  - 로딩 상태에서 타임라인과 목록의 표시/숨김이 자동으로 전환됩니다.
  - 일정 카드 옆에 맥동하는 원형 애니메이션 인디케이터를 도입해 진행 상태 가시성을 높였습니다.
- 스타일/UX
  - 화면 레이아웃을 조정해 타임라인 위치와 정렬을 개선했습니다.
  - 로딩 및 일반 상태 간 전환 시 시각적 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->