### PR TITLE
[BE] PlaceImage Update 로직 조회 쿼리 한 번의 조회로 변경

### DIFF
--- a/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/place/service/PlaceImageServiceTest.java
@@ -21,8 +21,10 @@ import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateRequestFixture;
 import com.daedan.festabook.place.dto.PlaceImageSequenceUpdateResponses;
 import com.daedan.festabook.place.infrastructure.PlaceImageJpaRepository;
 import com.daedan.festabook.place.infrastructure.PlaceJpaRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -173,12 +175,8 @@ public class PlaceImageServiceTest {
                     PlaceImageSequenceUpdateRequestFixture.create(placeImageId3, 1)
             );
 
-            given(placeImageJpaRepository.findById(placeImageId1))
-                    .willReturn(Optional.of(placeImage1));
-            given(placeImageJpaRepository.findById(placeImageId2))
-                    .willReturn(Optional.of(placeImage2));
-            given(placeImageJpaRepository.findById(placeImageId3))
-                    .willReturn(Optional.of(placeImage3));
+            given(placeImageJpaRepository.findAllById(Set.of(placeImageId1, placeImageId2, placeImageId3)))
+                    .willReturn(new ArrayList<>(List.of(placeImage1, placeImage2, placeImage3)));
 
             // when
             PlaceImageSequenceUpdateResponses result = placeImageService.updatePlaceImagesSequence(
@@ -208,7 +206,7 @@ public class PlaceImageServiceTest {
             // when & then
             assertThatThrownBy(() -> placeImageService.updatePlaceImagesSequence(festivalId, requests))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("존재하지 않는 플레이스 이미지입니다.");
+                    .hasMessage("존재하지 않는 플레이스 이미지가 있습니다.");
         }
 
         @Test
@@ -222,8 +220,8 @@ public class PlaceImageServiceTest {
             Place place = PlaceFixture.create(requestFestival);
             PlaceImage placeImage = PlaceImageFixture.create(place, placeImageId);
 
-            given(placeImageJpaRepository.findById(placeImage.getId()))
-                    .willReturn(Optional.of(placeImage));
+            given(placeImageJpaRepository.findAllById(Set.of(placeImageId)))
+                    .willReturn(List.of(placeImage));
 
             List<PlaceImageSequenceUpdateRequest> requests = PlaceImageSequenceUpdateRequestFixture.createList(1);
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#1004

<br>

## 🛠️ 작업 내용

- PlaceImage Update 로직 조회 쿼리 한 번의 조회로 변경했습니다.
    - PlaceImage 순서 업데이트 시 PlaceImage 개수만큼 쿼리가 N번 실행되고 있었습니다. PlaceImage가 현재 각 Place마다 5개씩 제한되고 있어서 심각한 문제는 아니었지만, 추후 Place당 Image 개수를 늘릴 생각도 하고 있어서, Network를 적게 타는 방식으로 변경하도록 해야 했습니다.
    - 로컬에서 전 후 비교를 한 결과 **약 23% 정도** 응답 속도가 개선됨을 확인할 수 있었습니다.
- 자세한 개선 사항은 [노션 페이지](https://www.notion.so/279a540dc0b7801ab725de06f511ddfa?source=copy_link)를 통해 확인해 주시면 감사하겠습니다.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
