### PR TITLE
[AN] hotfix: 축제 구독 API 엔드포인트 변경

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/data/service/FestivalNotificationService.kt
+++ b/android/app/src/main/java/com/daedan/festabook/data/service/FestivalNotificationService.kt
@@ -9,7 +9,7 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface FestivalNotificationService {
-    @POST("festivals/{festivalId}/notifications")
+    @POST("festivals/{festivalId}/notifications/android")
     suspend fun saveFestivalNotification(
         @Path("festivalId") id: Long,
         @Body request: FestivalNotificationRequest,


### PR DESCRIPTION
- `/festivals/{festivalId}/notifications`에서 `/festivals/{festivalId}/notifications/android`로 변경

## #️⃣ 이슈 번호

> ex) https://github.com/woowacourse-teams/2025-festabook/issues/992

<br>

## 🛠️ 작업 내용

- 축제 구독 API 엔드포인트 변경했습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
