### PR TITLE
[AN] FAQ아이템 제목과 아이콘이 겹치는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsItem.kt
+++ b/android/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsItem.kt
@@ -70,7 +70,7 @@ fun NewsItem(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment = Alignment.Top,
         ) {
             if (icon != null) {
                 icon()
@@ -80,8 +80,9 @@ fun NewsItem(
                 text = title,
                 fontFamily = FontFamily(Font(R.font.pretendard_bold)),
                 fontSize = 14.sp,
+                modifier = Modifier.weight(1f),
             )
-            Spacer(modifier = modifier.weight(1f))
+            Spacer(modifier = Modifier.width(8.dp))
             if (createdAt != null) {
                 Text(
                     text = createdAt,


### PR DESCRIPTION
## #️⃣ 이슈 번호

#1070 

<br>

## 🛠️ 작업 내용

- 제목 텍스트와 아이콘 사이 간격 조정
- 제목이 남은 면적을 차지하도록 변경

<br>

## 🙇🏻 중점 리뷰 요청



<br>

## 📸 이미지 첨부 (Optional)
<img width="400" height="74" alt="image" src="https://github.com/user-attachments/assets/4fe5f14b-d7b7-4004-a779-ccfd6dadf31c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 뉴스 항목의 수직 정렬을 개선했습니다.
  * 뉴스 항목 내 텐스트 및 아이콘의 간격 레이아웃을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->