### PR TITLE
[BE] Place Geography 응답 DTO에 TimeTags 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponse.java
@@ -3,20 +3,25 @@ package com.daedan.festabook.place.dto;
 import com.daedan.festabook.festival.dto.FestivalCoordinateResponse;
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceCategory;
+import com.daedan.festabook.timetag.domain.TimeTag;
+import com.daedan.festabook.timetag.dto.TimeTagResponses;
+import java.util.List;
 
 public record PlaceGeographyResponse(
         Long placeId,
         PlaceCategory category,
         FestivalCoordinateResponse markerCoordinate,
-        String title
+        String title,
+        TimeTagResponses timeTags
 ) {
 
-    public static PlaceGeographyResponse from(Place place) {
+    public static PlaceGeographyResponse from(Place place, List<TimeTag> timeTags) {
         return new PlaceGeographyResponse(
                 place.getId(),
                 place.getCategory(),
                 FestivalCoordinateResponse.from(place.getCoordinate()),
-                place.getTitle()
+                place.getTitle(),
+                TimeTagResponses.from(timeTags)
         );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponses.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceGeographyResponses.java
@@ -1,18 +1,25 @@
 package com.daedan.festabook.place.dto;
 
 import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.timetag.domain.TimeTag;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
+import java.util.Map;
 
 public record PlaceGeographyResponses(
         @JsonValue List<PlaceGeographyResponse> responses
 ) {
 
-    public static PlaceGeographyResponses from(List<Place> places) {
+    public static PlaceGeographyResponses from(List<Place> places, Map<Long, List<TimeTag>> timeTagsMap) {
         return new PlaceGeographyResponses(
                 places.stream()
                         .filter(place -> place.getCoordinate() != null)
-                        .map(PlaceGeographyResponse::from)
+                        .map(place ->
+                                PlaceGeographyResponse.from(
+                                        place,
+                                        timeTagsMap.getOrDefault(place.getId(), List.of())
+                                )
+                        )
                         .toList()
         );
     }

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceGeographyService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceGeographyService.java
@@ -7,7 +7,12 @@ import com.daedan.festabook.place.dto.PlaceCoordinateRequest;
 import com.daedan.festabook.place.dto.PlaceCoordinateResponse;
 import com.daedan.festabook.place.dto.PlaceGeographyResponses;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import com.daedan.festabook.timetag.domain.PlaceTimeTag;
+import com.daedan.festabook.timetag.domain.TimeTag;
+import com.daedan.festabook.timetag.infrastructure.PlaceTimeTagJpaRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -18,10 +23,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlaceGeographyService {
 
     private final PlaceJpaRepository placeJpaRepository;
+    private final PlaceTimeTagJpaRepository placeTimeTagJpaRepository;
 
+    @Transactional(readOnly = true)
     public PlaceGeographyResponses getAllPlaceGeographyByFestivalId(Long festivalId) {
         List<Place> places = placeJpaRepository.findAllByFestivalId(festivalId);
-        return PlaceGeographyResponses.from(places);
+        Map<Long, List<TimeTag>> timeTagsMap = mapTimeTagsToIds(places);
+
+        return PlaceGeographyResponses.from(places, timeTagsMap);
     }
 
     @Transactional
@@ -47,5 +56,19 @@ public class PlaceGeographyService {
         if (!place.isFestivalIdEqualTo(festivalId)) {
             throw new BusinessException("해당 축제의 플레이스가 아닙니다.", HttpStatus.FORBIDDEN);
         }
+    }
+
+    private Map<Long, List<TimeTag>> mapTimeTagsToIds(List<Place> places) {
+        // TODO: N+1 문제 해결
+        List<PlaceTimeTag> placeTimeTags = placeTimeTagJpaRepository.findAllByPlaceIn(places);
+
+        return placeTimeTags.stream()
+                .collect(Collectors.groupingBy(
+                        placeTimeTag -> placeTimeTag.getPlace().getId(),
+                        Collectors.mapping(
+                                PlaceTimeTag::getTimeTag,
+                                Collectors.toList()
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#955 

<br>

## 🛠️ 작업 내용

Place Geography 응답 DTO에 TimeTags 추가

<br>

## 🙇🏻 중점 리뷰 요청

- 잘부탁드립니다.

<br>

## 📸 이미지 첨부 (Optional)

<img width="1706" height="510" alt="image" src="https://github.com/user-attachments/assets/91881f55-9a0b-4904-a469-77c1d9f8b744" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 축제 장소 지리 정보에 시간 태그가 포함되어 응답됩니다(각 장소별 시간 태그 목록 및 기본 정보 제공).
* 테스트
  * 시간 태그 연동 시나리오 추가 및 기존 테스트 보강으로 응답 구조와 데이터 검증 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->