### PR TITLE
[BE] Place 전체 조회 API 개선

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/place/dto/PlaceResponses.java
+++ b/backend/src/main/java/com/daedan/festabook/place/dto/PlaceResponses.java
@@ -1,13 +1,32 @@
 package com.daedan.festabook.place.dto;
 
+import com.daedan.festabook.place.domain.Place;
+import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import com.daedan.festabook.place.domain.PlaceImage;
+import com.daedan.festabook.timetag.domain.TimeTag;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
+import java.util.Map;
 
 public record PlaceResponses(
         @JsonValue List<PlaceResponse> responses
 ) {
 
-    public static PlaceResponses from(List<PlaceResponse> responses) {
-        return new PlaceResponses(responses);
+    public static PlaceResponses from(
+            List<Place> places,
+            Map<Long, List<PlaceImage>> placeImages,
+            Map<Long, List<PlaceAnnouncement>> placeAnnouncements,
+            Map<Long, List<TimeTag>> timeTags
+    ) {
+        return new PlaceResponses(
+                places.stream()
+                        .map(place -> PlaceResponse.from(
+                                place,
+                                placeImages.getOrDefault(place.getId(), List.of()),
+                                placeAnnouncements.getOrDefault(place.getId(), List.of()),
+                                timeTags.getOrDefault(place.getId(), List.of())
+                        ))
+                        .toList()
+        );
     }
 }

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceAnnouncementJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceAnnouncementJpaRepository.java
@@ -2,12 +2,15 @@ package com.daedan.festabook.place.infrastructure;
 
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceAnnouncement;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceAnnouncementJpaRepository extends JpaRepository<PlaceAnnouncement, Long> {
 
     List<PlaceAnnouncement> findAllByPlaceId(Long placeId);
+
+    List<PlaceAnnouncement> findAllByPlaceIn(Collection<Place> places);
 
     Integer countByPlace(Place place);
 

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
@@ -15,7 +15,7 @@ public interface PlaceImageJpaRepository extends JpaRepository<PlaceImage, Long>
 
     List<PlaceImage> findAllByPlaceInAndSequence(List<Place> places, int sequence);
 
-    List<PlaceImage> findAllByPlaceIn(Collection<Place> places);
+    List<PlaceImage> findAllByPlaceInOrderBySequence(Collection<Place> places);
 
     @Query("SELECT MAX(p.sequence) FROM PlaceImage p WHERE p.place = :place AND p.deleted = false")
     Optional<Integer> findMaxSequenceByPlace(@Param("place") Place place);

--- a/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/place/infrastructure/PlaceImageJpaRepository.java
@@ -2,6 +2,7 @@ package com.daedan.festabook.place.infrastructure;
 
 import com.daedan.festabook.place.domain.Place;
 import com.daedan.festabook.place.domain.PlaceImage;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,6 +14,8 @@ public interface PlaceImageJpaRepository extends JpaRepository<PlaceImage, Long>
     List<PlaceImage> findAllByPlaceIdOrderBySequenceAsc(Long placeId);
 
     List<PlaceImage> findAllByPlaceInAndSequence(List<Place> places, int sequence);
+
+    List<PlaceImage> findAllByPlaceIn(Collection<Place> places);
 
     @Query("SELECT MAX(p.sequence) FROM PlaceImage p WHERE p.place = :place AND p.deleted = false")
     Optional<Integer> findMaxSequenceByPlace(@Param("place") Place place);

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
@@ -22,7 +22,6 @@ import com.daedan.festabook.timetag.domain.PlaceTimeTag;
 import com.daedan.festabook.timetag.domain.TimeTag;
 import com.daedan.festabook.timetag.infrastructure.PlaceTimeTagJpaRepository;
 import com.daedan.festabook.timetag.infrastructure.TimeTagJpaRepository;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,7 +55,8 @@ public class PlaceService {
     public PlaceResponses getAllPlaceByFestivalId(Long festivalId) {
         List<Place> places = placeJpaRepository.findAllByFestivalId(festivalId);
 
-        Map<Long, List<PlaceImage>> placeImages = placeImageJpaRepository.findAllByPlaceIn(places).stream()
+        Map<Long, List<PlaceImage>> placeImages = placeImageJpaRepository.findAllByPlaceInOrderBySequence(places)
+                .stream()
                 .collect(Collectors.groupingBy(
                         placeImage -> placeImage.getPlace().getId(),
                         Collectors.toList()
@@ -73,41 +73,12 @@ public class PlaceService {
                 .collect(Collectors.groupingBy(
                         placeTimeTag -> placeTimeTag.getPlace().getId(),
                         Collectors.mapping(
-                                placeTimeTag -> placeTimeTag.getTimeTag(),
+                                PlaceTimeTag::getTimeTag,
                                 Collectors.toList()
                         )
                 ));
 
-        return convertPlacesToPlaceResponses(places, placeImages, placeAnnouncements, timeTags);
-    }
-
-    private PlaceResponses convertPlacesToPlaceResponses(
-            List<Place> places,
-            Map<Long, List<PlaceImage>> placeImages,
-            Map<Long, List<PlaceAnnouncement>> placeAnnouncements,
-            Map<Long, List<TimeTag>> timeTags
-    ) {
-        return PlaceResponses.from(
-                places.stream()
-                        .map(place -> convertPlaceToPlaceResponse(
-                                place,
-                                placeImages.getOrDefault(place.getId(), List.of()).stream()
-                                        .sorted(Comparator.comparingInt(placeImage -> placeImage.getSequence()))
-                                        .toList(),
-                                placeAnnouncements.getOrDefault(place.getId(), List.of()),
-                                timeTags.getOrDefault(place.getId(), List.of())
-                        ))
-                        .toList()
-        );
-    }
-
-    private PlaceResponse convertPlaceToPlaceResponse(
-            Place place,
-            List<PlaceImage> placeImages,
-            List<PlaceAnnouncement> placeAnnouncements,
-            List<TimeTag> timeTags
-    ) {
-        return PlaceResponse.from(place, placeImages, placeAnnouncements, timeTags);
+        return PlaceResponses.from(places, placeImages, placeAnnouncements, timeTags);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
@@ -23,6 +23,8 @@ import com.daedan.festabook.timetag.domain.TimeTag;
 import com.daedan.festabook.timetag.infrastructure.PlaceTimeTagJpaRepository;
 import com.daedan.festabook.timetag.infrastructure.TimeTagJpaRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -51,11 +53,58 @@ public class PlaceService {
 
     @Transactional(readOnly = true)
     public PlaceResponses getAllPlaceByFestivalId(Long festivalId) {
+        List<Place> places = placeJpaRepository.findAllByFestivalId(festivalId);
+
+        Map<Long, List<PlaceImage>> placeImages = placeImageJpaRepository.findAllByPlaceIn(places).stream()
+                .collect(Collectors.groupingBy(
+                        placeImage -> placeImage.getPlace().getId(),
+                        Collectors.toList()
+                ));
+
+        Map<Long, List<PlaceAnnouncement>> placeAnnouncements = placeAnnouncementJpaRepository.findAllByPlaceIn(places)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        placeAnnouncement -> placeAnnouncement.getPlace().getId(),
+                        Collectors.toList()
+                ));
+
+        Map<Long, List<TimeTag>> timeTags = placeTimeTagJpaRepository.findAllByPlaceInWithTimeTag(places).stream()
+                .collect(Collectors.groupingBy(
+                        placeTimeTag -> placeTimeTag.getPlace().getId(),
+                        Collectors.mapping(
+                                placeTimeTag -> placeTimeTag.getTimeTag(),
+                                Collectors.toList()
+                        )
+                ));
+
+        return convertPlacesToPlaceResponses(places, placeImages, placeAnnouncements, timeTags);
+    }
+
+    private PlaceResponses convertPlacesToPlaceResponses(
+            List<Place> places,
+            Map<Long, List<PlaceImage>> placeImages,
+            Map<Long, List<PlaceAnnouncement>> placeAnnouncements,
+            Map<Long, List<TimeTag>> timeTags
+    ) {
         return PlaceResponses.from(
-                placeJpaRepository.findAllByFestivalId(festivalId).stream()
-                        .map(this::convertPlaceToResponse)
+                places.stream()
+                        .map(place -> convertPlaceToPlaceResponse(
+                                place,
+                                placeImages.getOrDefault(place.getId(), List.of()),
+                                placeAnnouncements.getOrDefault(place.getId(), List.of()),
+                                timeTags.getOrDefault(place.getId(), List.of())
+                        ))
                         .toList()
         );
+    }
+
+    private PlaceResponse convertPlaceToPlaceResponse(
+            Place place,
+            List<PlaceImage> placeImages,
+            List<PlaceAnnouncement> placeAnnouncements,
+            List<TimeTag> timeTags
+    ) {
+        return PlaceResponse.from(place, placeImages, placeAnnouncements, timeTags);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
+++ b/backend/src/main/java/com/daedan/festabook/place/service/PlaceService.java
@@ -22,6 +22,7 @@ import com.daedan.festabook.timetag.domain.PlaceTimeTag;
 import com.daedan.festabook.timetag.domain.TimeTag;
 import com.daedan.festabook.timetag.infrastructure.PlaceTimeTagJpaRepository;
 import com.daedan.festabook.timetag.infrastructure.TimeTagJpaRepository;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -90,7 +91,9 @@ public class PlaceService {
                 places.stream()
                         .map(place -> convertPlaceToPlaceResponse(
                                 place,
-                                placeImages.getOrDefault(place.getId(), List.of()),
+                                placeImages.getOrDefault(place.getId(), List.of()).stream()
+                                        .sorted(Comparator.comparingInt(placeImage -> placeImage.getSequence()))
+                                        .toList(),
                                 placeAnnouncements.getOrDefault(place.getId(), List.of()),
                                 timeTags.getOrDefault(place.getId(), List.of())
                         ))

--- a/backend/src/main/java/com/daedan/festabook/timetag/infrastructure/PlaceTimeTagJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/timetag/infrastructure/PlaceTimeTagJpaRepository.java
@@ -6,6 +6,8 @@ import com.daedan.festabook.timetag.domain.TimeTag;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlaceTimeTagJpaRepository extends JpaRepository<PlaceTimeTag, Long> {
 
@@ -16,4 +18,7 @@ public interface PlaceTimeTagJpaRepository extends JpaRepository<PlaceTimeTag, L
     boolean existsByTimeTag(TimeTag timeTag);
 
     List<PlaceTimeTag> findAllByPlaceIn(Collection<Place> places);
+
+    @Query("SELECT ptt FROM PlaceTimeTag ptt JOIN FETCH ptt.place JOIN FETCH ptt.timeTag WHERE ptt.place IN :places")
+    List<PlaceTimeTag> findAllByPlaceInWithTimeTag(@Param("places") Collection<Place> places);
 }

--- a/backend/src/main/java/com/daedan/festabook/timetag/infrastructure/TimeTagJpaRepository.java
+++ b/backend/src/main/java/com/daedan/festabook/timetag/infrastructure/TimeTagJpaRepository.java
@@ -1,10 +1,13 @@
 package com.daedan.festabook.timetag.infrastructure;
 
 import com.daedan.festabook.timetag.domain.TimeTag;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TimeTagJpaRepository extends JpaRepository<TimeTag, Long> {
 
     List<TimeTag> findAllByFestivalId(Long festivalId);
+
+    List<TimeTag> findAllByIdIn(Collection<Long> ids);
 }

--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceServiceTest.java
@@ -142,17 +142,21 @@ class PlaceServiceTest {
             Long festivalId = 1L;
 
             Festival festival = FestivalFixture.create(festivalId);
-            Place place = PlaceFixture.create(festival);
+            Place place = PlaceFixture.createWithNullDefaults(festival, 1L);
 
             PlaceImage image = PlaceImageFixture.create(place);
             PlaceAnnouncement announcement = PlaceAnnouncementFixture.create(place);
+            TimeTag timeTag = TimeTagFixture.createWithFestival(festival);
+            PlaceTimeTag placeTimeTag = PlaceTimeTagFixture.createWithPlaceAndTimeTag(place, timeTag);
 
             given(placeJpaRepository.findAllByFestivalId(festivalId))
                     .willReturn(List.of(place));
-            given(placeImageJpaRepository.findAllByPlaceIdOrderBySequenceAsc(place.getId()))
+            given(placeImageJpaRepository.findAllByPlaceInOrderBySequence(List.of(place)))
                     .willReturn(List.of(image));
-            given(placeAnnouncementJpaRepository.findAllByPlaceId(place.getId()))
+            given(placeAnnouncementJpaRepository.findAllByPlaceIn(List.of(place)))
                     .willReturn(List.of(announcement));
+            given(placeTimeTagJpaRepository.findAllByPlaceInWithTimeTag(List.of(place)))
+                    .willReturn(List.of(placeTimeTag));
 
             // when
             PlaceResponses result = placeService.getAllPlaceByFestivalId(festivalId);


### PR DESCRIPTION
## #️⃣ 이슈 번호

#1003


<br>

## 🛠️ 작업 내용

### 기존 방식
기존 방식은 Place를 전체 조회해온 후, 다음의 작업을 반복문을 통해 수행함
- Main Place라면, PlaceImage, PlaceAnnouncement, PlaceTimeTag, TimeTag를 조회하여 Response를 만듬
- Etc Place라면, PlaceTimeTag, TimeTag를 조회하여 Response를 만듬

결과적으로 Place 개수가 N개일때, 플레이스 전체 조회 1번 + 각 플레이스마다, 연관된 엔티티들을 조회 N번의 쿼리가 발생하게 됨
따라서 사진과 같이 수많은 쿼리가 발생하게 되었음
<img width="1878" height="1962" alt="image" src="https://github.com/user-attachments/assets/9a75e134-60cb-4f48-b01a-5bf52dd5f83b" />

### 모색한 해결 방안
1. Place, PlaceImage, PlaceAnnouncement, PlaceTimeTag + TimeTag를 각각 조회하여 4번의 쿼리로 값들을 조회
2. Place에 다대다, 일대다 매핑을 추가하고 값들을 fetch join하여 한 번의 쿼리로 모든 값을 조회
3. DTO를 새롭게 만들어 1번과 같은 방식으로 처리
    - 1번과 같은 방식으로 처리하기 때문에 불필요한 DTO만 추가된다고 판단하여 추가적으로 실험하지 않음

로컬에서 데이터베이스를 띄우고, 각각 실험을 진행

### 0. 기존 방식
평균 0.3783s의 시간이 소요됨

### 1. 각각 조회하여 4번의 쿼리로 처리
평균 0.0699s로 기존 방식에 비해 약 5.41배의 성능 향상을 보임

### 2. 다대일, 일대다 매핑을 추가하고 fetch join으로 모든 값 조회
평균 0.0648s로 기존 방식에 비해 약 5.83배의 성능  향상을 보임

2번 방식은 1번 방식에 비해 0.4배, 평균 0.04초정도의 성능이 뛰어났음

### 1번과 2번의 장단점 비교
나는 1번 방식을 선택하게 되었고 그에 대한 근거는 다음과 같음

**1번 방식은 2번 방식에 비해 코드에 드러나는 의도가 명확했음**
- 2번 방식의 경우 fetch join을 위해 다대다, 일대다 매핑을 Place에 추가해줘야 했는데 개발자로 하여금 이 연관관계를 사용해도 되는지 의문을 들게 만들고 있음
- 그에비해 1번 방식의 경우는 명확하게 PlaceImage, PlaceAnnouncement, PlaceTimeTag, TimeTag를 repository의 메서드를 통해 조회해오기 때문에 이해하기 쉬웠음
- 또한 2번 방식의 경우 일대다, 다대다 매핑을 고려하면서 다른 코드를 작업해야함 때문에 개발자의 실수를 유발할 가능성이 있음 (연관관계의 주인 그리고 양방향 매핑을 주의하면서 코드를 작성해야함)

**조회하는 행의 수가 2번 방식에 비해 최적화되어 있음**
- 2번 방식의 경우 모든 테이블을 조인해서 값을 가져오기 때문에 (Place의 수 X PlaceImage의 수 X PlaceAnnouncement의 수 X PlaceTimeTag의 수) 갯수만큼 행을 조회하게 됨 -> 이는 불필요한 중복이 매우 많아짐
- 그에비해 1번 방식의 경우에는 Place X PlaceImage, Place X PlaceAnnouncement, Place X PlaceTimeTag 만큼 Place 값들만 중복됨(이는 최적화할 수 있는 값임) 따라서, 비교적 적은 중복으로 값을 조회할 수 있음

**2번이 1번 방식보다 빠르지만 큰 차이를 보이지 못함**
- 2번 방식이 1번 방식에 비하여 0.4배 정도 빠르지만 미비한 수준이라고 판단하였음 앞에서 말했던 유지보수와 관련된 이점이 더 크다고 판단
