### PR TITLE
[AN] 탐색 화면 이동 로직 개선

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreActivity.kt
@@ -114,7 +114,7 @@ class ExploreActivity :
             handleSearchAction()
         }
 
-        binding.btnExploreClose.setOnClickListener {
+        binding.btnBackToMain.setOnClickListener {
             finish()
         }
     }
@@ -168,7 +168,7 @@ class ExploreActivity :
             }
         }
         viewModel.hasFestivalId.observe(this) { hasId ->
-            binding.btnExploreClose.visibility = if (hasId) View.VISIBLE else View.GONE
+            binding.layoutExploreToolbar.visibility = if (hasId) View.VISIBLE else View.GONE
             binding.ivLogoTitle.visibility = if (hasId) View.GONE else View.VISIBLE
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -44,10 +44,11 @@ class ExploreViewModel(
                 .debounce(300L)
                 .distinctUntilChanged()
                 .collectLatest { query ->
-                    if (query.isEmpty()) {
-                        _searchState.value = SearchUiState.Idle
-                        return@collectLatest
-                    }
+// 현재는 검색어가 없을 시, 전체 리스트를 보여주기 위해 아래의 코드를 주석처리해두었음.
+//                    if (query.isEmpty()) {
+//                        _searchState.value = SearchUiState.Idle
+//                        return@collectLatest
+//                    }
 
                     _searchState.value = SearchUiState.Loading
 

--- a/android/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/android/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,11H6.83l3.58,-3.59L9,6l-6,6 6,6 1.41,-1.41L6.83,13H21z"/>
+    
+</vector>

--- a/android/app/src/main/res/drawable/ic_arrow_left.xml
+++ b/android/app/src/main/res/drawable/ic_arrow_left.xml
@@ -1,5 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
-      
-    <path android:fillColor="@android:color/white" android:pathData="M560,720L320,480L560,240L616,296L432,480L616,664L560,720Z"/>
-    
-</vector>

--- a/android/app/src/main/res/layout/activity_explore.xml
+++ b/android/app/src/main/res/layout/activity_explore.xml
@@ -5,24 +5,41 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".presentation.explore.ExploreActivity">
 
-    <ImageView
-        android:id="@+id/btn_explore_close"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_explore_toolbar"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/explore_btn_close_desc"
-        android:visibility="invisible"
-        android:layout_marginStart="28dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:src="@drawable/ic_arrow_left"
-        android:clickable="true"
-        android:focusable="true"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:padding="8dp"
-        android:layout_marginTop="52dp"
-        tools:visibility="visible"/>
+        android:paddingVertical="12dp"
+        android:paddingHorizontal="8dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/btn_backToMain"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/explore_btn_backToMain_content_desc"
+            android:padding="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_arrow_back"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_explore_title"
+            style="@style/PretendardBold20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/explore_toolbar_title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ImageView
         android:id="@+id/iv_logo_title"
@@ -34,7 +51,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="gone"/>
+        tools:visibility="gone" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/til_search_input_layout"
@@ -56,8 +73,8 @@
         app:endIconMode="custom"
         app:endIconTint="@color/gray500"
         app:hintTextColor="@color/gray900"
-        app:layout_goneMarginTop="92dp"
-        app:layout_constraintTop_toBottomOf="@id/iv_logo_title">
+        app:layout_constraintTop_toBottomOf="@id/iv_logo_title"
+        app:layout_goneMarginTop="80dp">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/et_search_text"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -142,4 +142,6 @@
     <string name="update_failed_title">서버 통신 실패</string>
     <string name="update_failed_message">앱 서버에 접속할 수 없습니다. 다시 시도해주세요</string>
     <string name="update_failed_confirm">종료</string>
+    <string name="explore_btn_backToMain_content_desc">홈화면으로 돌아가기</string>
+    <string name="explore_toolbar_title">축제 검색</string>
 </resources>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #895 

<br>

## 🛠️ 작업 내용

- 이미 학교에 접근한 경우, 다시 탐색화면으로 갔을 때의 뷰를 변경했습니다. 
- 검색어가 없는 경우에는, 현재 존재하는 전체 대학 축제 리스트가 뜨도록 변경했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)


https://github.com/user-attachments/assets/a34e6181-73cf-4c44-ad6a-b869168fcf66




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 탐색 화면에 툴바(뒤로가기 버튼·제목) 추가로 더 명확한 내비게이션과 화면 타이틀 제공
  - 검색어가 비어 있어도 전체 목록을 불러오도록 동작 변경(초기 상태에서 바로 결과 확인 가능)
- 스타일
  - 뒤로가기 아이콘을 24dp 벡터로 교체해 시각적 일관성 개선
  - 툴바와 타이틀용 문자열 추가로 표시 텍스트와 콘텐츠 설명 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->