### PR TITLE
[BE] hotfix: 응답 status code 수정

### DIFF
--- a/backend/src/test/java/com/daedan/festabook/council/controller/CouncilControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/council/controller/CouncilControllerTest.java
@@ -99,7 +99,7 @@ class CouncilControllerTest {
                     .when()
                     .post("/councils")
                     .then()
-                    .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    .statusCode(HttpStatus.FORBIDDEN.value());
         }
     }
 

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalControllerTest.java
@@ -147,7 +147,7 @@ class FestivalControllerTest {
                     .when()
                     .post("/festivals")
                     .then()
-                    .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    .statusCode(HttpStatus.FORBIDDEN.value());
         }
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#901 

<br>

## 🛠️ 작업 내용

- GlobalExceptionHandler의 응답 status code로 테스트 수정

<br>

## 📸 이미지 첨부 (Optional)

<img width="811" height="324" alt="image" src="https://github.com/user-attachments/assets/ef65441f-e36a-4405-b293-34a012de2a2a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 권한이 부족한 사용자가 운영위원회/축제 생성을 시도할 때 반환 상태코드를 500에서 403(Forbidden)으로 정정하여 오류 의미를 명확화하고 클라이언트 처리를 용이하게 했습니다. API 응답의 일관성과 신뢰성이 향상됩니다.
- 테스트
  - 권한 실패 시나리오의 기대 상태코드를 403으로 업데이트하여 실제 동작과 일치하도록 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->