### PR TITLE
[AN] 지도 프리뷰 애니메이션 추가

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/AnimationUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/AnimationUtil.kt
@@ -1,7 +1,9 @@
 package com.daedan.festabook.presentation.common
 
+import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
+import android.view.animation.DecelerateInterpolator
 import androidx.recyclerview.widget.RecyclerView
 
 fun ViewGroup.scrollAnimation(limitedTranslationY: Float) {
@@ -13,3 +15,15 @@ fun ViewGroup.scrollAnimation(limitedTranslationY: Float) {
 }
 
 fun RecyclerView.canScrollUp(): Boolean = this.canScrollVertically(-1)
+
+fun ViewGroup.showBottomAnimation() {
+    alpha = 0.3f // 시작 시 투명하게 설정
+    translationY = 120f // 시작 시 아래로 이동
+    visibility = View.VISIBLE // 애니메이션 전에 뷰를 보이게 함'
+    animate()
+        .alpha(1f) // 투명도를 1로
+        .translationY(0f) // 원래 위치로 이동
+        .setDuration(300) // 0.5초 동안
+        .setInterpolator(DecelerateInterpolator()) // 점점 느려지게
+        .start()
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewFragment.kt
@@ -3,7 +3,6 @@ package com.daedan.festabook.presentation.placeList.placeDetailPreview
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
-import androidx.core.view.children
 import androidx.fragment.app.viewModels
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceDetailPreviewBinding
@@ -11,6 +10,7 @@ import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.common.setFormatDate
+import com.daedan.festabook.presentation.common.showBottomAnimation
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailActivity
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
@@ -45,7 +45,10 @@ class PlaceDetailPreviewFragment :
     }
 
     private fun setUpBackPressedCallback() {
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            backPressedCallback
+        )
     }
 
     private fun setupBinding() {
@@ -64,11 +67,12 @@ class PlaceDetailPreviewFragment :
                 if (selectedPlace == SelectedPlaceUiState.Empty) View.GONE else View.VISIBLE
 
             when (selectedPlace) {
-                is SelectedPlaceUiState.Loading -> {
-                    binding.layoutSelectedPlace.visibility = View.INVISIBLE
+                is SelectedPlaceUiState.Loading -> Unit
+                is SelectedPlaceUiState.Success -> {
+                    binding.layoutSelectedPlace.showBottomAnimation()
+                    updateSelectedPlaceUi(selectedPlace.value)
                 }
 
-                is SelectedPlaceUiState.Success -> updateSelectedPlaceUi(selectedPlace.value)
                 is SelectedPlaceUiState.Error -> showErrorSnackBar(selectedPlace.throwable)
                 is SelectedPlaceUiState.Empty -> backPressedCallback.isEnabled = false
             }
@@ -78,8 +82,6 @@ class PlaceDetailPreviewFragment :
     private fun updateSelectedPlaceUi(selectedPlace: PlaceDetailUiModel) {
         with(binding) {
             layoutSelectedPlace.visibility = View.VISIBLE
-            makeChildVisible()
-
             tvSelectedPlaceTitle.text =
                 selectedPlace.place.title ?: getString(R.string.place_list_default_title)
             tvSelectedPlaceLocation.text =
@@ -100,11 +102,5 @@ class PlaceDetailPreviewFragment :
 
     private fun startPlaceDetailActivity(placeDetail: PlaceDetailUiModel) {
         startActivity(PlaceDetailActivity.newIntent(requireContext(), placeDetail))
-    }
-
-    private fun FragmentPlaceDetailPreviewBinding.makeChildVisible() {
-        layoutSelectedPlace.children.forEach {
-            it.visibility = View.VISIBLE
-        }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
@@ -10,6 +10,7 @@ import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceDetailPreviewSecondaryBinding
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
+import com.daedan.festabook.presentation.common.showBottomAnimation
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
 import com.daedan.festabook.presentation.placeList.PlaceListViewModel
@@ -50,12 +51,13 @@ class PlaceDetailPreviewSecondaryFragment :
             backPressedCallback.isEnabled = true
             when (selectedPlace) {
                 is SelectedPlaceUiState.Success -> {
-                    binding.makeChildVisible()
+                    binding.layoutSelectedPlace.visibility = View.VISIBLE
+                    binding.layoutSelectedPlace.showBottomAnimation()
                     updateSelectedPlaceUi(selectedPlace.value)
                 }
 
                 is SelectedPlaceUiState.Error -> showErrorSnackBar(selectedPlace.throwable)
-                is SelectedPlaceUiState.Loading -> binding.makeChildInvisible()
+                is SelectedPlaceUiState.Loading -> Unit
                 is SelectedPlaceUiState.Empty -> backPressedCallback.isEnabled = false
             }
         }
@@ -66,18 +68,6 @@ class PlaceDetailPreviewSecondaryFragment :
             ivSecondaryCategoryItem.load(selectedPlace.place.category.getIconId())
             tvSelectedPlaceTitle.text =
                 selectedPlace.place.title ?: getString(selectedPlace.place.category.getTextId())
-        }
-    }
-
-    private fun FragmentPlaceDetailPreviewSecondaryBinding.makeChildInvisible() {
-        layoutSelectedPlace.children.forEach {
-            it.visibility = View.INVISIBLE
-        }
-    }
-
-    private fun FragmentPlaceDetailPreviewSecondaryBinding.makeChildVisible() {
-        layoutSelectedPlace.children.forEach {
-            it.visibility = View.VISIBLE
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/899

<br>

## 🛠️ 작업 내용

- 지도 프리뷰에 애니메이션을 적용했습니다

<br>

## 🙇🏻 중점 리뷰 요청

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/4ccb6f46-74f1-4cef-810f-e2042adeaf3c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 장소 상세 미리보기에서 로드 완료 시 콘텐츠가 아래에서 부드럽게 나타나는 애니메이션(페이드/상하 이동, 300ms) 적용
  - 보조 미리보기 화면에도 동일 애니메이션 적용으로 전환 경험 향상

- 리팩터링
  - 자식 뷰 가시성 토글 로직 제거로 UI 흐름 단순화
  - 로딩 상태에서 불필요한 가시성 변경 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->