### PR TITLE
[BE] 알림에 대학교 이름 표시 구현

### DIFF
--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -27,10 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnnouncementService {
 
     private static final int MAX_PINNED_ANNOUNCEMENTS = 3;
-
-    private static final String LEFT_SQUARE_BRACKET = "[";
-    private static final String RIGHT_SQUARE_BRACKET = "]";
-    private static final String SPACE = " ";
+    private static final String ANNOUNCEMENT_TITLE_WITH_UNIVERSITY_NAME_FORMAT = "[%s] %s";
 
     private final AnnouncementJpaRepository announcementJpaRepository;
     private final FestivalJpaRepository festivalJpaRepository;
@@ -112,8 +109,10 @@ public class AnnouncementService {
     }
 
     private static String formatTitleWithUniversityName(Festival festival, Announcement announcement) {
-        String bracketedUniversityName = LEFT_SQUARE_BRACKET + festival.getUniversityName() + RIGHT_SQUARE_BRACKET;
-        return bracketedUniversityName + SPACE + announcement.getTitle();
+        return String.format(
+                ANNOUNCEMENT_TITLE_WITH_UNIVERSITY_NAME_FORMAT,
+                festival.getUniversityName(), announcement.getTitle()
+        );
     }
 
     private Announcement getAnnouncementById(Long announcementId) {

--- a/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/daedan/festabook/announcement/service/AnnouncementService.java
@@ -28,6 +28,10 @@ public class AnnouncementService {
 
     private static final int MAX_PINNED_ANNOUNCEMENTS = 3;
 
+    private static final String LEFT_SQUARE_BRACKET = "[";
+    private static final String RIGHT_SQUARE_BRACKET = "]";
+    private static final String SPACE = " ";
+
     private final AnnouncementJpaRepository announcementJpaRepository;
     private final FestivalJpaRepository festivalJpaRepository;
     private final FestivalNotificationManager notificationManager;
@@ -95,15 +99,21 @@ public class AnnouncementService {
 
     public void sendAnnouncementNotification(Long festivalId, Long announcementId) {
         Announcement announcement = getAnnouncementById(announcementId);
-        validateAnnouncementBelongsToFestival(announcement, festivalId);
+        Festival festival = getFestivalById(festivalId);
+        validateAnnouncementBelongsToFestival(announcement, festival.getId());
 
         NotificationSendRequest request = NotificationSendRequest.builder()
-                .title(announcement.getTitle())
+                .title(formatTitleWithUniversityName(festival, announcement))
                 .body(announcement.getContent())
                 .putData("announcementId", String.valueOf(announcement.getId()))
                 .build();
 
         notificationManager.sendToFestivalTopic(festivalId, request);
+    }
+
+    private static String formatTitleWithUniversityName(Festival festival, Announcement announcement) {
+        String bracketedUniversityName = LEFT_SQUARE_BRACKET + festival.getUniversityName() + RIGHT_SQUARE_BRACKET;
+        return bracketedUniversityName + SPACE + announcement.getTitle();
     }
 
     private Announcement getAnnouncementById(Long announcementId) {

--- a/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/service/AnnouncementServiceTest.java
@@ -484,6 +484,8 @@ class AnnouncementServiceTest {
 
             given(announcementJpaRepository.findById(announcementId))
                     .willReturn(Optional.of(announcement));
+            given(festivalJpaRepository.findById(festivalId))
+                    .willReturn(Optional.of(festival));
 
             // when
             announcementService.sendAnnouncementNotification(festivalId, announcementId);
@@ -521,6 +523,8 @@ class AnnouncementServiceTest {
 
             given(announcementJpaRepository.findById(announcement.getId()))
                     .willReturn(Optional.of(announcement));
+            given(festivalJpaRepository.findById(otherFestivalId))
+                    .willReturn(Optional.of(otherFestival));
 
             // when & then
             assertThatThrownBy(() ->
@@ -540,6 +544,8 @@ class AnnouncementServiceTest {
 
             given(announcementJpaRepository.findById(announcementId))
                     .willReturn(Optional.of(announcement));
+            given(festivalJpaRepository.findById(festivalId))
+                    .willReturn(Optional.of(festival));
 
             willThrow(new BusinessException("FCM 메시지 전송을 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR))
                     .given(festivalNotificationManager)


### PR DESCRIPTION
## #️⃣ 이슈 번호

#1017 

<br>

## 🛠️ 작업 내용

- 알림에 대학교 이름 표시 구현
    - ex) [강릉원주대학교 성서캠퍼스] 대학 축제 알림 제목
    - ex) [한서대학교] 대학 축제 알림 제목 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 알림 제목에 축제의 대학교명이 대괄호로 자동 포함되어 공지 출처를 한눈에 식별할 수 있습니다. 예: [OO대학교] 공지 제목.
* Refactor
  * 알림 전송 시 축제 정보 확인 및 공지 검증 과정을 강화해 잘못된 매칭을 줄이고 알림 신뢰성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->