### PR TITLE
[AN] 포스터 이미지, 상세 이미지 확대 기능 추가

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -175,6 +175,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.photoview.dialog)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.androidx.core.testing)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/common/ImageUtil.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/common/ImageUtil.kt
@@ -21,14 +21,7 @@ fun ImageView.loadImage(
     url: String?,
     block: ImageRequest.Builder.() -> Unit = {},
 ) {
-    val finalUrl =
-        if (url != null && url.startsWith("/images/")) {
-            BuildConfig.FESTABOOK_URL.removeSuffix("/api/") + url
-        } else {
-            url
-        }
-
-    this.load(finalUrl) {
+    this.load(url.convertImageUrl()) {
         block()
         crossfade(true)
         placeholder(Color.LTGRAY.toDrawable())
@@ -36,6 +29,13 @@ fun ImageView.loadImage(
         error(R.drawable.img_fallback)
     }
 }
+
+fun String?.convertImageUrl() = if (this != null && this.startsWith("/images/")) {
+    BuildConfig.FESTABOOK_URL.removeSuffix("/api/") + this
+} else {
+    this
+}
+
 
 fun vectorToBitmap(
     context: Context,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/home/adapter/PosterItemViewHolder.kt
@@ -3,20 +3,39 @@ package com.daedan.festabook.presentation.home.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import coil3.load
 import coil3.request.CachePolicy
+import coil3.request.crossfade
 import coil3.request.transformations
 import coil3.transform.RoundedCornersTransformation
+import com.daedan.festabook.BuildConfig
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ItemHomePosterBinding
 import com.daedan.festabook.logging.DefaultFirebaseLogger
 import com.daedan.festabook.logging.model.PosterTouchLogData
 import com.daedan.festabook.logging.logger
+import com.daedan.festabook.presentation.common.convertImageUrl
 import com.daedan.festabook.presentation.common.loadImage
+import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 
 class PosterItemViewHolder(
-    val binding: ItemHomePosterBinding,
+    private val binding: ItemHomePosterBinding,
 ) : RecyclerView.ViewHolder(binding.root) {
+
     fun bind(url: String) {
+        val imageDialog = PhotoViewDialog.Builder(
+            context = binding.root.context,
+            images = listOf(url),
+        ) { imageView, url ->
+            imageView.load(url.convertImageUrl()) {
+                crossfade(true)
+            }
+        }
+            .withHiddenStatusBar(false)
+            .withTransitionFrom(binding.ivHomePoster)
+            .build()
+
         binding.ivHomePoster.loadImage(url) {
             transformations(RoundedCornersTransformation(20f))
             memoryCachePolicy(CachePolicy.ENABLED)
@@ -30,6 +49,9 @@ class PosterItemViewHolder(
                     url = url,
                 ),
             )
+        }
+        binding.ivHomePoster.setOnClickListener {
+            imageDialog.show()
         }
     }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ActivityPlaceDetailBinding
 import com.daedan.festabook.presentation.common.getObject
+import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
 import com.daedan.festabook.presentation.news.lost.model.LostUiModel
@@ -25,6 +26,7 @@ import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiState
 import com.daedan.festabook.presentation.placeList.model.PlaceUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 import timber.log.Timber
 
 class PlaceDetailActivity :
@@ -143,7 +145,7 @@ class PlaceDetailActivity :
         binding.sflScheduleSkeleton.stopShimmer()
     }
 
-    private fun TextView.setExpandedWhenClicked(defaultMaxLines:Int = DEFAULT_MAX_LINES) {
+    private fun TextView.setExpandedWhenClicked(defaultMaxLines: Int = DEFAULT_MAX_LINES) {
         setOnClickListener {
             maxLines =
                 if (maxLines == defaultMaxLines) {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerAdapter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerAdapter.kt
@@ -3,13 +3,15 @@ package com.daedan.festabook.presentation.placeDetail.adapter
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 
 class PlaceImageViewPagerAdapter : ListAdapter<ImageUiModel, PlaceImageViewPagerViewHolder>(DIFF_UTIL_CALLBACK) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): PlaceImageViewPagerViewHolder = PlaceImageViewPagerViewHolder.from(parent)
+    ): PlaceImageViewPagerViewHolder = PlaceImageViewPagerViewHolder.from(parent, currentList)
 
     override fun onBindViewHolder(
         holder: PlaceImageViewPagerViewHolder,

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerViewHolder.kt
@@ -4,20 +4,40 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.daedan.festabook.databinding.ItemPlaceImageBinding
+import com.daedan.festabook.presentation.common.loadImage
 import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
+import io.getstream.photoview.dialog.PhotoViewDialog
 
 class PlaceImageViewPagerViewHolder(
-    val binding: ItemPlaceImageBinding,
+    private val binding: ItemPlaceImageBinding,
+    private val images: List<ImageUiModel>
 ) : RecyclerView.ViewHolder(binding.root) {
+    private val imageDialogBuilder = PhotoViewDialog.Builder(
+        context = binding.root.context,
+        images = images.map { it.url }
+    ) { imageView, url ->
+        imageView.loadImage(url)
+    }
+
+    init {
+        binding.ivPlaceImage.setOnClickListener {
+            imageDialogBuilder
+                .withHiddenStatusBar(false)
+                .withStartPosition(bindingAdapterPosition)
+                .build()
+                .show()
+        }
+    }
+
     fun bind(imageUiModel: ImageUiModel) {
         binding.image = imageUiModel
     }
 
     companion object {
-        fun from(parent: ViewGroup): PlaceImageViewPagerViewHolder {
+        fun from(parent: ViewGroup, images: List<ImageUiModel>): PlaceImageViewPagerViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ItemPlaceImageBinding.inflate(layoutInflater, parent, false)
-            return PlaceImageViewPagerViewHolder(binding)
+            return PlaceImageViewPagerViewHolder(binding, images)
         }
     }
 }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListViewModel.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListViewModel.kt
@@ -75,13 +75,13 @@ class PlaceListViewModel(
                 }.onFailure {
                     _timeTags.value = emptyList()
                 }
-        }
 
-//         기본 선택값
-        if (!timeTags.value.isNullOrEmpty()) {
-            _selectedTimeTag.value = _timeTags.value?.first()
-        } else {
-            _selectedTimeTag.value = TimeTag.EMPTY
+            //         기본 선택값
+            if (!timeTags.value.isNullOrEmpty()) {
+                _selectedTimeTag.value = _timeTags.value?.first()
+            } else {
+                _selectedTimeTag.value = TimeTag.EMPTY
+            }
         }
     }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
 mockk = "1.14.5"
+photoviewDialog = "1.0.3"
 playServicesLocation = "21.3.0"
 retrofit = "3.0.0"
 kotlinx-serialization-json = "1.9.0"
@@ -63,6 +64,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+photoview-dialog = { module = "io.getstream:photoview-dialog", version.ref = "photoviewDialog" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/994

<br>

## 🛠️ 작업 내용

- 포스트 이미지, 상세 이미지 클릭 시 확대 가능한 다이얼로그가 표시되게 변경하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 중간에 네이버 지도 관련 PR이 있습니다 커밋 첨부드리니 확인부탁드립니다
- [refactor: 시간 태그 기본값 설정 위치 변경](https://github.com/woowacourse-teams/2025-festabook/pull/995/commits/b8e3d7025304a12487786437132b8737ad31841e)

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/d4805ec2-4f9c-4a89-a878-89b716e04f3b




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이미지 확대 보기 추가: 홈 포스터 이미지를 탭하면 전체 화면 뷰어가 열리고, 장소 상세의 이미지도 탭 시 여러 장을 스와이프하며 볼 수 있습니다. 상태바 숨김 및 부드러운 전환을 지원합니다.
- 개선
  - 이미지 URL 처리 로직을 정비해 이미지 로딩의 안정성과 일관성을 높였습니다.
  - 시간 태그의 기본 선택 동작을 보완해 초기 선택이 더 일관되게 적용됩니다.
- 작업
  - 이미지 뷰어 기능을 위한 외부 라이브러리를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->