### PR TITLE
[AN] 지도, 플레이스 화면 로깅 추가

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -21,3 +21,8 @@
 #-renamesourcefileattribute SourceFile
 -keep class com.daedan.festabook.logging.** {*;}
 -keep class com.daedan.festabook.presentation.**Fragment { *; }
+-keep class * implements com.daedan.festabook.logging.model.LogData {
+    <init>(...); # 생성자 유지
+    <fields>;    # 모든 필드 유지
+    <methods>;   # 모든 메서드 유지
+}

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -11,8 +11,10 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
+import androidx.viewpager2.widget.ViewPager2
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.ActivityPlaceDetailBinding
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.common.getObject
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.news.faq.model.FAQItemUiModel
@@ -21,6 +23,7 @@ import com.daedan.festabook.presentation.news.notice.adapter.NoticeAdapter
 import com.daedan.festabook.presentation.news.notice.adapter.OnNewsClickListener
 import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
 import com.daedan.festabook.presentation.placeDetail.adapter.PlaceImageViewPagerAdapter
+import com.daedan.festabook.presentation.placeDetail.logging.PlaceDetailImageSwipe
 import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiState
@@ -122,6 +125,22 @@ class PlaceDetailActivity :
             placeImageAdapter.submitList(placeDetail.images)
             binding.clImageIndicator.setViewPager(binding.vpPlaceImages)
         }
+        binding.vpPlaceImages.registerOnPageChangeCallback(
+            object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageScrolled(
+                    position: Int,
+                    positionOffset: Float,
+                    positionOffsetPixels: Int,
+                ) {
+                    binding.logger.log(
+                        PlaceDetailImageSwipe(
+                            baseLogData = binding.logger.getBaseLogData(),
+                            startIndex = position,
+                        )
+                    )
+                }
+            }
+        )
         // 임시로 곰지사항을 보이지 않게 하였습니다. 추후 복구 예정입니다
 //        if (placeDetail.notices.isEmpty()) {
 //            binding.rvPlaceNotice.visibility = View.GONE

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/PlaceDetailActivity.kt
@@ -31,7 +31,7 @@ import com.daedan.festabook.presentation.placeList.model.PlaceUiModel
 import timber.log.Timber
 
 class PlaceDetailActivity :
