### PR TITLE
[BE] FCM 알림 구독 iOS 대응

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/controller/AndroidFestivalNotificationSubscriptionController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/AndroidFestivalNotificationSubscriptionController.java
@@ -1,0 +1,39 @@
+package com.daedan.festabook.festival.controller;
+
+import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
+import com.daedan.festabook.festival.dto.FestivalNotificationResponse;
+import com.daedan.festabook.festival.service.FestivalNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/festivals")
+@Tag(name = "안드로이드 축제 공지사항 알림 구독", description = "안드로이드 축제 공지사항 알림 구독 API")
+public class AndroidFestivalNotificationSubscriptionController {
+
+    private final FestivalNotificationService festivalNotificationService;
+
+    @PostMapping("/{festivalId}/notifications/android")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "안드로이드 장치 축제 공지사항 알림 구독 (FCM 토픽 구독)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+    })
+    public FestivalNotificationResponse subscribeFestivalNotification(
+            @PathVariable Long festivalId,
+            @RequestBody FestivalNotificationRequest request
+    ) {
+        return festivalNotificationService.subscribeAndroidFestivalNotification(festivalId, request);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/festivals")
-@Tag(name = "축제 알림", description = "축제 알림 관련 API")
-public class FestivalNotificationController {
+@Tag(name = "축제 공지사항 알림", description = "축제 공지사항 알림 관련 API")
+public class FestivalNotificationSubscriptionController {
 
     private final FestivalNotificationService festivalNotificationService;
 
     @PostMapping("/{festivalId}/notifications")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "특정 축제의 알림 구독 (FCM 토픽 구독)")
+    @Operation(summary = "특정 축제의 알림 구독 (FCM 토픽 구독) [old 안드로이드 알림 구독 버전]")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
     })

--- a/backend/src/main/java/com/daedan/festabook/festival/controller/IosFestivalNotificationSubscriptionController.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/controller/IosFestivalNotificationSubscriptionController.java
@@ -1,0 +1,39 @@
+package com.daedan.festabook.festival.controller;
+
+import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
+import com.daedan.festabook.festival.dto.FestivalNotificationResponse;
+import com.daedan.festabook.festival.service.FestivalNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/festivals")
+@Tag(name = "iOS 축제 공지사항 알림 구독", description = "iOS 축제 공지사항 알림 구독 API")
+public class IosFestivalNotificationSubscriptionController {
+
+    private final FestivalNotificationService festivalNotificationService;
+
+    @PostMapping("/{festivalId}/notifications/ios")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "iOS 장치 축제 공지사항 알림 구독 (FCM 토픽 구독)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", useReturnTypeSchema = true),
+    })
+    public FestivalNotificationResponse subscribeFestivalNotification(
+            @PathVariable Long festivalId,
+            @RequestBody FestivalNotificationRequest request
+    ) {
+        return festivalNotificationService.subscribeIosFestivalNotification(festivalId, request);
+    }
+}

