### PR TITLE
[AN] FAQ화면 Compose 마이그레이션

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+ktlint_standard_annotation = disabled
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ fabric.properties
 
 .idea
 .DS_Store
+*.log

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.kotlin.compose)
     id("kotlin-kapt")
     id("kotlin-parcelize")
     id("com.google.gms.google-services")
@@ -140,6 +141,7 @@ android {
         buildConfig = true
         dataBinding = true
         viewBinding = true
+        compose = true
     }
 }
 
@@ -173,7 +175,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.ui.tooling)
     implementation(libs.androidx.material3)
     implementation(libs.photoview.dialog)
     testImplementation(libs.junit)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -66,8 +66,8 @@ android {
         applicationId = "com.daedan.festabook"
         minSdk = 28
         targetSdk = 36
-        versionCode = 10_100
-        versionName = "v 1.1.0"
+        versionCode = 10_200
+        versionName = "v 1.2.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField(

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -175,6 +175,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.photoview.dialog)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.androidx.core.testing)

--- a/android/app/src/main/java/com/daedan/festabook/domain/model/PlaceCategory.kt
+++ b/android/app/src/main/java/com/daedan/festabook/domain/model/PlaceCategory.kt
@@ -23,6 +23,8 @@ enum class PlaceCategory {
                 PARKING,
                 PRIMARY,
                 STAGE,
+                PHOTO_BOOTH,
+                EXTRA,
             )
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/logging/model/explore/ExploreLogData.kt
+++ b/android/app/src/main/java/com/daedan/festabook/logging/model/explore/ExploreLogData.kt
@@ -1,0 +1,26 @@
+package com.daedan.festabook.logging.model.explore
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+// 탐색 화면 진입
+@Parcelize
+data class ExploreViewLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val hasFestivalId: Boolean,
+) : BaseLogData
+
+// 검색 요청에 따른 결과 정보
+@Parcelize
+data class ExploreSearchResultLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val query: String,
+    val resultCount: Int,
+) : BaseLogData
+
+// 대학교 선택
+@Parcelize
+data class ExploreSelectUniversityLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val universityName: String,
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/logging/model/home/HomeLogData.kt
+++ b/android/app/src/main/java/com/daedan/festabook/logging/model/home/HomeLogData.kt
@@ -1,0 +1,31 @@
+package com.daedan.festabook.logging.model.home
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+// 홈 화면 진입
+@Parcelize
+data class HomeViewLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val universityName: String,
+    val festivalId: Long,
+) : BaseLogData
+
+// Explore 버튼 클릭
+@Parcelize
+data class ExploreClickLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+) : BaseLogData
+
+// Schedule 버튼 클릭
+@Parcelize
+data class ScheduleClickLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+) : BaseLogData
+
+// 라인업 아티스트 클릭
+@Parcelize
+data class LineupClickLogData(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val artistId: Long,
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/ImageUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/ImageUtil.kt
@@ -21,14 +21,7 @@ fun ImageView.loadImage(
     url: String?,
     block: ImageRequest.Builder.() -> Unit = {},
 ) {
-    val finalUrl =
-        if (url != null && url.startsWith("/images/")) {
-            BuildConfig.FESTABOOK_URL.removeSuffix("/api/") + url
-        } else {
-            url
-        }
-
-    this.load(finalUrl) {
+    this.load(url.convertImageUrl()) {
         block()
         crossfade(true)
         placeholder(Color.LTGRAY.toDrawable())
@@ -36,6 +29,13 @@ fun ImageView.loadImage(
         error(R.drawable.img_fallback)
     }
 }
+
+fun String?.convertImageUrl() = if (this != null && this.startsWith("/images/")) {
+    BuildConfig.FESTABOOK_URL.removeSuffix("/api/") + this
+} else {
+    this
+}
+
 
 fun vectorToBitmap(
     context: Context,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/component/EmptyStateScreen.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/component/EmptyStateScreen.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.presentation.common.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.daedan.festabook.R
+
+@Composable
+fun EmptyStateScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Text(
+            text = stringResource(R.string.empty_state_message),
+            modifier = Modifier.align(Alignment.Center),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptyStateScreenPreview() {
+    EmptyStateScreen()
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/explore/ExploreActivity.kt
@@ -14,6 +14,10 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.doOnTextChanged
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ActivityExploreBinding
+import com.daedan.festabook.logging.logger
+import com.daedan.festabook.logging.model.explore.ExploreSearchResultLogData
+import com.daedan.festabook.logging.model.explore.ExploreSelectUniversityLogData
+import com.daedan.festabook.logging.model.explore.ExploreViewLogData
 import com.daedan.festabook.presentation.explore.adapter.OnUniversityClickListener
 import com.daedan.festabook.presentation.explore.adapter.SearchResultAdapter
 import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
@@ -34,6 +38,13 @@ class ExploreActivity :
         viewModel.onUniversitySelected(university)
         binding.tilSearchInputLayout.endIconMode = TextInputLayout.END_ICON_CUSTOM
         binding.tilSearchInputLayout.setEndIconDrawable(R.drawable.ic_arrow_right)
+
+        binding.logger.log(
+            ExploreSelectUniversityLogData(
+                baseLogData = binding.logger.getBaseLogData(),
+                universityName = university.universityName,
+            ),
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -69,6 +80,13 @@ class ExploreActivity :
         setupBinding()
         setupRecyclerView()
         setupObservers()
+
+        binding.logger.log(
+            ExploreViewLogData(
+                baseLogData = binding.logger.getBaseLogData(),
+                hasFestivalId = viewModel.hasFestivalId.value ?: false,
+            ),
+        )
     }
 
     private fun setupBinding() {
@@ -151,6 +169,17 @@ class ExploreActivity :
                         binding.tilSearchInputLayout.isErrorEnabled = false
                         searchResultAdapter.submitList(state.universitiesFound)
                     }
+
+                    binding.logger.log(
+                        ExploreSearchResultLogData(
+                            baseLogData = binding.logger.getBaseLogData(),
+                            query =
+                                binding.etSearchText.text
+                                    ?.toString()
+                                    .orEmpty(),
+                            resultCount = state.universitiesFound.size,
+                        ),
+                    )
                 }
 
                 is SearchUiState.Error -> {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/HomeFragment.kt
@@ -7,6 +7,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.PagerSnapHelper
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentHomeBinding
+import com.daedan.festabook.logging.logger
+import com.daedan.festabook.logging.model.home.ExploreClickLogData
+import com.daedan.festabook.logging.model.home.HomeViewLogData
+import com.daedan.festabook.logging.model.home.ScheduleClickLogData
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.formatFestivalPeriod
 import com.daedan.festabook.presentation.common.showErrorSnackBar
@@ -19,6 +23,7 @@ import timber.log.Timber
 
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private val viewModel: HomeViewModel by viewModels({ requireActivity() }) { HomeViewModel.Factory }
+
     private val centerItemMotionEnlarger = CenterItemMotionEnlarger()
 
     private val posterAdapter: PosterAdapter by lazy {
@@ -43,12 +48,20 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
     private fun setupNavigateToExploreButton() {
         binding.layoutTitleWithIcon.setOnClickListener {
+            binding.logger.log(ExploreClickLogData(binding.logger.getBaseLogData()))
+
             startActivity(ExploreActivity.newIntent(requireContext()))
         }
     }
 
     private fun setupNavigateToScheduleButton() {
         binding.btnNavigateToSchedule.setOnClickListener {
+            binding.logger.log(
+                ScheduleClickLogData(
+                    baseLogData = binding.logger.getBaseLogData(),
+                ),
+            )
+
             viewModel.navigateToScheduleClick()
         }
     }
@@ -113,6 +126,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                 scrollToInitialPosition(posterUrls.size)
             }
         }
+        binding.logger.log(
+            HomeViewLogData(
+                baseLogData = binding.logger.getBaseLogData(),
+                universityName = festivalUiState.organization.universityName,
+                festivalId = festivalUiState.organization.id,
+            ),
+        )
     }
 
     private fun attachSnapHelper() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
@@ -3,20 +3,39 @@ package com.daedan.festabook.presentation.home.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import coil3.load
 import coil3.request.CachePolicy
+import coil3.request.crossfade
 import coil3.request.transformations
 import coil3.transform.RoundedCornersTransformation
+import com.daedan.festabook.BuildConfig
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ItemHomePosterBinding
 import com.daedan.festabook.logging.DefaultFirebaseLogger
 import com.daedan.festabook.logging.model.PosterTouchLogData
 import com.daedan.festabook.logging.logger
+import com.daedan.festabook.presentation.common.convertImageUrl
 import com.daedan.festabook.presentation.common.loadImage
+import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 
 class PosterItemViewHolder(
-    val binding: ItemHomePosterBinding,
+    private val binding: ItemHomePosterBinding,
 ) : RecyclerView.ViewHolder(binding.root) {
+
     fun bind(url: String) {
+        val imageDialog = PhotoViewDialog.Builder(
+            context = binding.root.context,
+            images = listOf(url),
+        ) { imageView, url ->
+            imageView.load(url.convertImageUrl()) {
+                crossfade(true)
+            }
+        }
+            .withHiddenStatusBar(false)
+            .withTransitionFrom(binding.ivHomePoster)
+            .build()
+
         binding.ivHomePoster.loadImage(url) {
             transformations(RoundedCornersTransformation(20f))
             memoryCachePolicy(CachePolicy.ENABLED)
@@ -30,6 +49,9 @@ class PosterItemViewHolder(
                     url = url,
                 ),
             )
+        }
+        binding.ivHomePoster.setOnClickListener {
+            imageDialog.show()
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
@@ -19,6 +19,7 @@ import com.daedan.festabook.domain.repository.NoticeRepository
 import com.daedan.festabook.presentation.common.Event
 import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import com.daedan.festabook.presentation.news.faq.model.toUiModel
 import com.daedan.festabook.presentation.news.lost.LostUiState
 import com.daedan.festabook.presentation.news.lost.model.LostUiModel
 import com.daedan.festabook.presentation.news.lost.model.toLostGuideItemUiModel
@@ -27,7 +28,6 @@ import com.daedan.festabook.presentation.news.notice.NoticeUiState
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 import com.daedan.festabook.presentation.news.notice.model.toUiModel
 import kotlinx.coroutines.launch
-import com.daedan.festabook.presentation.news.faq.model.toUiModel as faqToUiModel
 
 class NewsViewModel(
     private val noticeRepository: NoticeRepository,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/NewsViewModel.kt
@@ -1,5 +1,8 @@
 package com.daedan.festabook.presentation.news
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -34,8 +37,8 @@ class NewsViewModel(
     private val _noticeUiState: MutableLiveData<NoticeUiState> = MutableLiveData<NoticeUiState>()
     val noticeUiState: LiveData<NoticeUiState> = _noticeUiState
 
-    private val _faqUiState: MutableLiveData<FAQUiState> = MutableLiveData()
-    val faqUiState: LiveData<FAQUiState> get() = _faqUiState
+    var faqUiState by mutableStateOf<FAQUiState>(FAQUiState.InitialLoading)
+        private set
 
     private val _lostUiState: MutableLiveData<LostUiState> = MutableLiveData()
     val lostUiState: LiveData<LostUiState> get() = _lostUiState
@@ -139,14 +142,15 @@ class NewsViewModel(
 
     private fun loadAllFAQs(state: FAQUiState = FAQUiState.InitialLoading) {
         viewModelScope.launch {
-            _faqUiState.value = state
+            faqUiState = state
 
             val result = faqRepository.getAllFAQ()
+
             result
-                .onSuccess { fAQItems ->
-                    _faqUiState.value = FAQUiState.Success(fAQItems.map { it.faqToUiModel() })
+                .onSuccess { faqItems ->
+                    faqUiState = FAQUiState.Success(faqItems.map { it.toUiModel() })
                 }.onFailure {
-                    _faqUiState.value = FAQUiState.Error(it)
+                    faqUiState = FAQUiState.Error(it)
                 }
         }
     }
@@ -161,8 +165,8 @@ class NewsViewModel(
     }
 
     private fun updateFAQUiState(onUpdate: (List<FAQItemUiModel>) -> List<FAQItemUiModel>) {
-        val currentState = _faqUiState.value ?: return
-        _faqUiState.value =
+        val currentState = faqUiState
+        faqUiState =
             when (currentState) {
                 is FAQUiState.Success -> currentState.copy(faqs = onUpdate(currentState.faqs))
                 else -> currentState

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsItem.kt
@@ -1,4 +1,4 @@
-package com.daedan.festabook.presentation.news.faq.component
+package com.daedan.festabook.presentation.news.component
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsItem.kt
@@ -92,7 +92,7 @@ fun NewsItem(
             } else {
                 Icon(
                     painter = painterResource(R.drawable.ic_chevron_down),
-                    contentDescription = stringResource(R.string.faq_expand),
+                    contentDescription = stringResource(R.string.chevron_down),
                     modifier = Modifier.rotate(rotation),
                 )
             }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentFaqBinding
@@ -20,16 +21,15 @@ class FAQFragment : BaseFragment<FragmentFaqBinding>(R.layout.fragment_faq) {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        val composeView = ComposeView(requireContext())
-        composeView.setContent {
-            FAQScreen(uiState = viewModel.faqUiState, onFaqClick = { faqItemUiModel ->
-                (requireParentFragment() as OnNewsClickListener).onFAQClick(faqItemUiModel)
-            })
+    ): View =
+        ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                FAQScreen(uiState = viewModel.faqUiState, onFaqClick = { faqItemUiModel ->
+                    (requireParentFragment() as OnNewsClickListener).onFAQClick(faqItemUiModel)
+                })
+            }
         }
-
-        return composeView
-    }
 
     companion object {
         fun newInstance() = FAQFragment()

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQFragment.kt
@@ -1,57 +1,34 @@
 package com.daedan.festabook.presentation.news.faq
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.viewModels
-import androidx.recyclerview.widget.DefaultItemAnimator
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentFaqBinding
 import com.daedan.festabook.presentation.common.BaseFragment
-import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.news.NewsViewModel
-import com.daedan.festabook.presentation.news.faq.adapter.FAQAdapter
+import com.daedan.festabook.presentation.news.faq.component.FAQScreen
 import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
-import timber.log.Timber
 
 class FAQFragment : BaseFragment<FragmentFaqBinding>(R.layout.fragment_faq) {
     private val viewModel: NewsViewModel by viewModels({ requireParentFragment() }) { NewsViewModel.Factory }
-    private val adapter by lazy {
-        FAQAdapter(requireParentFragment() as OnNewsClickListener)
-    }
 
-    override fun onViewCreated(
-        view: View,
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) {
-        super.onViewCreated(view, savedInstanceState)
-        binding.rvFaq.adapter = adapter
-        (binding.rvFaq.itemAnimator as DefaultItemAnimator).supportsChangeAnimations = false
-        setupObservers()
-    }
-
-    private fun setupObservers() {
-        viewModel.faqUiState.observe(viewLifecycleOwner) { state ->
-            when (state) {
-                FAQUiState.InitialLoading -> {}
-                FAQUiState.Refreshing -> {}
-                is FAQUiState.Success -> {
-                    adapter.submitList(state.faqs) {
-                        showEmptyStateMessage()
-                    }
-                }
-
-                is FAQUiState.Error -> {
-                    Timber.w(state.throwable.stackTraceToString())
-                    showErrorSnackBar(state.throwable)
-                }
-            }
+    ): View {
+        val composeView = ComposeView(requireContext())
+        composeView.setContent {
+            FAQScreen(uiState = viewModel.faqUiState, onFaqClick = { faqItemUiModel ->
+                (requireParentFragment() as OnNewsClickListener).onFAQClick(faqItemUiModel)
+            })
         }
-    }
 
-    private fun showEmptyStateMessage() {
-        val itemCount = binding.rvFaq.adapter?.itemCount ?: 0
-
-        binding.tvEmptyState.root.visibility = if (itemCount == 0) View.VISIBLE else View.GONE
+        return composeView
     }
 
     companion object {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQUiState.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/FAQUiState.kt
@@ -5,8 +5,6 @@ import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 sealed interface FAQUiState {
     data object InitialLoading : FAQUiState
 
-    data object Refreshing : FAQUiState
-
     data class Success(
         val faqs: List<FAQItemUiModel>,
     ) : FAQUiState

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQItem.kt
@@ -3,6 +3,7 @@ package com.daedan.festabook.presentation.news.faq.component
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -51,6 +52,10 @@ fun FAQItem(
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .background(
+                    color = colorResource(R.color.gray100),
+                    shape = RoundedCornerShape(16.dp),
+                ).border(
+                    width = 1.dp,
                     color = colorResource(R.color.gray200),
                     shape = RoundedCornerShape(16.dp),
                 ).animateContentSize()

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQItem.kt
@@ -1,0 +1,96 @@
+package com.daedan.festabook.presentation.news.faq.component
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.daedan.festabook.R
+import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+
+private const val ICON_ROTATION_EXPANDED: Float = 180F
+private const val ICON_ROTATION_COLLAPSED: Float = 0F
+
+@Composable
+fun FAQItem(
+    faqItemUiModel: FAQItemUiModel,
+    onclick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val rotation by animateFloatAsState(
+        targetValue = if (faqItemUiModel.isExpanded) ICON_ROTATION_EXPANDED else ICON_ROTATION_COLLAPSED,
+    )
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .background(
+                    color = colorResource(R.color.gray200),
+                    shape = RoundedCornerShape(16.dp),
+                ).animateContentSize()
+                .clickable { onclick() }
+                .padding(16.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = faqItemUiModel.question,
+                fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+                fontSize = 14.sp,
+            )
+            Icon(
+                painter = painterResource(R.drawable.ic_chevron_down),
+                contentDescription = stringResource(R.string.faq_expand),
+                modifier = Modifier.rotate(rotation),
+            )
+        }
+
+        if (faqItemUiModel.isExpanded) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = faqItemUiModel.answer)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun FAQItemPreview() {
+    FAQItem(
+        faqItemUiModel =
+            FAQItemUiModel(
+                questionId = 1,
+                question = "Q. 주차는 어디에 가능한가요?",
+                answer = "널린게 미소집 앞마당입니다.널린게 미소집 앞마당입니다널린게 미소집 앞마당입니다널린게 미소집 앞마당입니다널린게 미소집 앞마당입니다",
+                sequence = 1,
+                isExpanded = true,
+            ),
+        onclick = {},
+    )
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -52,7 +54,10 @@ fun FAQItem(
                     color = colorResource(R.color.gray200),
                     shape = RoundedCornerShape(16.dp),
                 ).animateContentSize()
-                .clickable { onclick() }
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) { onclick() }
                 .padding(16.dp),
     ) {
         Row(

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import com.daedan.festabook.presentation.common.component.EmptyStateScreen
 import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+import timber.log.Timber
 
 @Composable
 fun FAQScreen(
@@ -18,7 +19,9 @@ fun FAQScreen(
     modifier: Modifier = Modifier,
 ) {
     when (uiState) {
-        is FAQUiState.Error -> Unit
+        is FAQUiState.Error -> {
+            Timber.w(uiState.throwable.stackTraceToString())
+        }
 
         is FAQUiState.InitialLoading -> Unit
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.daedan.festabook.R
 import com.daedan.festabook.presentation.common.component.EmptyStateScreen
+import com.daedan.festabook.presentation.news.component.NewsItem
 import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 import timber.log.Timber

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
@@ -1,0 +1,54 @@
+package com.daedan.festabook.presentation.news.faq.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.common.component.EmptyStateScreen
+import com.daedan.festabook.presentation.news.faq.FAQUiState
+import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
+
+@Composable
+fun FAQScreen(
+    uiState: FAQUiState,
+    onFaqClick: (FAQItemUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (uiState) {
+        is FAQUiState.Error -> Unit
+
+        is FAQUiState.InitialLoading -> Unit
+
+        is FAQUiState.Success -> {
+            if (uiState.faqs.isEmpty()) {
+                EmptyStateScreen()
+            } else {
+                LazyColumn(modifier = modifier) {
+                    itemsIndexed(
+                        items = uiState.faqs,
+                        key = { _, faq -> faq.questionId },
+                    ) { index, faq ->
+                        FAQItem(
+                            faqItemUiModel = faq,
+                            onclick = { onFaqClick(faq) },
+                            modifier =
+                                Modifier.padding(
+                                    top = if (index == 0) 12.dp else 6.dp,
+                                    bottom = 6.dp,
+                                ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FAQScreenPreview() {
+    FAQScreen(uiState = FAQUiState.Success(emptyList()), onFaqClick = {})
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/FAQScreen.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.daedan.festabook.R
 import com.daedan.festabook.presentation.common.component.EmptyStateScreen
 import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
@@ -20,7 +23,9 @@ fun FAQScreen(
 ) {
     when (uiState) {
         is FAQUiState.Error -> {
-            Timber.w(uiState.throwable.stackTraceToString())
+            LaunchedEffect(uiState) {
+                Timber.w(uiState.throwable.stackTraceToString())
+            }
         }
 
         is FAQUiState.InitialLoading -> Unit
@@ -34,8 +39,10 @@ fun FAQScreen(
                         items = uiState.faqs,
                         key = { _, faq -> faq.questionId },
                     ) { index, faq ->
-                        FAQItem(
-                            faqItemUiModel = faq,
+                        NewsItem(
+                            title = stringResource(R.string.tab_faq_question, faq.question),
+                            description = faq.answer,
+                            isExpanded = faq.isExpanded,
                             onclick = { onFaqClick(faq) },
                             modifier =
                                 Modifier.padding(

--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/NewsItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/faq/component/NewsItem.kt
@@ -6,13 +6,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -32,19 +32,22 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.daedan.festabook.R
-import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 
 private const val ICON_ROTATION_EXPANDED: Float = 180F
 private const val ICON_ROTATION_COLLAPSED: Float = 0F
 
 @Composable
-fun FAQItem(
-    faqItemUiModel: FAQItemUiModel,
+fun NewsItem(
+    title: String,
+    description: String,
+    isExpanded: Boolean,
     onclick: () -> Unit,
     modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    createdAt: String? = null,
 ) {
     val rotation by animateFloatAsState(
-        targetValue = if (faqItemUiModel.isExpanded) ICON_ROTATION_EXPANDED else ICON_ROTATION_COLLAPSED,
+        targetValue = if (isExpanded) ICON_ROTATION_EXPANDED else ICON_ROTATION_COLLAPSED,
     )
     Column(
         modifier =
@@ -67,24 +70,37 @@ fun FAQItem(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            if (icon != null) {
+                icon()
+                Spacer(modifier = Modifier.width(8.dp))
+            }
             Text(
-                text = faqItemUiModel.question,
+                text = title,
                 fontFamily = FontFamily(Font(R.font.pretendard_bold)),
                 fontSize = 14.sp,
             )
-            Icon(
-                painter = painterResource(R.drawable.ic_chevron_down),
-                contentDescription = stringResource(R.string.faq_expand),
-                modifier = Modifier.rotate(rotation),
-            )
+            Spacer(modifier = modifier.weight(1f))
+            if (createdAt != null) {
+                Text(
+                    text = createdAt,
+                    fontFamily = FontFamily(Font(R.font.pretendard_regular)),
+                    fontSize = 10.sp,
+                    color = colorResource(R.color.gray500),
+                )
+            } else {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron_down),
+                    contentDescription = stringResource(R.string.faq_expand),
+                    modifier = Modifier.rotate(rotation),
+                )
+            }
         }
 
-        if (faqItemUiModel.isExpanded) {
+        if (isExpanded) {
             Spacer(modifier = Modifier.height(8.dp))
-            Text(text = faqItemUiModel.answer)
+            Text(text = description)
         }
     }
 }
@@ -92,15 +108,28 @@ fun FAQItem(
 @Preview
 @Composable
 private fun FAQItemPreview() {
-    FAQItem(
-        faqItemUiModel =
-            FAQItemUiModel(
-                questionId = 1,
-                question = "Q. 주차는 어디에 가능한가요?",
-                answer = "널린게 미소집 앞마당입니다.널린게 미소집 앞마당입니다널린게 미소집 앞마당입니다널린게 미소집 앞마당입니다널린게 미소집 앞마당입니다",
-                sequence = 1,
-                isExpanded = true,
-            ),
+    NewsItem(
+        title = stringResource(R.string.tab_faq_question, "주차는 어디에 가능한가요"),
+        description = "미소집이요미소집이요미소집이요미소집이요미소집이요미소집이요미소집이요미소집이요",
+        isExpanded = false,
         onclick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun NoticeItemPreview() {
+    NewsItem(
+        title = "공지사항 제목입니다.",
+        description = "설명입니다.설명입니다.설명입니다.설명입니다.설명입니다.설명입니다.설명입니다.",
+        isExpanded = true,
+        onclick = {},
+        icon = {
+            Icon(
+                painter = painterResource(R.drawable.ic_pin),
+                contentDescription = "",
+            )
+        },
+        createdAt = "11/12 12:00",
     )
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -83,6 +83,7 @@ class PlaceDetailActivity :
         binding.vpPlaceImages.adapter = placeImageAdapter
         binding.tvLocation.setExpandedWhenClicked()
         binding.tvHost.setExpandedWhenClicked()
+        binding.tvPlaceDescription.setExpandedWhenClicked(2)
         binding.ivBackToPrevious.setOnClickListener {
             finish()
         }
@@ -142,13 +143,13 @@ class PlaceDetailActivity :
         binding.sflScheduleSkeleton.stopShimmer()
     }
 
-    private fun TextView.setExpandedWhenClicked() {
+    private fun TextView.setExpandedWhenClicked(defaultMaxLines:Int = DEFAULT_MAX_LINES) {
         setOnClickListener {
             maxLines =
-                if (maxLines == DEFAULT_MAX_LINES) {
+                if (maxLines == defaultMaxLines) {
                     Integer.MAX_VALUE
                 } else {
-                    DEFAULT_MAX_LINES
+                    defaultMaxLines
                 }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ActivityPlaceDetailBinding
 import com.daedan.festabook.presentation.common.getObject
+import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 import com.daedan.festabook.presentation.news.lost.model.LostUiModel
@@ -25,6 +26,7 @@ import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiState
 import com.daedan.festabook.presentation.placeList.model.PlaceUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 import timber.log.Timber
 
 class PlaceDetailActivity :
@@ -143,7 +145,7 @@ class PlaceDetailActivity :
         binding.sflScheduleSkeleton.stopShimmer()
     }
 
-    private fun TextView.setExpandedWhenClicked(defaultMaxLines:Int = DEFAULT_MAX_LINES) {
+    private fun TextView.setExpandedWhenClicked(defaultMaxLines: Int = DEFAULT_MAX_LINES) {
         setOnClickListener {
             maxLines =
                 if (maxLines == defaultMaxLines) {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerAdapter.kt
@@ -3,13 +3,15 @@ package com.daedan.festabook.presentation.placeDetail.adapter
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 
 class PlaceImageViewPagerAdapter : ListAdapter<ImageUiModel, PlaceImageViewPagerViewHolder>(DIFF_UTIL_CALLBACK) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): PlaceImageViewPagerViewHolder = PlaceImageViewPagerViewHolder.from(parent)
+    ): PlaceImageViewPagerViewHolder = PlaceImageViewPagerViewHolder.from(parent, currentList)
 
     override fun onBindViewHolder(
         holder: PlaceImageViewPagerViewHolder,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerViewHolder.kt
@@ -4,20 +4,40 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.daedan.festabook.databinding.ItemPlaceImageBinding
+import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 
 class PlaceImageViewPagerViewHolder(
-    val binding: ItemPlaceImageBinding,
+    private val binding: ItemPlaceImageBinding,
+    private val images: List<ImageUiModel>
 ) : RecyclerView.ViewHolder(binding.root) {
+    private val imageDialogBuilder = PhotoViewDialog.Builder(
+        context = binding.root.context,
+        images = images.map { it.url }
+    ) { imageView, url ->
+        imageView.loadImage(url)
+    }
+
+    init {
+        binding.ivPlaceImage.setOnClickListener {
+            imageDialogBuilder
+                .withHiddenStatusBar(false)
+                .withStartPosition(bindingAdapterPosition)
+                .build()
+                .show()
+        }
+    }
+
     fun bind(imageUiModel: ImageUiModel) {
         binding.image = imageUiModel
     }
 
     companion object {
-        fun from(parent: ViewGroup): PlaceImageViewPagerViewHolder {
+        fun from(parent: ViewGroup, images: List<ImageUiModel>): PlaceImageViewPagerViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ItemPlaceImageBinding.inflate(layoutInflater, parent, false)
-            return PlaceImageViewPagerViewHolder(binding)
+            return PlaceImageViewPagerViewHolder(binding, images)
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListViewModel.kt
@@ -75,13 +75,13 @@ class PlaceListViewModel(
                 }.onFailure {
                     _timeTags.value = emptyList()
                 }
-        }
 
-//         기본 선택값
-        if (!timeTags.value.isNullOrEmpty()) {
-            _selectedTimeTag.value = _timeTags.value?.first()
-        } else {
-            _selectedTimeTag.value = TimeTag.EMPTY
+            //         기본 선택값
+            if (!timeTags.value.isNullOrEmpty()) {
+                _selectedTimeTag.value = _timeTags.value?.first()
+            } else {
+                _selectedTimeTag.value = TimeTag.EMPTY
+            }
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapManager.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/MapManager.kt
@@ -153,9 +153,9 @@ class MapManager(
         val currentPosition = map.cameraPosition.target
         val zoomWeight = map.cameraPosition.zoom.zoomWeight()
         return currentPosition.distanceTo(initialCenter) >
-            (maxLength * zoomWeight).coerceAtLeast(
-                maxLength,
-            )
+                (maxLength * zoomWeight).coerceAtLeast(
+                    maxLength,
+                )
     }
 
     fun clearMapManager() {
@@ -236,9 +236,6 @@ class MapManager(
             map = this@MapManager.map
         }
     }
-
-    private fun Context.getRootPixel() = context.resources.displayMetrics.heightPixels
-
     private fun Marker.generate(place: PlaceCoordinateUiModel): Marker {
         width = Marker.SIZE_AUTO
         height = Marker.SIZE_AUTO

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
@@ -63,6 +63,10 @@ class PlaceMapFragment :
         PlaceDetailPreviewSecondaryFragment().newInstance()
     }
 
+    private val mapFragment by lazy {
+        MapFragment().newInstance() as MapFragment
+    }
+
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
@@ -88,6 +92,7 @@ class PlaceMapFragment :
             }
 
         childFragmentManager.commit {
+            add(R.id.fcv_map_container, mapFragment, null)
             add(R.id.fcv_place_list_container, placeListFragment, null)
             add(R.id.fcv_map_container, placeDetailPreviewFragment, null)
             add(R.id.fcv_place_category_container, placeCategoryFragment, null)
@@ -107,7 +112,6 @@ class PlaceMapFragment :
     }
 
     private suspend fun setUpMapManager() {
-        val mapFragment = binding.fcvMapContainer.getFragment<MapFragment>()
         naverMap = mapFragment.getMap()
         (placeListFragment as? OnMapReadyCallback)?.onMapReady(naverMap)
         naverMap.locationSource = locationSource

--- a/android/app/src/main/res/layout/activity_place_detail.xml
+++ b/android/app/src/main/res/layout/activity_place_detail.xml
@@ -183,6 +183,8 @@
                     android:textAppearance="@style/PretendardRegular14"
                     android:autoLink="web"
                     android:textColorLink="@color/gray500"
+                    android:maxLines="2"
+                    android:ellipsize="end"
                     app:layout_constraintEnd_toEndOf="@id/end_guideline"
                     app:layout_constraintStart_toStartOf="@id/iv_host"
                     app:layout_constraintTop_toBottomOf="@id/tv_host"

--- a/android/app/src/main/res/layout/fragment_place_detail_preview.xml
+++ b/android/app/src/main/res/layout/fragment_place_detail_preview.xml
@@ -111,13 +111,16 @@
 
             <TextView
                 android:id="@+id/tv_selected_place_description"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
                 android:textAppearance="@style/PretendardRegular12"
                 android:autoLink="web"
                 android:textColorLink="@color/gray500"
+                android:maxLines="2"
+                android:ellipsize="end"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/cv_place_image"
                 app:layout_constraintStart_toStartOf="@id/iv_selected_place_host"
                 app:layout_constraintTop_toBottomOf="@id/iv_selected_place_host"
                 tools:text="시원한 맥주와 맛있는 파전" />

--- a/android/app/src/main/res/layout/fragment_place_detail_preview_secondary.xml
+++ b/android/app/src/main/res/layout/fragment_place_detail_preview_secondary.xml
@@ -31,7 +31,7 @@
                 android:id="@+id/tv_selected_place_title"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
+                android:layout_marginStart="8dp"
                 android:layout_marginEnd="16dp"
                 android:textAppearance="@style/PretendardBold18"
                 android:textColor="@color/gray900"

--- a/android/app/src/main/res/layout/fragment_place_map.xml
+++ b/android/app/src/main/res/layout/fragment_place_map.xml
@@ -19,7 +19,6 @@
 
                 <androidx.fragment.app.FragmentContainerView
                     android:id="@+id/fcv_map_container"
-                    android:name="com.naver.maps.map.MapFragment"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
 

--- a/android/app/src/main/res/layout/item_place_list.xml
+++ b/android/app/src/main/res/layout/item_place_list.xml
@@ -114,6 +114,6 @@
             android:layout_height="1dp"
             android:layout_marginTop="16dp"
             android:background="@color/gray300"
-            app:layout_constraintTop_toBottomOf="@id/cv_place_image" />
+            app:layout_constraintTop_toBottomOf="@id/iv_location" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ retrofit2KotlinxSerializationConverter = "1.0.0"
 shimmer = "0.5.0"
 swiperefreshlayout = "1.1.0"
 timber = "5.0.1"
+uiTooling = "1.9.1"
 viewpager2 = "1.1.0"
 firebaseMessaging = "25.0.0"
 ktlint = "13.0.0"
@@ -76,10 +77,8 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "uiTooling" }
 
 
 [plugins]

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.0"
+agp = "8.11.1"
 appUpdateKtx = "2.1.0"
 assertjCore = "3.27.3"
 circleindicator = "2.1.6"

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
 mockk = "1.14.5"
+photoviewDialog = "1.0.3"
 playServicesLocation = "21.3.0"
 retrofit = "3.0.0"
 kotlinx-serialization-json = "1.9.0"
@@ -63,6 +64,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+photoview-dialog = { module = "io.getstream:photoview-dialog", version.ref = "photoviewDialog" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 08 22:08:17 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## #️⃣ 이슈 번호

#972 

<br>

## 🛠️ 작업 내용
- FAQ 화면 Compose 마이그레이션
<br>

## 🙇🏻 중점 리뷰 요청

- 현재 에러일 때 스낵바를 띄우는데 스낵바를 띄우는 함수가  fragment에서만 호출 가능한 구조네용. 컴포즈에서는 Scaffold에서 띄우는게 권장이라고 하는데 지금 Scaffold에서 띄우려면 NewsFragment 전체를 다 엎어야하는 상황이고 FragmentUtil에 있는 에러 분기처리에 따른 스낵바를 띄우는 로직을 새로 짜야해서 일단 지금은 스킵하고 에러상태일 때 Timber.w만 찍게 해놨습니당. FAQ 화면에 새로고침은 없어서 일단은 이대로가도 큰 문제가 될 것 같지는 않네용.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/978eff82-edf4-4ade-a7b8-47ce40a1a4f3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - FAQ 및 뉴스 관련 UI를 Jetpack Compose로 추가/개선하고 접기/펼치기 가능한 항목과 빈 상태 화면을 도입했습니다.
  - 전체화면 사진 보기(이미지 다이얼로그) 기능을 추가했습니다.
- 리팩터링
  - 화면 상태 관리를 Compose 상태로 전환하고 불필요한 상태 단계를 제거했습니다.
  - 이미지 URL 처리 로직을 재사용 가능한 형태로 정리했습니다.
- 작업
  - 빌드 도구, 플러그인 및 라이브러리 버전 업데이트, Gradle 래퍼 업그레이드.
  - .gitignore 및 Kotlin 린트 설정 업데이트.
- 기타
  - 홈/탐색/검색 등 화면 상호작용에 대한 로깅을 추가했습니다.
  - 카테고리 열거형에 신규 항목을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->