### PR TITLE
[AN] 빈 아이템 문구 메시지와 분실물 가이드가 겹치는 문제 해결

### DIFF
--- a/android/app/src/main/res/layout/fragment_lost_item.xml
+++ b/android/app/src/main/res/layout/fragment_lost_item.xml
@@ -12,6 +12,7 @@
             android:id="@+id/srl_lost_item_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:elevation="1dp"
             android:importantForAccessibility="no"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">


### PR DESCRIPTION
## #️⃣ 이슈 번호

#999 

<br>

## 🛠️ 작업 내용

- elevation="1dp"

<br>

## 🙇🏻 중점 리뷰 요청

- 

<br>

## 📸 이미지 첨부 (Optional)
