### PR TITLE
[FE] DEV -> PROD 병합

### DIFF
--- a/frontend/src/pages/PlacePage.jsx
+++ b/frontend/src/pages/PlacePage.jsx
@@ -204,15 +204,6 @@ const OtherPlaceCard = ({ place, onEdit, onDelete, onCoordinateEdit, showToast }
                             </div>
                             {placeCategories[place.category]}
                         </div>
-                        {timeTags.length > 0 && (
-                            <div className='flex flex-wrap gap-1 mt-2'>
-                                {timeTags.map(tag => (
-                                    <div key={tag.timeTagId} className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border bg-yellow-50 text-yellow-800 border-yellow-200">
-                                        {tag.name}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
                     </div>
 
                     {/* 호버 시 액션 버튼 */}
@@ -249,6 +240,15 @@ const OtherPlaceCard = ({ place, onEdit, onDelete, onCoordinateEdit, showToast }
                         </button>
                     </div>
                 </div>
+                {timeTags.length > 0 && (
+                    <div className='flex flex-wrap gap-1 mt-2'>
+                        {timeTags.map(tag => (
+                            <div key={tag.timeTagId} className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border bg-yellow-50 text-yellow-800 border-yellow-200">
+                                {tag.name}
+                            </div>
+                        ))}
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 리팩터링
  * 메인 장소 카드 헤더에서 시간 태그 표시를 제거했습니다.
  * 기타 장소 카드에 시간 태그 표시를 추가했습니다. 헤더/액션 영역 아래에 배치되며, 태그가 하나 이상 있을 때만 노출됩니다. 태그 스타일과 표시 방식은 기존과 동일합니다.
  * 이제 사용자는 메인 카드 상단에서 시간 태그를 보지 않고, 기타 카드에서만 확인합니다. 정보 배치가 정돈되어 가독성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->