### PR TITLE
[AN] 아이템이 없을 시 문구 표시 

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
@@ -35,7 +35,9 @@ class FAQFragment : BaseFragment<FragmentFaqBinding>(R.layout.fragment_faq) {
                 FAQUiState.InitialLoading -> {}
                 FAQUiState.Refreshing -> {}
                 is FAQUiState.Success -> {
-                    adapter.submitList(state.faqs)
+                    adapter.submitList(state.faqs) {
+                        showEmptyStateMessage()
+                    }
                 }
 
                 is FAQUiState.Error -> {
@@ -44,6 +46,12 @@ class FAQFragment : BaseFragment<FragmentFaqBinding>(R.layout.fragment_faq) {
                 }
             }
         }
+    }
+
+    private fun showEmptyStateMessage() {
+        val itemCount = binding.rvFaq.adapter?.itemCount ?: 0
+
+        binding.tvEmptyState.root.visibility = if (itemCount == 0) View.VISIBLE else View.GONE
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/lost/LostItemFragment.kt
@@ -57,7 +57,9 @@ class LostItemFragment : BaseFragment<FragmentLostItemBinding>(R.layout.fragment
 
                 is LostItemUiState.Success -> {
                     binding.srlLostItemList.isRefreshing = false
-                    adapter.submitList(state.lostItems)
+                    adapter.submitList(state.lostItems) {
+                        showEmptyStateMessage()
+                    }
                     hideSkeleton()
                 }
 
@@ -114,6 +116,12 @@ class LostItemFragment : BaseFragment<FragmentLostItemBinding>(R.layout.fragment
         binding.srlLostItemList.visibility = View.VISIBLE
         binding.sflLostItemSkeleton.visibility = View.GONE
         binding.sflLostItemSkeleton.stopShimmer()
+    }
+
+    private fun showEmptyStateMessage() {
+        val itemCount = binding.rvLostItemList.adapter?.itemCount ?: 0
+
+        binding.tvEmptyState.root.visibility = if (itemCount == 0) View.VISIBLE else View.GONE
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/notice/NoticeFragment.kt
@@ -68,6 +68,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
 
                 is NoticeUiState.Success -> {
                     noticeAdapter.submitList(noticeState.notices) {
+                        showEmptyStateMessage()
                         scrollExpandedNoticeToTop(noticeState)
                     }
                     binding.srlNoticeList.isRefreshing = false
@@ -101,6 +102,12 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
         binding.srlNoticeList.visibility = View.VISIBLE
         binding.sflNoticeSkeleton.visibility = View.GONE
         binding.sflNoticeSkeleton.stopShimmer()
+    }
+
+    private fun showEmptyStateMessage() {
+        val itemCount = binding.rvNoticeList.adapter?.itemCount ?: 0
+
+        binding.tvEmptyState.root.visibility = if (itemCount == 0) View.VISIBLE else View.GONE
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -55,12 +55,15 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
                 is ScheduleEventsUiState.Loading,
                 -> {
                     showLoadingView(isLoading = true)
+                    showEmptyStateMessage()
                 }
 
                 is ScheduleEventsUiState.Success -> {
-                    adapter.submitList(schedule.events)
-                    scrollToCenterOfCurrentEvent(schedule.currentEventPosition)
                     showLoadingView(isLoading = false)
+                    adapter.submitList(schedule.events) {
+                        scrollToCenterOfCurrentEvent(schedule.currentEventPosition)
+                        showEmptyStateMessage()
+                    }
                 }
 
                 is ScheduleEventsUiState.Error -> {
@@ -70,6 +73,7 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
                     )
                     showErrorSnackBar(schedule.throwable)
                     showLoadingView(isLoading = false)
+                    showEmptyStateMessage()
                 }
             }
         }
@@ -103,6 +107,20 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
 
                 recyclerView.smoothScrollBy(NO_OFFSET, dy)
             }
