### PR TITLE
[BE] 노출되면 안되는 값을 로그에서 마스킹

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/logging/LocalLoggingFilter.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LocalLoggingFilter.java
@@ -40,15 +40,15 @@ public class LocalLoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        StopWatch stopWatch = new StopWatch();
         String uri = request.getRequestURI();
-        String httpMethod = request.getMethod();
-        String queryString = request.getQueryString();
-
         if (isSkipLoggingForPath(uri)) {
             filterChain.doFilter(request, response);
             return;
         }
+
+        StopWatch stopWatch = new StopWatch();
+        String httpMethod = request.getMethod();
+        String queryString = request.getQueryString();
 
         stopWatch.start();
         try {
@@ -63,7 +63,7 @@ public class LocalLoggingFilter extends OncePerRequestFilter {
             log.info(
                     "[API End] statusCode={} requestBody={} executionTime={}ms",
                     statusCode,
-                    maskingIfContainsMaskingPath(uri, httpMethod, requestBody),
+                    requestBody,
                     executionTime
             );
         }
@@ -71,14 +71,6 @@ public class LocalLoggingFilter extends OncePerRequestFilter {
 
     private boolean isSkipLoggingForPath(String uri) {
         return LOGGING_SKIP_PATH_PREFIX.stream().anyMatch(uri::startsWith);
-    }
-
-    private Object maskingIfContainsMaskingPath(String uri, String httpMethod, Object requestBody) {
-        if (BODY_MASKING_PATH.contains(new MaskingPath(uri, httpMethod))) {
-            return "MASKING";
-        }
-
-        return requestBody;
     }
 
     private String extractBodyFromCache(HttpServletRequest request) {

--- a/backend/src/main/java/com/daedan/festabook/global/logging/LocalLoggingFilter.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LocalLoggingFilter.java
@@ -75,10 +75,10 @@ public class LocalLoggingFilter extends OncePerRequestFilter {
 
     private Object maskingIfContainsMaskingPath(String uri, String httpMethod, Object requestBody) {
         if (BODY_MASKING_PATH.contains(new MaskingPath(uri, httpMethod))) {
-            return requestBody;
+            return "MASKING";
         }
 
-        return "MASKING";
+        return requestBody;
     }
 
     private String extractBodyFromCache(HttpServletRequest request) {

--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingFilter.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingFilter.java
@@ -103,10 +103,10 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private Object maskingIfContainsMaskingPath(String uri, String httpMethod, Object requestBody) {
         if (BODY_MASKING_PATH.contains(new MaskingPath(uri, httpMethod))) {
-            return requestBody;
+            return "MASKING";
         }
 
-        return "MASKING";
+        return requestBody;
     }
 
     private Object extractBodyFromCache(HttpServletRequest request) {

--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingFilter.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingFilter.java
@@ -55,17 +55,17 @@ public class LoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        StopWatch stopWatch = new StopWatch();
         String uri = request.getRequestURI();
-        String httpMethod = request.getMethod();
-        String ipAddress = request.getHeader(REQUEST_USER_IP_HEADER_NAME);
-        String token = extractTokenFromHeader(request);
-        String username = extractUsernameFromToken(token);
-
         if (isSkipLoggingForPath(uri)) {
             filterChain.doFilter(request, response);
             return;
         }
+
+        StopWatch stopWatch = new StopWatch();
+        String httpMethod = request.getMethod();
+        String ipAddress = request.getHeader(REQUEST_USER_IP_HEADER_NAME);
+        String token = extractTokenFromHeader(request);
+        String username = extractUsernameFromToken(token);
 
         stopWatch.start();
         try {
@@ -89,7 +89,7 @@ public class LoggingFilter extends OncePerRequestFilter {
                     ipAddress,
                     username,
                     statusCode,
-                    maskingIfContainsMaskingPath(uri, httpMethod, requestBody),
+                    maskIfContainsMaskingPath(uri, httpMethod, requestBody),
                     executionTime
             );
             log.info("", kv("event", apiLog));
@@ -101,7 +101,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         return LOGGING_SKIP_PATH_PREFIX.stream().anyMatch(uri::startsWith);
     }
 
-    private Object maskingIfContainsMaskingPath(String uri, String httpMethod, Object requestBody) {
+    private Object maskIfContainsMaskingPath(String uri, String httpMethod, Object requestBody) {
         if (BODY_MASKING_PATH.contains(new MaskingPath(uri, httpMethod))) {
             return "MASKING";
         }

--- a/backend/src/main/java/com/daedan/festabook/global/logging/MaskingPath.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/MaskingPath.java
@@ -1,0 +1,7 @@
+package com.daedan.festabook.global.logging;
+
+public record MaskingPath(
+        String uri,
+        String method
+) {
+}

--- a/backend/src/test/java/com/daedan/festabook/global/security/JwtTestHelper.java
+++ b/backend/src/test/java/com/daedan/festabook/global/security/JwtTestHelper.java
@@ -69,7 +69,7 @@ public class JwtTestHelper {
         council.updateRole(Set.of(roleType));
         councilRepository.save(council);
 
-        String token = jwtProvider.createToken(randomUsername, festival.getId());
+        String token = jwtProvider.createToken(randomUsername, festival.getId(), Set.of(roleType));
         return new Header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + token);
     }
 
@@ -83,7 +83,7 @@ public class JwtTestHelper {
         council.updateRole(Set.of(roleType));
         councilRepository.save(council);
 
-        String token = jwtProvider.createToken(randomUsername, festival.getId());
+        String token = jwtProvider.createToken(randomUsername, festival.getId(), Set.of(roleType));
         return new Header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + token);
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#723 

<br>

## 🛠️ 작업 내용

- 노출되면 안되는 비밀번호가 포함된 body를 마스킹하였습니다.

<br>

<img width="1119" height="38" alt="image" src="https://github.com/user-attachments/assets/d95c318b-bcfb-4f2f-9b0c-1763d8d32048" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - 인증/계정 관련 일부 엔드포인트의 요청 본문을 로그에서 마스킹해 민감정보 노출을 줄였습니다.
- Refactor
  - 토큰 생성 흐름에 사용자 역할 정보를 포함하도록 변경해 권한 기반 접근 제어의 정확성과 안정성을 향상시켰습니다.
- Tests
  - 테스트 헬퍼를 최신 토큰 형식(역할 포함)에 맞춰 업데이트해 관련 시나리오 신뢰성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->