### PR TITLE
[BE] 외부 의존성 로그 기록 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/logging/LocalLoggingAspect.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LocalLoggingAspect.java
@@ -19,6 +19,7 @@ public class LocalLoggingAspect {
             (
                 within(@org.springframework.web.bind.annotation.RestController *) ||
                 within(@org.springframework.stereotype.Service *) ||
+                within(@com.daedan.festabook.global.logging.Loggable *) ||
                 execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))
             )
             """

--- a/backend/src/main/java/com/daedan/festabook/global/logging/Loggable.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/Loggable.java
@@ -1,0 +1,11 @@
+package com.daedan.festabook.global.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Loggable {
+}

--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingAspect.java
@@ -30,6 +30,7 @@ public class LoggingAspect {
             (
                 within(@org.springframework.web.bind.annotation.RestController *) ||
                 within(@org.springframework.stereotype.Service *) ||
+                within(@com.daedan.festabook.global.logging.Loggable *) ||
                 execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))
             )
             """

--- a/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
+++ b/backend/src/main/java/com/daedan/festabook/notification/infrastructure/FcmNotificationManager.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.notification.infrastructure;
 
 import com.daedan.festabook.festival.domain.FestivalNotificationManager;
 import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.global.logging.Loggable;
 import com.daedan.festabook.notification.dto.NotificationSendRequest;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+@Loggable
 @Component
 @RequiredArgsConstructor
 public class FcmNotificationManager implements FestivalNotificationManager {

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -1,6 +1,7 @@
 package com.daedan.festabook.storage.infrastructure;
 
 import com.daedan.festabook.global.exception.BusinessException;
+import com.daedan.festabook.global.logging.Loggable;
 import com.daedan.festabook.storage.domain.StorageManager;
 import com.daedan.festabook.storage.dto.StorageUploadRequest;
 import com.daedan.festabook.storage.dto.StorageUploadResponse;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+@Loggable
 @Slf4j
 @Component
 @Profile("dev")

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/LocalStorageManager.java
@@ -15,8 +15,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-@Loggable
 @Slf4j
+@Loggable
 @Component
 @Profile("dev")
 public class LocalStorageManager implements StorageManager {

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/MockStorageManager.java
@@ -1,11 +1,13 @@
 package com.daedan.festabook.storage.infrastructure;
 
+import com.daedan.festabook.global.logging.Loggable;
 import com.daedan.festabook.storage.domain.StorageManager;
 import com.daedan.festabook.storage.dto.StorageUploadRequest;
 import com.daedan.festabook.storage.dto.StorageUploadResponse;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+@Loggable
 @Component
 @Profile("!prod & !dev")
 public class MockStorageManager implements StorageManager {

--- a/backend/src/main/java/com/daedan/festabook/storage/infrastructure/S3StorageManager.java
+++ b/backend/src/main/java/com/daedan/festabook/storage/infrastructure/S3StorageManager.java
@@ -1,5 +1,6 @@
 package com.daedan.festabook.storage.infrastructure;
 
+import com.daedan.festabook.global.logging.Loggable;
 import com.daedan.festabook.storage.domain.StorageManager;
 import com.daedan.festabook.storage.dto.StorageUploadRequest;
 import com.daedan.festabook.storage.dto.StorageUploadResponse;
@@ -14,6 +15,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+@Loggable
 @Component
 @Profile("prod")
 public class S3StorageManager implements StorageManager {


### PR DESCRIPTION
## #️⃣ 이슈 번호

#910 

<br>

## 🛠️ 작업 내용

- 외부 의존성들은 @Component를 사용하여 빈 등록을 하고 있었기 때문에 로그가 기록되지 않고 있었다.
- 따라서 외부 의존성들도 로그를 상세히 작성하고 span으로 기록될 수 있도록 추가하였다.

<br>

<img width="850" height="207" alt="image" src="https://github.com/user-attachments/assets/b54ad543-4f65-4ffa-9372-90e638ff0336" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * 주석 기반 로깅을 도입해 애플리케이션 전반에서 일관된 요청/응답 및 예외 로그 수집 범위를 확대했습니다.
  * 주요 스토리지 및 알림 관리 컴포넌트에 로깅을 활성화해 운영 가시성과 대응 효율을 높였습니다.

* Refactor
  * 로깅 대상 범위를 넓혀 관찰 가능성(Observability)과 문제 진단 속도를 개선했습니다.
  * 기능 동작 및 공개 API에는 변경 없이 모니터링을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->