### PR TITLE
[BE] 로그에 festival 헤더 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/global/logging/LoggingFilter.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/LoggingFilter.java
@@ -48,6 +48,7 @@ public class LoggingFilter extends OncePerRequestFilter {
     private static final String REQUEST_USER_IP_HEADER_NAME = "X-Forwarded-For";
     private static final String AUTHENTICATION_HEADER = "Authorization";
     private static final String AUTHENTICATION_SCHEME = "Bearer ";
+    private static final String FESTIVAL_HEADER_NAME = "festival";
 
     private final ObjectMapper objectMapper;
     private final JwtProvider jwtProvider;
@@ -66,6 +67,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         String httpMethod = request.getMethod();
         String ipAddress = request.getHeader(REQUEST_USER_IP_HEADER_NAME);
         String token = extractTokenFromHeader(request);
+        String festivalId = request.getHeader(FESTIVAL_HEADER_NAME);
         String username = extractUsernameFromToken(token);
 
         stopWatch.start();
@@ -87,6 +89,7 @@ public class LoggingFilter extends OncePerRequestFilter {
                     uri,
                     ipAddress,
                     username,
+                    festivalId,
                     statusCode,
                     maskIfContainsMaskingPath(uri, httpMethod, requestBody),
                     executionTime

--- a/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiLog.java
+++ b/backend/src/main/java/com/daedan/festabook/global/logging/dto/ApiLog.java
@@ -7,6 +7,7 @@ public record ApiLog(
         String uri,
         String ipAddress,
         String username,
+        String festivalId,
         int httpStatusCode,
         Object requestBody,
         long executionTime
@@ -18,6 +19,7 @@ public record ApiLog(
             String uri,
             String ipAddress,
             String username,
+            String festivalId,
             int httpStatusCode,
             Object requestBody,
             long executionTime
@@ -29,6 +31,7 @@ public record ApiLog(
                 uri,
                 ipAddress,
                 username,
+                festivalId,
                 httpStatusCode,
                 requestBody,
                 executionTime


### PR DESCRIPTION
## #️⃣ 이슈 번호

#971 

<br>

## 🛠️ 작업 내용

- 로그에 festival 헤더 추가

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 요청의 ‘festival’ 헤더에서 축제 ID를 추출해 서버 접근 로그에 포함합니다.
  - 로그에 축제 ID 필드가 추가되어 트래픽 추적성과 모니터링·분석 정밀도가 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->