### PR TITLE
[BE] @PreAuthorize의 인증/인가 예외를 GlobalExceptionHandler에서 처리

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,8 @@ import java.io.StringWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,6 +32,44 @@ public class GlobalExceptionHandler {
                     businessException.getStatus().value(),
                     businessException.getMessage(),
                     businessException.getClass().getSimpleName(),
+                    ""
+            );
+            log.info("", kv("event", exceptionLog));
+        }
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthenticationCredentialsNotFoundException(
+            AuthenticationCredentialsNotFoundException exception
+    ) {
+        try {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED.value())
+                    .body(new ExceptionResponse("인증되지 않은 사용자입니다."));
+        } finally {
+            ExceptionLog exceptionLog = new ExceptionLog(
+                    "exception",
+                    HttpStatus.UNAUTHORIZED.value(),
+                    exception.getMessage(),
+                    exception.getClass().getSimpleName(),
+                    ""
+            );
+            log.info("", kv("event", exceptionLog));
+        }
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleAccessDeniedException(AccessDeniedException exception) {
+        try {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN.value())
+                    .body(new ExceptionResponse("인가되지 않은 사용자입니다."));
+        } finally {
+            ExceptionLog exceptionLog = new ExceptionLog(
+                    "exception",
+                    HttpStatus.FORBIDDEN.value(),
+                    exception.getMessage(),
+                    exception.getClass().getSimpleName(),
                     ""
             );
             log.info("", kv("event", exceptionLog));

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -27,8 +27,7 @@ public class GlobalExceptionHandler {
                     .status(businessException.getStatus())
                     .body(businessException.toResponse());
         } finally {
-            ExceptionLog exceptionLog = new ExceptionLog(
-                    "exception",
+            ExceptionLog exceptionLog = ExceptionLog.from(
                     businessException.getStatus().value(),
                     businessException.getMessage(),
                     businessException.getClass().getSimpleName(),
@@ -47,8 +46,7 @@ public class GlobalExceptionHandler {
                     .status(HttpStatus.UNAUTHORIZED.value())
                     .body(new ExceptionResponse("인증되지 않은 사용자입니다."));
         } finally {
-            ExceptionLog exceptionLog = new ExceptionLog(
-                    "exception",
+            ExceptionLog exceptionLog = ExceptionLog.from(
                     HttpStatus.UNAUTHORIZED.value(),
                     exception.getMessage(),
                     exception.getClass().getSimpleName(),
@@ -65,8 +63,7 @@ public class GlobalExceptionHandler {
                     .status(HttpStatus.FORBIDDEN.value())
                     .body(new ExceptionResponse("인가되지 않은 사용자입니다."));
         } finally {
-            ExceptionLog exceptionLog = new ExceptionLog(
-                    "exception",
+            ExceptionLog exceptionLog = ExceptionLog.from(
                     HttpStatus.FORBIDDEN.value(),
                     exception.getMessage(),
                     exception.getClass().getSimpleName(),
@@ -86,8 +83,7 @@ public class GlobalExceptionHandler {
                     .internalServerError()
                     .body(new ExceptionResponse(INTERNAL_ERROR_MESSAGE));
         } finally {
-            ExceptionLog exceptionLog = new ExceptionLog(
-                    "exception",
+            ExceptionLog exceptionLog = ExceptionLog.from(
                     HttpStatus.INTERNAL_SERVER_ERROR.value(),
                     runtimeException.getMessage(),
                     runtimeException.getClass().getSimpleName(),

--- a/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/daedan/festabook/global/exception/GlobalExceptionHandler.java
@@ -56,7 +56,7 @@ public class GlobalExceptionHandler {
         }
     }
 
-    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ExceptionResponse> handleAccessDeniedException(AccessDeniedException exception) {
         try {
             return ResponseEntity

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/ExceptionLog.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/ExceptionLog.java
@@ -1,10 +1,25 @@
 package com.daedan.festabook.global.logging.dto;
 
 public record ExceptionLog(
-        String type,
+        LogType type,
         int errorCode,
         String exceptionMessage,
         String exceptionClass,
         String stackTrace
 ) {
+
+    public static ExceptionLog from(
+            int errorCode,
+            String exceptionMessage,
+            String exceptionClass,
+            String stackTrace
+    ) {
+        return new ExceptionLog(
+                LogType.EXCEPTION,
+                errorCode,
+                exceptionMessage,
+                exceptionClass,
+                stackTrace
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#852 

<br>

## 🛠️ 작업 내용

- @PreAuthorize의 인증/인가 예외를 GlobalExceptionHandler에서 처리
- ExceptionLog도 LogType을 사용
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * 미인증 요청에 대해 HTTP 401과 “인증되지 않은 사용자입니다.” 메시지를 반환해 안내를 명확히 했습니다.
  * 권한 부족 요청에 대해 HTTP 403과 “인가되지 않은 사용자입니다.” 메시지를 반환해 오류 구분을 개선했습니다.
  * 인증/인가 실패 시 예외 응답 처리를 일관되게 개선했습니다.

* Refactor
  * 예외 로깅 형식과 수준을 표준화하여 401/403은 정보로, 서버 오류는 오류로 기록되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->