### PR TITLE
[AN] Hotfix: 포토부스, 기타시설 클릭 시, 한 눈에 보기에 빈 화면 뜨는 버그 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/domain/model/PlaceCategory.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/PlaceCategory.kt
@@ -23,6 +23,8 @@ enum class PlaceCategory {
                 PARKING,
                 PRIMARY,
                 STAGE,
+                PHOTO_BOOTH,
+                EXTRA,
             )
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

>https://github.com/woowacourse-teams/2025-festabook/issues/919

<br>

## 🛠️ 작업 내용

- 포토부스, 기타시설 클릭 시, 한 눈에 보기에 빈 화면 뜨는 버그를 해결하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 보조 카테고리에 포토부스 및 기타가 추가되었습니다. 이제 지도/목록, 검색 필터, 카테고리 탭에서 해당 항목을 선택하고 탐색할 수 있으며, 관련 장소에 새 태그/배지가 표시됩니다.
  * 추천 및 정렬 기능이 새 보조 카테고리를 인식하여 더 정확한 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->