### PR TITLE
[BE] WARN, ERROR 수준의 예외를 세분화

### DIFF
--- a/backend/src/test/java/com/daedan/festabook/global/config/TestSecurityConfig.java
+++ b/backend/src/test/java/com/daedan/festabook/global/config/TestSecurityConfig.java
@@ -24,8 +24,8 @@ public class TestSecurityConfig {
                         .requestMatchers("/test/addCorsMappings/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/test/addArgumentResolvers").permitAll()
                         .requestMatchers(HttpMethod.GET, "/test/resolveArgument").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/test/business-exception-test").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/test/runtime-exception-test").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/test/exception-controller/custom-exception").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/test/exception-controller/inject-exception").permitAll()
                 );
 
         return http.build();

--- a/backend/src/test/java/com/daedan/festabook/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/global/exception/GlobalExceptionHandlerTest.java
@@ -5,16 +5,27 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.daedan.festabook.global.config.TestSecurityConfig;
 import io.restassured.RestAssured;
+import java.sql.SQLException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +37,9 @@ class GlobalExceptionHandlerTest {
 
     private static final String MESSAGE_PARAM_NAME = "message";
     private static final String STATUS_CODE_PARAM_NAME = "status-code";
+
+    @Autowired
+    private ExceptionController exceptionController;
 
     @LocalServerPort
     private int port;
@@ -51,7 +65,7 @@ class GlobalExceptionHandlerTest {
                     .queryParam(MESSAGE_PARAM_NAME, expectedMessage)
                     .queryParam(STATUS_CODE_PARAM_NAME, expectedStatusCode)
                     .when()
-                    .get("/test/business-exception-test")
+                    .get("/test/exception-controller/custom-exception")
                     .then()
                     .log()
                     .all()
@@ -59,19 +73,24 @@ class GlobalExceptionHandlerTest {
                     .body("size()", equalTo(expectedFieldSize))
                     .body("message", equalTo(expectedMessage));
         }
+    }
+
+    @Nested
+    class handleAuthenticationCredentialsNotFoundException {
 
         @Test
-        void 성공_예상치_못한_예외_발생시_안내_메시지를_응답() {
+        void 인증_실패_예외_발생시_401_응답() {
             // given
-            String expectedMessage = "관리자에게";
-            int expectedStatusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+            exceptionController.injectException(new AuthenticationCredentialsNotFoundException(""));
+            String expectedMessage = "인증되지 않은 사용자입니다.";
+            int expectedStatusCode = HttpStatus.UNAUTHORIZED.value();
             int expectedFieldSize = 1;
 
             // when & then
             RestAssured
                     .given()
                     .when()
-                    .get("/test/runtime-exception-test")
+                    .get("/test/exception-controller/inject-exception")
                     .then()
                     .log()
                     .all()
@@ -81,10 +100,124 @@ class GlobalExceptionHandlerTest {
         }
     }
 
+    @Nested
+    class handleAccessDeniedException {
+
+        @Test
+        void 인가_실패_예외_발생시_403_응답() {
+            // given
+            exceptionController.injectException(new AccessDeniedException(""));
+            String expectedMessage = "인가되지 않은 사용자입니다.";
+            int expectedStatusCode = HttpStatus.FORBIDDEN.value();
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .when()
+                    .get("/test/exception-controller/inject-exception")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(expectedStatusCode)
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("message", containsString(expectedMessage));
+        }
+    }
+
+    @Nested
+    class handleWarnDatabaseException {
+
+        @ParameterizedTest
+        @MethodSource
+        void 데이터베이스_일시적인_예외_발생시_500_응답(DataAccessException exception) {
+            // given
+            exceptionController.injectException(exception);
+            int expectedStatusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .when()
+                    .get("/test/exception-controller/inject-exception")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(expectedStatusCode)
+                    .body("size()", equalTo(expectedFieldSize));
+        }
+
+        private static Stream<DataAccessException> 데이터베이스_일시적인_예외_발생시_500_응답() {
+            return Stream.of(
+                    new DataIntegrityViolationException(""),
+                    new DataAccessResourceFailureException("")
+            );
+        }
+    }
+
+    @Nested
+    class handleErrorDatabaseException {
+
+        @ParameterizedTest
+        @MethodSource
+        void 데이터베이스_치명적인_예외_발생시_500_응답(DataAccessException exception) {
+            // given
+            exceptionController.injectException(exception);
+            int expectedStatusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .when()
+                    .get("/test/exception-controller/inject-exception")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(expectedStatusCode)
+                    .body("size()", equalTo(expectedFieldSize));
+        }
+
+        private static Stream<DataAccessException> 데이터베이스_치명적인_예외_발생시_500_응답() {
+            return Stream.of(
+                    new BadSqlGrammarException("", "", new SQLException()),
+                    new DataAccessResourceFailureException("")
+            );
+        }
+    }
+
+    @Nested
+    class handleRuntimeException {
+
+        @Test
+        void 성공_예상치_못한_예외_발생시_안내_메시지를_응답() {
+            // given
+            exceptionController.injectException(new RuntimeException());
+            String expectedMessage = "서버에 오류가 발생하였습니다. 관리자에게 문의해주세요.";
+            int expectedStatusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+            int expectedFieldSize = 1;
+
+            // when & then
+            RestAssured
+                    .given()
+                    .when()
+                    .get("/test/exception-controller/inject-exception")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(expectedStatusCode)
+                    .body("size()", equalTo(expectedFieldSize))
+                    .body("message", equalTo(expectedMessage));
+        }
+    }
+
     @RestController
     static public class ExceptionController {
 
-        @GetMapping("/test/business-exception-test")
+        private Exception exception;
+
+        @GetMapping("/test/exception-controller/custom-exception")
         public void test1(
                 @RequestParam(MESSAGE_PARAM_NAME) String message,
                 @RequestParam(STATUS_CODE_PARAM_NAME) int statusCode
@@ -92,9 +225,13 @@ class GlobalExceptionHandlerTest {
             throw new BusinessException(message, HttpStatus.valueOf(statusCode));
         }
 
-        @GetMapping("/test/runtime-exception-test")
-        public void test2() {
-            throw new RuntimeException();
+        @GetMapping("/test/exception-controller/inject-exception")
+        public void test() throws Exception {
+            throw exception;
+        }
+
+        public void injectException(Exception exception) {
+            this.exception = exception;
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#870 

<br>

## 🛠️ 작업 내용

- warn, error 수준의 예외를 세분화하여 처리하도록 수정하였습니다.
- GlobalExceptionHandler의 테스트를 추가하였습니다.
- 추가된 예외
  -  WARN : 데이터베이스 타임아웃, 데이터베이스 무결성 제약조건
  - ERROR: JPQL 문법 오류, SQL 문법 오류


<br>

## 📸 이미지 첨부 (Optional)

<img width="524" height="422" alt="image" src="https://github.com/user-attachments/assets/a16a006c-1d6f-4bb9-9610-1041ff724b1b" />
