### PR TITLE
[BE] Announcement 생성/수정 테스트 누락 

### DIFF
--- a/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/com/daedan/festabook/announcement/controller/AnnouncementControllerTest.java
@@ -461,7 +461,7 @@ class AnnouncementControllerTest {
     }
 
     @Nested
-    class ConccurentTest {
+    class ConcurrentTest {
 
         @Test
         void 동시성_3개_이상의_동시_요청시_3개의_고정_공지만_생성된다() {
@@ -526,7 +526,7 @@ class AnnouncementControllerTest {
                         .contentType(ContentType.JSON)
                         .body(updateAnnouncement)
                         .when()
-                        .post("/{announcementId}/pin", initAnnouncement.getId());
+                        .post("announcement/{announcementId}/pin", initAnnouncement.getId());
             };
 
             int expectedPinnedAnnouncementCount = 3;

--- a/backend/src/test/java/com/daedan/festabook/global/lock/ConcurrencyTestHelper.java
+++ b/backend/src/test/java/com/daedan/festabook/global/lock/ConcurrencyTestHelper.java
@@ -10,6 +10,8 @@ public class ConcurrencyTestHelper {
     }
 
     public static void test(int requestCount, Runnable... requests) {
+        validateRequests(requests);
+
         try (ExecutorService threadPool = Executors.newFixedThreadPool(requestCount)) {
             CountDownLatch startLatch = new CountDownLatch(1);
             CountDownLatch endLatch = new CountDownLatch(requestCount);
@@ -33,6 +35,12 @@ public class ConcurrencyTestHelper {
                 endLatch.await();
             } catch (InterruptedException ignore) {
             }
+        }
+    }
+
+    private static void validateRequests(Runnable[] requests) {
+        if (requests.length == 0) {
+            throw new IllegalArgumentException("실행할 api 인자는 최소 1개 이상이어야 합니다.");
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#1063 

<br>

## 🛠️ 작업 내용

- Announcement 생성/수정 테스트 누락 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

이번 업데이트는 내부 테스트 개선사항으로 구성되어 있습니다. 최종 사용자에게 영향을 주는 기능 변경 사항은 없습니다.

* **Tests**
  * 동시성 테스트 구조 재구성 및 확장: 생성·수정 동시 요청 시 고정 공지 최대 개수 검증 포함된 신규 동시성 테스트 추가 및 기존 일부 중복 테스트 제거.
  * 테스트 코드 정리: 요청 생성에 픽스처 도입으로 설정 간소화 및 가독성 향상.
  * 동시성 테스트 헬퍼 개선: 다중 요청 동시 실행을 지원하고 입력 검증을 추가하여 안정성 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->