+        }
+    }
+
+    private fun showEmptyStateMessage() {
+        val itemCount = binding.rvScheduleEvent.adapter?.itemCount ?: 0
+
+        if (itemCount == 0) {
+            binding.rvScheduleEvent.visibility = View.GONE
+            binding.viewScheduleEventTimeLine.visibility = View.GONE
+            binding.tvEmptyState.root.visibility = View.VISIBLE
+        } else {
+            binding.rvScheduleEvent.visibility = View.VISIBLE
+            binding.viewScheduleEventTimeLine.visibility = View.VISIBLE
+            binding.tvEmptyState.root.visibility = View.GONE
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/schedule/ScheduleTabPageFragment.kt
@@ -61,8 +61,8 @@ class ScheduleTabPageFragment : BaseFragment<FragmentScheduleTabPageBinding>(R.l
                 is ScheduleEventsUiState.Success -> {
                     showLoadingView(isLoading = false)
                     adapter.submitList(schedule.events) {
-                        scrollToCenterOfCurrentEvent(schedule.currentEventPosition)
                         showEmptyStateMessage()
+                        scrollToCenterOfCurrentEvent(schedule.currentEventPosition)
                     }
                 }
 

--- a/android/app/src/main/res/layout/fragment_faq.xml
+++ b/android/app/src/main/res/layout/fragment_faq.xml
@@ -14,5 +14,14 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <include
+            android:id="@+id/tv_empty_state"
+            layout="@layout/item_empty_state"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_lost_item.xml
+++ b/android/app/src/main/res/layout/fragment_lost_item.xml
@@ -25,6 +25,15 @@
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+        <include
+            android:id="@+id/tv_empty_state"
+            layout="@layout/item_empty_state"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.facebook.shimmer.ShimmerFrameLayout
             android:id="@+id/sfl_lost_item_skeleton"
             android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_notice.xml
+++ b/android/app/src/main/res/layout/fragment_notice.xml
@@ -26,6 +26,15 @@
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+        <include
+            android:id="@+id/tv_empty_state"
+            layout="@layout/item_empty_state"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.facebook.shimmer.ShimmerFrameLayout
             android:id="@+id/sfl_notice_skeleton"
             android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
+++ b/android/app/src/main/res/layout/fragment_schedule_tab_page.xml
@@ -32,6 +32,15 @@
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+        <include
+            android:id="@+id/tv_empty_state"
+            layout="@layout/item_empty_state"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.airbnb.lottie.LottieAnimationView
             android:id="@+id/lav_schedule_loading"
             android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout/item_empty_state.xml
+++ b/android/app/src/main/res/layout/item_empty_state.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:text="@string/empty_state_message" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="app_name">Festabook</string>
 
+
+    <!--공통-->
+    <string name="empty_state_message">현재 표시할 항목이 없습니다.</string>
+
     <!--바텀 네비게이션 바-->
     <string name="menu_home_title">홈</string>
     <string name="menu_schedule_title">일정</string>


### PR DESCRIPTION
## #️⃣ 이슈 번호

#893 

<br>

## 🛠️ 작업 내용

- 일정, 소식, FAQ, 분실물 화면에 아이템이 없을 시 문구가 보이도록 기능을 추가했습니다.


<br>

## 🙇🏻 중점 리뷰 요청
- 로직이 많이 겹치는데 인터페이스로 구현하는게 더 좋았을까 싶긴하네요 🤔

<br>

## 📸 이미지 첨부 (Optional)
<img width="200" height="445" alt="스크린샷 2025-09-19 오후 5 31 59" src="https://github.com/user-attachments/assets/29ab0bfe-df01-48e5-a1c4-ffae7b943640" />
<img width="200" height="445" alt="스크린샷 2025-09-20 오후 6 41 26" src="https://github.com/user-attachments/assets/a1f61685-a914-4894-ba85-5156f66f42c9" />
<img width="200" height="445" alt="스크린샷 2025-09-20 오후 6 44 35" src="https://github.com/user-attachments/assets/f61f4881-c07b-4917-8806-e53d5d1b0f96" />
<img width="200" height="445" alt="스크린샷 2025-09-20 오후 6 48 30" src="https://github.com/user-attachments/assets/63758b88-afb1-49ee-bc88-01ae3a8ac9db" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - FAQ, 분실물, 공지, 일정 탭에 빈 상태 표시를 추가했습니다. 데이터가 없을 때 안내 메시지를 보여주고, 필요한 경우 리스트/타임라인을 숨깁니다.
- UI 개선
  - 재사용 가능한 빈 상태 레이아웃과 공통 안내 문구를 도입했습니다.
  - 목록 갱신 후 빈 상태가 자동으로 반영되도록 처리하여 화면 전환 없이도 즉시 상태가 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->