### PR TITLE
[BE] Device별 FestivalNotification 조회 API에 응답 필드 추가

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationReadResponse.java
+++ b/backend/src/main/java/com/daedan/festabook/festival/dto/FestivalNotificationReadResponse.java
@@ -4,6 +4,7 @@ import com.daedan.festabook.festival.domain.FestivalNotification;
 
 public record FestivalNotificationReadResponse(
         Long festivalNotificationId,
+        Long festivalId,
         String universityName,
         String festivalName
 ) {
@@ -11,6 +12,7 @@ public record FestivalNotificationReadResponse(
     public static FestivalNotificationReadResponse from(FestivalNotification festivalNotification) {
         return new FestivalNotificationReadResponse(
                 festivalNotification.getId(),
+                festivalNotification.getFestival().getId(),
                 festivalNotification.getFestival().getUniversityName(),
                 festivalNotification.getFestival().getFestivalName()
         );

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionControllerTest.java
@@ -187,7 +187,7 @@ class FestivalNotificationSubscriptionControllerTest {
             festivalNotificationJpaRepository.saveAll(festivalNotifications);
 
             int expectedSize = 2;
-            int expectedFieldSize = 3;
+            int expectedFieldSize = 4;
 
             // when & then
             RestAssured.

--- a/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/festival/controller/FestivalNotificationSubscriptionControllerTest.java
@@ -200,10 +200,12 @@ class FestivalNotificationSubscriptionControllerTest {
                     .body("$", hasSize(expectedSize))
                     .body("[0].size()", equalTo(expectedFieldSize))
                     .body("[0].festivalNotificationId", notNullValue())
+                    .body("[0].festivalId", notNullValue())
                     .body("[0].universityName", equalTo(festivalNotification1.getFestival().getUniversityName()))
                     .body("[0].festivalName", equalTo(festivalNotification1.getFestival().getFestivalName()))
                     .body("[1].size()", equalTo(expectedFieldSize))
                     .body("[1].festivalNotificationId", notNullValue())
+                    .body("[1].festivalId", notNullValue())
                     .body("[1].universityName", equalTo(festivalNotification2.getFestival().getUniversityName()))
                     .body("[1].festivalName", equalTo(festivalNotification2.getFestival().getFestivalName()));
         }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#1016

<br>

## 🛠️ 작업 내용

- Device별 FestivalNotification 조회 API에 응답 필드 추가

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 축제 알림 조회/목록 API 응답에 festivalId 필드가 추가되었습니다. 각 알림의 소속 축제를 클라이언트에서 식별할 수 있어, 축제 상세 이동·정렬·필터링 등의 상호작용이 쉬워집니다. 기존 응답 구조는 유지되며 추가 필드는 선택적으로 활용 가능합니다.
- 테스트
  - 응답 항목 수와 필드 검증을 festivalId 추가에 맞춰 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->