-    AppCompatActivity(R.layout.activity_place_detail),
+    AppCompatActivity(),
     OnNewsClickListener {
     private val noticeAdapter by lazy {
         NoticeAdapter(this)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerViewHolder.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/adapter/PlaceImageViewPagerViewHolder.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.daedan.festabook.databinding.ItemPlaceImageBinding
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.placeDetail.model.ImageUiModel
 
 class PlaceImageViewPagerViewHolder(

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/logging/PlaceDetailImageClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/logging/PlaceDetailImageClick.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.presentation.placeDetail.logging
+
+import com.daedan.festabook.domain.model.PlaceCategory
+import com.daedan.festabook.logging.model.BaseLogData
+import com.daedan.festabook.presentation.placeList.model.PlaceCategoryUiModel
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceDetailImageClick(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val index: Int
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/logging/PlaceDetailImageSwipe.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeDetail/logging/PlaceDetailImageSwipe.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.presentation.placeDetail.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceDetailImageSwipe(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val startIndex: Int,
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/PlaceListFragment.kt
@@ -15,6 +15,7 @@ import coil3.request.ImageRequest
 import coil3.request.ImageResult
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceListBinding
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.placeListBottomSheetFollowBehavior
@@ -25,6 +26,10 @@ import com.daedan.festabook.presentation.placeList.adapter.PlaceListAdapter
 import com.daedan.festabook.presentation.placeList.behavior.BottomSheetFollowCallback
 import com.daedan.festabook.presentation.placeList.behavior.MoveToInitialPositionCallback
 import com.daedan.festabook.presentation.placeList.behavior.PlaceListBottomSheetBehavior
+import com.daedan.festabook.presentation.placeList.logging.PlaceBackToSchoolClick
+import com.daedan.festabook.presentation.placeList.logging.PlaceItemClick
+import com.daedan.festabook.presentation.placeList.logging.PlaceListSwipeUp
+import com.daedan.festabook.presentation.placeList.logging.PlaceMapButtonReClick
 import com.daedan.festabook.presentation.placeList.model.PlaceListUiState
 import com.daedan.festabook.presentation.placeList.model.PlaceUiModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -76,6 +81,14 @@ class PlaceListFragment :
     override fun onPlaceClicked(place: PlaceUiModel) {
         Timber.d("onPlaceClicked: $place")
         startPlaceDetailActivity(place)
+        binding.logger.log(
+            PlaceItemClick(
+                baseLogData = binding.logger.getBaseLogData(),
+                placeId = place.id,
+                timeTagName = viewModel.selectedTimeTag.value?.name?:"undefinded",
+                category = place.category.name
+            )
+        )
     }
 
     override fun onMenuItemReClick() {
@@ -83,6 +96,11 @@ class PlaceListFragment :
         val layoutParams = binding.layoutPlaceList.layoutParams as? CoordinatorLayout.LayoutParams
         val behavior = layoutParams?.behavior as? BottomSheetBehavior
         behavior?.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+        binding.logger.log(
+            PlaceMapButtonReClick(
+                baseLogData = binding.logger.getBaseLogData()
+            )
+        )
     }
 
     override fun onMapReady(naverMap: NaverMap) {
@@ -156,6 +174,9 @@ class PlaceListFragment :
     private fun setUpBinding() {
         binding.chipBackToInitialPosition.setOnClickListener {
             viewModel.onBackToInitialPositionClicked()
+            binding.logger.log(PlaceBackToSchoolClick(
+                baseLogData = binding.logger.getBaseLogData()
+            ))
         }
         binding.rvPlaces.itemAnimator = null
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/behavior/PlaceListBottomSheetBehavior.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/behavior/PlaceListBottomSheetBehavior.kt
@@ -7,6 +7,8 @@ import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.daedan.festabook.R
+import com.daedan.festabook.logging.DefaultFirebaseLogger
+import com.daedan.festabook.presentation.placeList.logging.PlaceListSwipeUp
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class PlaceListBottomSheetBehavior<V : View>(
@@ -19,6 +21,10 @@ class PlaceListBottomSheetBehavior<V : View>(
     private lateinit var recyclerView: RecyclerView
     private var headerRange: IntRange = 0..0
 
+    private val logger by lazy {
+        DefaultFirebaseLogger.getInstance(context)
+    }
+
     init {
         state = STATE_HALF_EXPANDED
         isGestureInsetBottomIgnored = true
@@ -30,6 +36,13 @@ class PlaceListBottomSheetBehavior<V : View>(
                 ) {
                     if (newState == STATE_HALF_EXPANDED && ::recyclerView.isInitialized) {
                         recyclerView.scrollToPosition(HEADER_POSITION)
+                    }
+                    if (newState == STATE_EXPANDED) {
+                        logger.log(
+                            PlaceListSwipeUp(
+                                baseLogData = logger.getBaseLogData()
+                            )
+                        )
                     }
                 }
 

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/LocationPermissionChanged.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/LocationPermissionChanged.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class LocationPermissionChanged(
+    override val baseLogData: BaseLogData.CommonLogData
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceBackToSchoolClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceBackToSchoolClick.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceBackToSchoolClick(
+    override val baseLogData: BaseLogData.CommonLogData
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceCategoryClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceCategoryClick.kt
@@ -1,0 +1,11 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import com.daedan.festabook.presentation.placeList.model.PlaceCategoryUiModel
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceCategoryClick(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val currentCategories: String
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceFragmentEnter.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceFragmentEnter.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceFragmentEnter(
+    override val baseLogData: BaseLogData.CommonLogData
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceItemClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceItemClick.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceItemClick(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val placeId: Long,
+    val timeTagName: String,
+    val category: String
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceListSwipeUp.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceListSwipeUp.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceListSwipeUp(
+    override val baseLogData: BaseLogData.CommonLogData,
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceMapButtonReClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceMapButtonReClick.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceMapButtonReClick(
+    override val baseLogData: BaseLogData.CommonLogData
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceMarkerClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceMarkerClick.kt
@@ -1,0 +1,13 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import com.daedan.festabook.presentation.placeList.model.PlaceCategoryUiModel
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceMarkerClick(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val placeId: Long,
+    val timeTagName: String,
+    val category: String
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlacePreviewClick.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlacePreviewClick.kt
@@ -1,0 +1,14 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.domain.model.PlaceCategory
+import com.daedan.festabook.logging.model.BaseLogData
+import com.daedan.festabook.presentation.placeList.model.PlaceCategoryUiModel
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlacePreviewClick(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val placeName: String,
+    val timeTag: String,
+    val category: String,
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceTimeTagSelected.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/logging/PlaceTimeTagSelected.kt
@@ -1,0 +1,11 @@
+package com.daedan.festabook.presentation.placeList.logging
+
+import com.daedan.festabook.logging.model.BaseLogData
+import com.daedan.festabook.logging.model.LogData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceTimeTagSelected(
+    override val baseLogData: BaseLogData.CommonLogData,
+    val timeTagName: String
+) : BaseLogData

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeCategory/PlaceCategoryFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeCategory/PlaceCategoryFragment.kt
@@ -6,8 +6,11 @@ import androidx.core.view.children
 import androidx.fragment.app.viewModels
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceCategoryBinding
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.placeList.PlaceListViewModel
+import com.daedan.festabook.presentation.placeList.logging.LocationPermissionChanged
+import com.daedan.festabook.presentation.placeList.logging.PlaceCategoryClick
 import com.daedan.festabook.presentation.placeList.model.PlaceCategoryUiModel
 import com.google.android.material.chip.Chip
 
@@ -33,6 +36,12 @@ class PlaceCategoryFragment : BaseFragment<FragmentPlaceCategoryBinding>(R.layou
             viewModel.unselectPlace()
             viewModel.setSelectedCategories(selectedCategories)
             binding.chipCategoryAll.isChecked = selectedCategories.isEmpty()
+            binding.logger.log(
+                PlaceCategoryClick(
+                    baseLogData = binding.logger.getBaseLogData(),
+                    currentCategories = selectedCategories.joinToString(",") { it.toString() }
+                )
+            )
         }
 
         setUpChipCategoryAllListener()

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewFragment.kt
@@ -6,6 +6,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.viewModels
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceDetailPreviewBinding
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.loadImage
@@ -15,6 +16,7 @@ import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailActivity
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
 import com.daedan.festabook.presentation.placeList.PlaceListViewModel
+import com.daedan.festabook.presentation.placeList.logging.PlacePreviewClick
 import com.daedan.festabook.presentation.placeList.model.SelectedPlaceUiState
 
 class PlaceDetailPreviewFragment :
@@ -56,6 +58,14 @@ class PlaceDetailPreviewFragment :
             val selectedPlaceState = viewModel.selectedPlace.value
             if (selectedPlaceState is SelectedPlaceUiState.Success) {
                 startPlaceDetailActivity(selectedPlaceState.value)
+                binding.logger.log(
+                    PlacePreviewClick(
+                        baseLogData = binding.logger.getBaseLogData(),
+                        placeName = selectedPlaceState.value.place.title?:"undefined",
+                        timeTag = viewModel.selectedTimeTag.value?.name?:"undefined",
+                        category = selectedPlaceState.value.place.category.name
+                    )
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeDetailPreview/PlaceDetailPreviewSecondaryFragment.kt
@@ -8,12 +8,14 @@ import androidx.fragment.app.viewModels
 import coil3.load
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceDetailPreviewSecondaryBinding
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.showBottomAnimation
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
 import com.daedan.festabook.presentation.placeList.PlaceListViewModel
+import com.daedan.festabook.presentation.placeList.logging.PlacePreviewClick
 import com.daedan.festabook.presentation.placeList.model.SelectedPlaceUiState
 import com.daedan.festabook.presentation.placeList.model.getIconId
 import com.daedan.festabook.presentation.placeList.model.getTextId
@@ -54,6 +56,14 @@ class PlaceDetailPreviewSecondaryFragment :
                     binding.layoutSelectedPlace.visibility = View.VISIBLE
                     binding.layoutSelectedPlace.showBottomAnimation()
                     updateSelectedPlaceUi(selectedPlace.value)
+                    binding.logger.log(
+                        PlacePreviewClick(
+                            baseLogData = binding.logger.getBaseLogData(),
+                            placeName = selectedPlace.value.place.title?:"undefined",
+                            timeTag = viewModel.selectedTimeTag.value?.name?:"undefined",
+                            category = selectedPlace.value.place.category.name
+                        )
+                    )
                 }
 
                 is SelectedPlaceUiState.Error -> showErrorSnackBar(selectedPlace.throwable)

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
@@ -21,6 +21,7 @@ import com.daedan.festabook.presentation.placeList.PlaceListViewModel
 import com.daedan.festabook.presentation.placeList.logging.LocationPermissionChanged
 import com.daedan.festabook.presentation.placeList.logging.PlaceFragmentEnter
 import com.daedan.festabook.presentation.placeList.logging.PlaceMarkerClick
+import com.daedan.festabook.presentation.placeList.logging.PlaceTimeTagSelected
 import com.daedan.festabook.presentation.placeList.model.PlaceListUiState
 import com.daedan.festabook.presentation.placeList.model.SelectedPlaceUiState
 import com.daedan.festabook.presentation.placeList.placeCategory.PlaceCategoryFragment
@@ -262,6 +263,12 @@ class PlaceMapFragment :
     override fun onTimeTagSelected(item: TimeTag) {
         viewModel.unselectPlace()
         viewModel.onDaySelected(item)
+        binding.logger.log(
+            PlaceTimeTagSelected(
+                baseLogData = binding.logger.getBaseLogData(),
+                timeTagName = item.name
+            )
+        )
     }
 
     override fun onNothingSelected() {

--- a/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/placeList/placeMap/PlaceMapFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentPlaceMapBinding
 import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.logging.logger
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
 import com.daedan.festabook.presentation.common.showErrorSnackBar
@@ -17,6 +18,9 @@ import com.daedan.festabook.presentation.common.toPx
 import com.daedan.festabook.presentation.main.MainActivity.Companion.newInstance
 import com.daedan.festabook.presentation.placeList.PlaceListFragment
 import com.daedan.festabook.presentation.placeList.PlaceListViewModel
+import com.daedan.festabook.presentation.placeList.logging.LocationPermissionChanged
+import com.daedan.festabook.presentation.placeList.logging.PlaceFragmentEnter
+import com.daedan.festabook.presentation.placeList.logging.PlaceMarkerClick
 import com.daedan.festabook.presentation.placeList.model.PlaceListUiState
 import com.daedan.festabook.presentation.placeList.model.SelectedPlaceUiState
 import com.daedan.festabook.presentation.placeList.placeCategory.PlaceCategoryFragment
@@ -42,7 +46,13 @@ class PlaceMapFragment :
     OnTimeTagSelectedListener {
     private lateinit var naverMap: NaverMap
     private val locationSource by lazy {
-        FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
+        FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE).apply {
+            activate {
+                binding.logger.log(LocationPermissionChanged(
+                    baseLogData = binding.logger.getBaseLogData()
+                ))
+            }
+        }
     }
     private var mapManager: MapManager? = null
     private val viewModel by viewModels<PlaceListViewModel> { PlaceListViewModel.Factory }
@@ -104,6 +114,11 @@ class PlaceMapFragment :
             setUpMapManager()
             setUpObserver()
         }
+        binding.logger.log(
+            PlaceFragmentEnter(
+                baseLogData = binding.logger.getBaseLogData()
+            )
+        )
     }
 
     override fun onDestroy() {
@@ -202,6 +217,14 @@ class PlaceMapFragment :
                             hide(placeDetailPreviewSecondaryFragment)
                             show(placeDetailPreviewFragment)
                         }
+                        binding.logger.log(
+                            PlaceMarkerClick(
+                                baseLogData = binding.logger.getBaseLogData(),
+                                placeId = selectedPlace.value.place.id,
+                                timeTagName = viewModel.selectedTimeTag.value?.name?:"undefined",
+                                category = selectedPlace.value.place.category.name
+                            )
+                        )
                     }
 
                     is SelectedPlaceUiState.Empty -> {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/woowacourse-teams/2025-festabook/issues/906

<br>

## 🛠️ 작업 내용

- 지도와 플레이스 화면의 로깅을 진행했습니다

<br>

## 🙇🏻 중점 리뷰 요청

### Proguard Rule를 추가했습니다 (LogData 구현체 유지)


<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 주요 화면(장소 목록/지도/카테고리/프리뷰/상세)에서 이미지 스와이프·클릭, 목록 항목/마커 선택, 카테고리·시간태그 선택, 하단시트 동작 등 사용자 상호작용 로깅을 추가했습니다.
  * 디버그 빌드에서도 로깅이 동작하도록 조정했습니다.
  * ProGuard 규칙을 보완해 특정 화면과 로깅 관련 코드가 난독화/제거로 인한 문제 없이 안정적으로 동작하도록 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->