--- a/backend/src/main/java/com/daedan/festabook/festival/domain/FestivalNotificationManager.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/domain/FestivalNotificationManager.java
@@ -4,6 +4,10 @@ import com.daedan.festabook.notification.dto.NotificationSendRequest;
 
 public interface FestivalNotificationManager {
 
+    void subscribeAndroidFestivalTopic(Long festivalId, String token);
+
+    void subscribeIosFestivalTopic(Long festivalId, String token);
+
     void subscribeFestivalTopic(Long festivalId, String token);
 
     void unsubscribeFestivalTopic(Long festivalId, String token);

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
@@ -42,6 +42,38 @@ public class FestivalNotificationService {
         return FestivalNotificationResponse.from(savedFestivalNotification);
     }
 
+    @Transactional
+    public FestivalNotificationResponse subscribeAndroidFestivalNotification(Long festivalId,
+                                                                             FestivalNotificationRequest request) {
+        validateDuplicatedFestivalNotification(festivalId, request.deviceId());
+
+        Festival festival = getFestivalById(festivalId);
+        Device device = getDeviceById(request.deviceId());
+        FestivalNotification festivalNotification = new FestivalNotification(festival, device);
+        FestivalNotification savedFestivalNotification = festivalNotificationJpaRepository.save(
+                festivalNotification);
+
+        festivalNotificationManager.subscribeAndroidFestivalTopic(festivalId, device.getFcmToken());
+
+        return FestivalNotificationResponse.from(savedFestivalNotification);
+    }
+
+    @Transactional
+    public FestivalNotificationResponse subscribeIosFestivalNotification(Long festivalId,
+                                                                         FestivalNotificationRequest request) {
+        validateDuplicatedFestivalNotification(festivalId, request.deviceId());
+
+        Festival festival = getFestivalById(festivalId);
+        Device device = getDeviceById(request.deviceId());
+        FestivalNotification festivalNotification = new FestivalNotification(festival, device);
+        FestivalNotification savedFestivalNotification = festivalNotificationJpaRepository.save(
+                festivalNotification);
+
+        festivalNotificationManager.subscribeIosFestivalTopic(festivalId, device.getFcmToken());
+
+        return FestivalNotificationResponse.from(savedFestivalNotification);
+    }
+
     @Transactional(readOnly = true)
     public FestivalNotificationReadResponses getAllFestivalNotificationByDeviceId(Long deviceId) {
         Device device = getDeviceById(deviceId);

--- a/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/service/FestivalNotificationService.java
@@ -27,8 +27,10 @@ public class FestivalNotificationService {
     private final FestivalNotificationManager festivalNotificationManager;
 
     @Transactional
-    public FestivalNotificationResponse subscribeFestivalNotification(Long festivalId,
-                                                                      FestivalNotificationRequest request) {
+    public FestivalNotificationResponse subscribeFestivalNotification(
+            Long festivalId,
+            FestivalNotificationRequest request
+    ) {
         validateDuplicatedFestivalNotification(festivalId, request.deviceId());
 
         Festival festival = getFestivalById(festivalId);
@@ -43,8 +45,10 @@ public class FestivalNotificationService {
     }
 
     @Transactional
-    public FestivalNotificationResponse subscribeAndroidFestivalNotification(Long festivalId,
-                                                                             FestivalNotificationRequest request) {
+    public FestivalNotificationResponse subscribeAndroidFestivalNotification(
+            Long festivalId,
+            FestivalNotificationRequest request
+    ) {
         validateDuplicatedFestivalNotification(festivalId, request.deviceId());
 
         Festival festival = getFestivalById(festivalId);
@@ -59,8 +63,10 @@ public class FestivalNotificationService {
     }
 
     @Transactional
-    public FestivalNotificationResponse subscribeIosFestivalNotification(Long festivalId,
-                                                                         FestivalNotificationRequest request) {
+    public FestivalNotificationResponse subscribeIosFestivalNotification(
+            Long festivalId,
+            FestivalNotificationRequest request
+    ) {
         validateDuplicatedFestivalNotification(festivalId, request.deviceId());
 
         Festival festival = getFestivalById(festivalId);

--- a/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daedan/festabook/global/security/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
     private static final String[] POST_WHITELIST = {
             "/devices",
             "/festivals/*/notifications",
+            "/festivals/*/notifications/*",
             "/places/*/favorites",
             "/councils/login"
     };

--- a/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
+++ b/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
@@ -16,8 +16,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmNotificationManager implements FestivalNotificationManager {
 
-    private final String ANDROID_TOPIC_SUFFIX = "-android";
-    private final String IOS_TOPIC_SUFFIX = "-ios";
+    private static final String ANDROID_TOPIC_SUFFIX = "-android";
+    private static final String IOS_TOPIC_SUFFIX = "-ios";
 
     @Value("${fcm.topic.festival-prefix}")
     private String topicFestivalPrefix;

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionControllerTest.java
@@ -1,0 +1,262 @@
+package com.daedan.festabook.festival.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+import com.daedan.festabook.device.domain.Device;
+import com.daedan.festabook.device.domain.DeviceFixture;
+import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.domain.FestivalNotification;
+import com.daedan.festabook.festival.domain.FestivalNotificationFixture;
+import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
+import com.daedan.festabook.festival.dto.FestivalNotificationRequestFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.festival.infrastructure.FestivalNotificationJpaRepository;
+import com.daedan.festabook.notification.infrastructure.FcmNotificationManager;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FestivalNotificationSubscriptionControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private DeviceJpaRepository deviceJpaRepository;
+
+    @Autowired
+    private FestivalNotificationJpaRepository festivalNotificationJpaRepository;
+
+    @MockitoBean
+    private FcmNotificationManager fcmNotificationManager;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class subscribeFestivalNotification {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(device.getId());
+
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications", festival.getId())
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("festivalNotificationId", notNullValue());
+
+            then(fcmNotificationManager).should()
+                    .subscribeFestivalTopic(any(), any());
+        }
+
+        @Test
+        void 예외_축제에_이미_알림을_구독한_디바이스() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotification festivalNotification = FestivalNotificationFixture.create(festival,
+                    device);
+            festivalNotificationJpaRepository.save(festivalNotification);
+
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(device.getId());
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications", festival.getId())
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("이미 알림을 구독한 축제입니다."));
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 예외_존재하지_않는_디바이스() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Long invalidDeviceId = 0L;
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(invalidDeviceId);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications", festival.getId())
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("존재하지 않는 디바이스입니다."));
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 예외_존재하지_않는_축제() {
+            // given
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(device.getId());
+
+            Long invalidFestivalId = 0L;
+
+            // when & then
+            RestAssured.
+                    given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications", invalidFestivalId)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("존재하지 않는 축제입니다."));
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    class getAllFestivalNotificationByDeviceId {
+
+        @Test
+        void 성공() {
+            // given
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            Festival festival1 = FestivalFixture.create();
+            Festival festival2 = FestivalFixture.create();
+            festivalJpaRepository.save(festival1);
+            festivalJpaRepository.save(festival2);
+
+            FestivalNotification festivalNotification1 = FestivalNotificationFixture.create(festival1, device);
+            FestivalNotification festivalNotification2 = FestivalNotificationFixture.create(festival2, device);
+            List<FestivalNotification> festivalNotifications = List.of(festivalNotification1, festivalNotification2);
+            festivalNotificationJpaRepository.saveAll(festivalNotifications);
+
+            int expectedSize = 2;
+            int expectedFieldSize = 3;
+
+            // when & then
+            RestAssured.
+                    given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .get("/festivals/notifications/{deviceId}", device.getId())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasSize(expectedSize))
+                    .body("[0].size()", equalTo(expectedFieldSize))
+                    .body("[0].festivalNotificationId", notNullValue())
+                    .body("[0].universityName", equalTo(festivalNotification1.getFestival().getUniversityName()))
+                    .body("[0].festivalName", equalTo(festivalNotification1.getFestival().getFestivalName()))
+                    .body("[1].size()", equalTo(expectedFieldSize))
+                    .body("[1].festivalNotificationId", notNullValue())
+                    .body("[1].universityName", equalTo(festivalNotification2.getFestival().getUniversityName()))
+                    .body("[1].festivalName", equalTo(festivalNotification2.getFestival().getFestivalName()));
+        }
+    }
+
+    @Nested
+    class unsubscribeFestivalNotification {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotification festivalNotification = FestivalNotificationFixture.create(festival,
+                    device);
+            festivalNotificationJpaRepository.save(festivalNotification);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .delete("/festivals/notifications/{festivalNotificationId}",
+                            festivalNotification.getId())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            boolean exists = festivalNotificationJpaRepository.existsById(festivalNotification.getId());
+            assertThat(exists).isFalse();
+            then(fcmNotificationManager).should()
+                    .unsubscribeFestivalTopic(any(), any());
+        }
+
+        @Test
+        void 성공_알림_삭제시_축제_알림이_존재하지_않아도_정상_처리() {
+            // given
+            Long invalidFestivalNotificationId = 0L;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .delete("/festivals/notifications/{festivalNotificationId}",
+                            invalidFestivalNotificationId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/IosFestivalNotificationSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/IosFestivalNotificationSubscriptionControllerTest.java
@@ -1,0 +1,166 @@
+package com.daedan.festabook.festival.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+import com.daedan.festabook.device.domain.Device;
+import com.daedan.festabook.device.domain.DeviceFixture;
+import com.daedan.festabook.device.infrastructure.DeviceJpaRepository;
+import com.daedan.festabook.festival.domain.Festival;
+import com.daedan.festabook.festival.domain.FestivalFixture;
+import com.daedan.festabook.festival.domain.FestivalNotification;
+import com.daedan.festabook.festival.domain.FestivalNotificationFixture;
+import com.daedan.festabook.festival.dto.FestivalNotificationRequest;
+import com.daedan.festabook.festival.dto.FestivalNotificationRequestFixture;
+import com.daedan.festabook.festival.infrastructure.FestivalJpaRepository;
+import com.daedan.festabook.festival.infrastructure.FestivalNotificationJpaRepository;
+import com.daedan.festabook.notification.infrastructure.FcmNotificationManager;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class IosFestivalNotificationSubscriptionControllerTest {
+
+    @Autowired
+    private FestivalJpaRepository festivalJpaRepository;
+
+    @Autowired
+    private DeviceJpaRepository deviceJpaRepository;
+
+    @Autowired
+    private FestivalNotificationJpaRepository festivalNotificationJpaRepository;
+
+    @MockitoBean
+    private FcmNotificationManager fcmNotificationManager;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Nested
+    class subscribeIosFestivalNotification {
+
+        @Test
+        void 성공() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(device.getId());
+
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications/ios", festival.getId())
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("festivalNotificationId", notNullValue());
+
+            then(fcmNotificationManager).should()
+                    .subscribeIosFestivalTopic(any(), any());
+        }
+
+        @Test
+        void 예외_축제에_이미_알림을_구독한_디바이스() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotification festivalNotification = FestivalNotificationFixture.create(festival,
+                    device);
+            festivalNotificationJpaRepository.save(festivalNotification);
+
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(device.getId());
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications/ios", festival.getId())
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("이미 알림을 구독한 축제입니다."));
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 예외_존재하지_않는_디바이스() {
+            // given
+            Festival festival = FestivalFixture.create();
+            festivalJpaRepository.save(festival);
+
+            Long invalidDeviceId = 0L;
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(invalidDeviceId);
+
+            // when & then
+            RestAssured
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications/ios", festival.getId())
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("존재하지 않는 디바이스입니다."));
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 예외_존재하지_않는_축제() {
+            // given
+            Device device = DeviceFixture.create();
+            deviceJpaRepository.save(device);
+
+            FestivalNotificationRequest request = FestivalNotificationRequestFixture.create(device.getId());
+
+            Long invalidFestivalId = 0L;
+
+            // when & then
+            RestAssured.
+                    given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .post("/festivals/{festivalId}/notifications/ios", invalidFestivalId)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo("존재하지 않는 축제입니다."));
+
+            then(fcmNotificationManager).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -30,4 +30,4 @@ secret:
 
 fcm:
   topic:
-    festival-prefix: test-topic
+    festival-prefix: example-festival


### PR DESCRIPTION
## #️⃣ 이슈 번호

#879 

<br>

## 🛠️ 작업 내용

android용, ios용 FCM 축제 공지사항 알림 구독 api를 추가했습니다.
추후 안드로이드에서 엔드포인트를 이전하면 옛 api를 지워야 합니다.


## 추후 논의사항
api 경로가 어색합니다.

알림(notification) 관련 api입니다.
하지만 api 경로 시작은 festival로 시작하고 있습니다.
```
기존
POST /festivals/{festivalId}/notifications

제안
POST /subscriptions/notifications/festivals/{festivalId}

DELETE /subscriptions/notifications/festivals/{festivalId}
```

<br>

## 📸 이미지 첨부 (Optional)

<img width="1703" height="471" alt="image" src="https://github.com/user-attachments/assets/33e0a5fb-d13b-428b-8b34-efbb5fbb6c4f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 축제 알림 구독에 플랫폼 전용 엔드포인트 추가: POST /festivals/{festivalId}/notifications/android, /ios
  - 구독 성공 시 201 Created와 구독 ID 반환
- 문서
  - API 태그 및 설명 정비, 기존 엔드포인트에 “[old 안드로이드 알림 구독 버전]” 표기 추가
- 리팩터
  - 컨트롤러 명칭 정리로 일관성 향상
- 작업
  - 알림 구독 엔드포인트 인증 예외 범위 확장(화이트리스트 추가)
- 테스트
  - Android/iOS 구독 성공·예외 케이스 통합 테스트 추가 및 기존 테스트 명칭 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->