### PR TITLE
[FE] 각 부스의 타임 태그를 부스별로 볼 수 있도록 추가

### DIFF
--- a/frontend/src/pages/PlacePage.jsx
+++ b/frontend/src/pages/PlacePage.jsx
@@ -185,6 +185,8 @@ const OtherPlaceCard = ({ place, onEdit, onDelete, onCoordinateEdit, showToast }
         return colorMap[category] || 'bg-gray-100 text-gray-900 border-gray-200';
     };
 
+    const timeTags = place.timeTags || [];
+
     return (
         <div
             className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden transition-all duration-300 hover:shadow-lg hover:scale-[1.02] group"
@@ -193,6 +195,15 @@ const OtherPlaceCard = ({ place, onEdit, onDelete, onCoordinateEdit, showToast }
         >
             {/* 콘텐츠 섹션 */}
             <div className="p-4">
+            <div className='grid grid-cols-4 gap-1 w-11/12 mb-1'>
+                    {timeTags.map(tag => (
+                        <div key={tag.timeTagId} className="flex items-center shrink-0">
+                            <div className="inline-flex items-center px-1 font-extrabold bg-yellow-200 border-yellow-300 py-1 rounded-lg text-[9px] border">
+                                {tag.name}
+                            </div>
+                        </div>
+                    ))}
+                </div>
                 <div className="flex items-center justify-between mb-1">
                     <div className="flex-1 min-w-0">
                         <h3 className="font-bold text-lg text-gray-900 truncate" title={place.title}>


### PR DESCRIPTION
## #️⃣ 이슈 번호

#950 

<br>

## 🛠️ 작업 내용

- 각 부스의 타임 태그를 부스별로 볼 수 있도록 추가

<br>

## 📸 이미지 첨부 (Optional)

<img width="291" height="533" alt="image" src="https://github.com/user-attachments/assets/1f152024-49ce-45e9-829a-5890332f4021" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 장소 카드(Main/Other)에 시간 태그 배지 표시 추가: 태그 이름을 4열 그리드로 시각화하여 가독성 향상.
- Style
  - 보기 모드 토글 버튼의 클래스 표현식을 정리(동작 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->