### PR TITLE
[BE] Device Update API 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/device/controller/DeviceController.java
+++ b/backend/src/main/java/com/daedan/festabook/device/controller/DeviceController.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.device.controller;
 
 import com.daedan.festabook.device.dto.DeviceRequest;
 import com.daedan.festabook.device.dto.DeviceResponse;
+import com.daedan.festabook.device.dto.DeviceUpdateRequest;
 import com.daedan.festabook.device.service.DeviceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -9,6 +10,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +36,18 @@ public class DeviceController {
             @RequestBody DeviceRequest request
     ) {
         return deviceService.registerDevice(request);
+    }
+
+    @PatchMapping("/{deviceId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "디바이스 업데이트")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+    })
+    public DeviceResponse updateDevice(
+            @PathVariable Long deviceId,
+            @RequestBody DeviceUpdateRequest request
+    ) {
+        return deviceService.updateDevice(deviceId, request);
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/device/domain/Device.java
+++ b/backend/src/main/java/com/daedan/festabook/device/domain/Device.java
@@ -42,6 +42,12 @@ public class Device extends BaseEntity {
         this.fcmToken = fcmToken;
     }
 
+    public void updateDevice(String fcmToken) {
+        validateFcmToken(fcmToken);
+
+        this.fcmToken = fcmToken;
+    }
+
     private void validateDeviceIdentifier(String deviceIdentifier) {
         if (deviceIdentifier == null || deviceIdentifier.trim().isEmpty()) {
             throw new BusinessException("디바이스 식별자는 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/daedan/festabook/device/dto/DeviceUpdateRequest.java
+++ b/backend/src/main/java/com/daedan/festabook/device/dto/DeviceUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.daedan.festabook.device.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DeviceUpdateRequest(
+
+        @Schema(description = "FCM 토큰", example = "e4Jse...")
+        String fcmToken
+) {
+}

--- a/backend/src/main/java/com/daedan/festabook/device/service/DeviceService.java
+++ b/backend/src/main/java/com/daedan/festabook/device/service/DeviceService.java
@@ -3,8 +3,11 @@ package com.daedan.festabook.device.service;
 import com.daedan.festabook.device.domain.Device;
 import com.daedan.festabook.device.dto.DeviceRequest;
 import com.daedan.festabook.device.dto.DeviceResponse;
+import com.daedan.festabook.device.dto.DeviceUpdateRequest;
 import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +24,21 @@ public class DeviceService {
         return DeviceResponse.from(device);
     }
 
+    @Transactional
+    public DeviceResponse updateDevice(Long deviceId, DeviceUpdateRequest request) {
+        Device device = getDeviceById(deviceId);
+        device.updateDevice(request.fcmToken());
+
+        return DeviceResponse.from(device);
+    }
+
     private Device saveNewDevice(DeviceRequest request) {
         Device newDevice = request.toEntity();
         return deviceJpaRepository.save(newDevice);
+    }
+
+    private Device getDeviceById(Long deviceId) {
+        return deviceJpaRepository.findById(deviceId)
+                .orElseThrow(() -> new BusinessException("존재하지 않는 디바이스입니다.", HttpStatus.BAD_REQUEST));
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
@@ -58,6 +58,10 @@ public class SecurityConfig {
             "/councils/login"
     };
 
+    private static final String[] PATCH_WHITELIST = {
+            "/devices/*"
+    };
+
     private static final String[] DELETE_WHITELIST = {
             "/festivals/notifications/*",
             "/places/favorites/*"
@@ -77,6 +81,7 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_WHITELIST).permitAll()
                         .requestMatchers(HttpMethod.GET, GET_WHITELIST).permitAll()
                         .requestMatchers(HttpMethod.POST, POST_WHITELIST).permitAll()
+                        .requestMatchers(HttpMethod.PATCH, PATCH_WHITELIST).permitAll()
                         .requestMatchers(HttpMethod.DELETE, DELETE_WHITELIST).permitAll()
                         .anyRequest().hasAnyAuthority(
                                 RoleType.ROLE_COUNCIL.name(),

--- a/backend/src/test/java/com/daedan/festabook/device/controller/DeviceControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/device/controller/DeviceControllerTest.java
@@ -3,8 +3,13 @@ package com.daedan.festabook.device.controller;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.daedan.festabook.device.domain.Device;
+import com.daedan.festabook.device.domain.DeviceFixture;
 import com.daedan.festabook.device.dto.DeviceRequest;
 import com.daedan.festabook.device.dto.DeviceRequestFixture;
+import com.daedan.festabook.device.dto.DeviceUpdateRequest;
+import com.daedan.festabook.device.dto.DeviceUpdateRequestFixture;
+import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +17,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -20,6 +26,9 @@ import org.springframework.http.HttpStatus;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DeviceControllerTest {
+
+    @Autowired
+    private DeviceJpaRepository deviceJpaRepository;
 
     @LocalServerPort
     private int port;
@@ -86,6 +95,35 @@ class DeviceControllerTest {
                     .statusCode(HttpStatus.CREATED.value())
                     .body("size()", equalTo(expectedFieldSize))
                     .body("deviceId", equalTo(expectedId));
+        }
+    }
+
+    @Nested
+    class updateDevice {
+
+        @Test
+        void 성공() {
+            // given
+            Long deviceId = 1L;
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            String fcmToken = "FCM_00000000";
+            DeviceUpdateRequest request = DeviceUpdateRequestFixture.create(fcmToken);
+
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .patch("/devices/{deviceId}", deviceId)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("deviceId", notNullValue());
         }
     }
 }

--- a/backend/src/test/java/com/daedan/festabook/device/dto/DeviceUpdateRequestFixture.java
+++ b/backend/src/test/java/com/daedan/festabook/device/dto/DeviceUpdateRequestFixture.java
@@ -1,0 +1,20 @@
+package com.daedan.festabook.device.dto;
+
+public class DeviceUpdateRequestFixture {
+
+    private static final String DEFAULT_FCM_TOKEN = "dummy";
+
+    public static DeviceUpdateRequest create() {
+        return new DeviceUpdateRequest(
+                DEFAULT_FCM_TOKEN
+        );
+    }
+
+    public static DeviceUpdateRequest create(
+            String fcmToken
+    ) {
+        return new DeviceUpdateRequest(
+                fcmToken
+        );
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/device/service/DeviceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/device/service/DeviceServiceTest.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.device.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -11,7 +12,10 @@ import com.daedan.festabook.device.domain.DeviceFixture;
 import com.daedan.festabook.device.dto.DeviceRequest;
 import com.daedan.festabook.device.dto.DeviceRequestFixture;
 import com.daedan.festabook.device.dto.DeviceResponse;
+import com.daedan.festabook.device.dto.DeviceUpdateRequest;
+import com.daedan.festabook.device.dto.DeviceUpdateRequestFixture;
 import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
+import com.daedan.festabook.global.exception.BusinessException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -73,6 +77,44 @@ class DeviceServiceTest {
             assertThat(result.deviceId()).isEqualTo(expectedId);
             then(deviceJpaRepository).should(never())
                     .save(any());
+        }
+    }
+
+    @Nested
+    class updateDevice {
+
+        @Test
+        void 성공() {
+            // given
+            Long deviceId = 1L;
+            Device device = DeviceFixture.create(deviceId);
+
+            given(deviceJpaRepository.findById(device.getId()))
+                    .willReturn(Optional.of(device));
+
+            DeviceUpdateRequest request = DeviceUpdateRequestFixture.create();
+
+            // when
+            DeviceResponse result = deviceService.updateDevice(device.getId(), request);
+
+            // then
+            assertThat(result.deviceId()).isEqualTo(deviceId);
+        }
+
+        @Test
+        void 예외_존재하지_않는_디바이스() {
+            // given
+            Long invalidDeviceId = 0L;
+            Device device = DeviceFixture.create(invalidDeviceId);
+            DeviceUpdateRequest request = DeviceUpdateRequestFixture.create();
+
+            given(deviceJpaRepository.findById(invalidDeviceId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> deviceService.updateDevice(device.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("존재하지 않는 디바이스입니다.");
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#875

<br>

## 🛠️ 작업 내용

- iOS는 fcmToken과 기기식별자의 생명주기가 같지 않은데, 로직이 최초 앱 실행 후 POST가 두 번 나가는 이유로 인해 새로 발급 받는 fcm Token이 저장되지 않아 따로 API 구현했습니다. 컨텍스트 이해 안 되시는 분들은 따로 말씀해 주시면 설명해 드릴게요! ^^7

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 기기 업데이트 API 추가: PATCH /devices/{deviceId}로 FCM 토큰 갱신 지원, 성공 시 200과 갱신된 기기 정보 반환.
  - 보안 정책 조정: PATCH /devices/* 요청을 인증 없이 허용.
- Tests
  - 컨트롤러/서비스에 기기 업데이트 성공 및 미존재 기기 예외 시나리오 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->